### PR TITLE
Update go version in go.mod

### DIFF
--- a/code/go/go.mod
+++ b/code/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/package-spec/code/go
 
-go 1.14
+go 1.15
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.0


### PR DESCRIPTION
## What does this PR do?

This PR updates the Golang version in `go.mod` to match the one actually being used in CI.

## Why is it important?

To avoid confusion.
