### PR TITLE
Change proposal doc tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE/Change_Proposal.md
+++ b/.github/ISSUE_TEMPLATE/Change_Proposal.md
@@ -5,5 +5,4 @@ labels: discuss
 title: "[Change Proposal] "
 ---
 
-Please read the section on [Change Proposals in the Contributing Guide](/CONTRIBUTING.md#change-proposals) 
-and flesh out this issue accordingly. Thank you!
+Please read the section on [Change Proposals in the Contributing Guide](https://github.com/elastic/package-spec/blob/master/CONTRIBUTING.md#change-proposals) and flesh out this issue accordingly. Thank you!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ must be discussed first. At a high level, this process looks something like this
    - What problem the proposal is solving. This provides context and could help shape the solution.
    - Where the solution will need to be implemented, i.e. which parts, if any, of the Elastic Stack will be impacted. It's 
      okay if the initial proposal doesn't get this 100% right; the discussion in the proposal issue should provide clarity.
+     Feel free to tag relevant experts to get their opinions.
 
 2. Once we have consensus on the proposal issue, we modify the issue description to include an **ordered** checklist of 
    tasks that need to be resolved to make the change happen in a safe way.  For example, maybe Kibana needs to implement 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Any changes to Elastic Stack products or Elastic Packages that require changes t
 must be discussed first and then safely implemented across impacted products. At a high level, this process looks
 something like this:
 
-1. The change must be proposed via a [new Change Proposal issue](https://github.com/elastic/package-spec/issues/new/choose) 
+1. Propose your change via a [new Change Proposal issue](https://github.com/elastic/package-spec/issues/new/choose) 
    in the `package-spec` repository (i.e. this repository). This gives us an opportunity to understand which parts of the 
    Elastic Stack might be impacted by this change and pull in relevant experts to get their opinions. The initial proposal 
    should cover these areas:
@@ -15,16 +15,18 @@ something like this:
      okay if the initial proposal doesn't get this 100% right; the discussion in the proposal issue should provide clarity.
      Feel free to tag relevant experts to get their opinions.
 
-2. Once we have consensus on the proposal issue, we modify the issue description to include an **ordered** checklist of 
+2. Discussion ensues and eventually we hope to reach some consensus.
+
+3. Once ther's consensus on the proposal issue, modify the issue description to include an **ordered** checklist of 
    tasks that need to be resolved to make the change happen in a safe way.  For example, maybe Kibana needs to implement 
    support for a new property in the Package Specification first, then only when that support is implemented, the Package
    Specification can itself be modified, which would then allow packages to define this property and have these packages 
    still be valid. At this point the proposal issue serves as a meta issue for the safe implementation of the change.
 
-3. We file issues in each of the repositories corresponding to the checklist items and update the checklist with links to 
+4. File issues in each of the repositories corresponding to the checklist items and update the checklist with links to 
    these issues.
 
-4. No single PR may close the proposal issue. But as these PRs get resolved, the corresponding checklist item should be 
+5. No single PR may close the proposal issue. But as these PRs get resolved, the corresponding checklist item should be 
    checked off. The proposal issue is closed when all items are checked off.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,8 @@
 ## Change Proposals
 
 Any changes to Elastic Stack products or Elastic Packages that require changes to the Elastic Package Specification 
-must be discussed first. At a high level, this process looks something like this:
+must be discussed first and then safely implemented across impacted products. At a high level, this process looks
+something like this:
 
 1. The change must be proposed via a [new Change Proposal issue](https://github.com/elastic/package-spec/issues/new/choose) 
    in the `package-spec` repository (i.e. this repository). This gives us an opportunity to understand which parts of the 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ something like this:
 
 2. Discussion ensues and eventually we hope to reach some consensus.
 
-3. Once ther's consensus on the proposal issue, modify the issue description to include an **ordered** checklist of 
+3. Once there's consensus on the proposal issue, modify the issue description to include an **ordered** checklist of 
    tasks that need to be resolved to make the change happen in a safe way.  For example, maybe Kibana needs to implement 
    support for a new property in the Package Specification first, then only when that support is implemented, the Package
    Specification can itself be modified, which would then allow packages to define this property and have these packages 


### PR DESCRIPTION
## What does this PR do?

Makes a couple of minor changes to the change proposal process documentation.

## Why is it important?

1. To fix a bad link in the issue template.
2. To encourage proposal writers to tag experts who could opine on their proposals.
3. To make it slightly clearer who is responsible for certain actions related to the the proposal.

Follow up to #124. 