### PR TITLE
Adding PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## What does this PR do?
+
+<!-- Mandatory
+Explain here WHAT changes you made in the PR.
+-->
+
+## Why is it important?
+
+<!-- Mandatory
+Explain here the WHY, or the rationale/motivation for the changes.
+-->
+
+## Checklist
+
+<!-- Mandatory
+Add a checklist of things that are required to be reviewed in order to have the PR approved
+
+List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
+-->
+
+- [ ] I have added test packages to [`code/go/internal/validator/test/packages`](https://github.com/elastic/package-spec/tree/master/code/go/internal/validator/test/packages)) that prove my change is effective.
+- [ ] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/master/versions/1/changelog.yml).
+
+## Related issues
+
+<!-- Recommended
+Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
+
+- Closes #123
+- Relates #123
+- Requires #123
+- Supersedes #123
+-->
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Add a checklist of things that are required to be reviewed in order to have the 
 List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
 -->
 
-- [ ] I have added test packages to [`code/go/internal/validator/test/packages`](https://github.com/elastic/package-spec/tree/master/code/go/internal/validator/test/packages)) that prove my change is effective.
+- [ ] I have added test packages to [`code/go/internal/validator/test/packages`](https://github.com/elastic/package-spec/tree/master/code/go/internal/validator/test/packages) that prove my change is effective.
 - [ ] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/master/versions/1/changelog.yml).
 
 ## Related issues


### PR DESCRIPTION
This PR adds a GitHub PR template for this repository. This should encourage contributors to perform suggested typical steps on every PR.