### PR TITLE
Adding contribuing guide section + issue template for change proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/Change_Proposal.md
+++ b/.github/ISSUE_TEMPLATE/Change_Proposal.md
@@ -5,5 +5,5 @@ labels: discuss
 title: "[Change Proposal] "
 ---
 
-Please read the section on [Change Proposals in the Contributing Guide](/CONTRIBUTING.md#change-proposals) and flesh out
-this issue accordingly. Thank you!
+Please read the section on [Change Proposals in the Contributing Guide](/CONTRIBUTING.md#change-proposals) 
+and flesh out this issue accordingly. Thank you!

--- a/.github/ISSUE_TEMPLATE/Change_Proposal.md
+++ b/.github/ISSUE_TEMPLATE/Change_Proposal.md
@@ -5,5 +5,5 @@ labels: discuss
 title: "[Change Proposal] "
 ---
 
-Please read the section on [Change Proposals in the Contributing Guide](link TODO) and flesh out
+Please read the section on [Change Proposals in the Contributing Guide](/CONTRIBUTING.md#change-proposals) and flesh out
 this issue accordingly. Thank you!

--- a/.github/ISSUE_TEMPLATE/Change_Proposal.md
+++ b/.github/ISSUE_TEMPLATE/Change_Proposal.md
@@ -1,0 +1,11 @@
+---
+name: Change Proposal
+about: For proposing and discussing a change to the Elastic Package Specification
+labels: discuss
+title: "[Change Proposal] "
+---
+
+<!--
+Please read the section on [Change Proposals in the Contributing Guide](link TODO) and flesh out
+this issue accordingly. Thank you!
+-->

--- a/.github/ISSUE_TEMPLATE/Change_Proposal.md
+++ b/.github/ISSUE_TEMPLATE/Change_Proposal.md
@@ -5,7 +5,5 @@ labels: discuss
 title: "[Change Proposal] "
 ---
 
-<!--
 Please read the section on [Change Proposals in the Contributing Guide](link TODO) and flesh out
 this issue accordingly. Thank you!
--->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,31 @@
 # Contributing
 
+## Change Proposals
+
+Any changes to Elastic Stack products or Elastic Packages that require changes to the Elastic Package Specification 
+must be discussed first. At a high level, this process looks something like this:
+
+1. The change must be proposed via a [new Change Proposal issue](https://github.com/elastic/package-spec/issues/new) 
+   in the `package-spec` repository (i.e. this repository). This gives us an opportunity to understand which parts of the 
+   Elastic Stack might be impacted by this change and pull in relevant experts to get their opinions. The initial proposal 
+   should cover these areas:
+   - What problem the proposal is solving. This provides context and could help shape the solution.
+   - Where the solution will need to be implemented, i.e. which parts, if any, of the Elastic Stack will be impacted. It's 
+     okay if the initial proposal doesn't get this 100% right; the discussion in the proposal issue should provide clarity.
+
+2. Once we have consensus on the proposal issue, we modify the issue description to include an **ordered** checklist of 
+   tasks that need to be resolved to make the change happen in a safe way.  For example, maybe Kibana needs to implement 
+   support for a new property in the Package Specification first, then only when that support is implemented, the Package
+   Specification can itself be modified, which would then allow packages to define this property and have these packages 
+   still be valid. At this point the proposal issue serves as a meta issue for the safe implementation of the change.
+
+3. We file issues in each of the repositories corresponding to the checklist items and update the checklist with links to 
+   these issues.
+
+4. No single PR may close the proposal issue. But as these PRs get resolved, the corresponding checklist item should be 
+   checked off. The proposal issue is closed when all items are checked off.
+
+
 ## Folder Item spec
 
 ### Using predefined placeholders in filename patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 Any changes to Elastic Stack products or Elastic Packages that require changes to the Elastic Package Specification 
 must be discussed first. At a high level, this process looks something like this:
 
-1. The change must be proposed via a [new Change Proposal issue](https://github.com/elastic/package-spec/issues/new) 
+1. The change must be proposed via a [new Change Proposal issue](https://github.com/elastic/package-spec/issues/new/choose) 
    in the `package-spec` repository (i.e. this repository). This gives us an opportunity to understand which parts of the 
    Elastic Stack might be impacted by this change and pull in relevant experts to get their opinions. The initial proposal 
    should cover these areas:


### PR DESCRIPTION
## What does this PR do?

Introduces a section in the Contributing Guide + a GitHub issue template to guide users on how and why to propose changes to the Package Specification in this repository.

## Why is it important?

So we follow a consistent process that promotes discussion amongst relevant parties + a safe approach to introducing changes to the Package Specification and Elastic Stack components.

## Related issues

- Closes #108.