### PR TITLE
Relocate format checkers

### DIFF
--- a/code/go/internal/validator/folder_item_spec.go
+++ b/code/go/internal/validator/folder_item_spec.go
@@ -8,17 +8,14 @@ import (
 	"regexp"
 	"sync"
 
+	"github.com/elastic/package-spec/code/go/internal/validator/semantic"
+
 	ve "github.com/elastic/package-spec/code/go/internal/errors"
 
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/elastic/package-spec/code/go/internal/yamlschema"
-)
-
-const (
-	relativePathFormat   = "relative-path"
-	dataStreamNameFormat = "data-stream-name"
 )
 
 type folderItemSpec struct {
@@ -91,13 +88,13 @@ func (s *folderItemSpec) validate(fs http.FileSystem, folderSpecPath string, ite
 
 	formatCheckersMutex.Lock()
 	defer func() {
-		unloadRelativePathFormatChecker()
-		unloadDataStreamNameFormatChecker()
+		semantic.UnloadRelativePathFormatChecker()
+		semantic.UnloadDataStreamNameFormatChecker()
 		formatCheckersMutex.Unlock()
 	}()
 
-	loadRelativePathFormatChecker(filepath.Dir(itemPath))
-	loadDataStreamNameFormatChecker(filepath.Dir(itemPath))
+	semantic.LoadRelativePathFormatChecker(filepath.Dir(itemPath))
+	semantic.LoadDataStreamNameFormatChecker(filepath.Dir(itemPath))
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
 		return ve.ValidationErrors{err}
@@ -112,24 +109,4 @@ func (s *folderItemSpec) validate(fs http.FileSystem, folderSpecPath string, ite
 		errs = append(errs, fmt.Errorf("field %s: %s", re.Field(), adjustErrorDescription(re.Description())))
 	}
 	return errs
-}
-
-func loadRelativePathFormatChecker(currentPath string) {
-	gojsonschema.FormatCheckers.Add(relativePathFormat, RelativePathChecker{
-		currentPath: currentPath,
-	})
-}
-
-func unloadRelativePathFormatChecker() {
-	gojsonschema.FormatCheckers.Remove(relativePathFormat)
-}
-
-func loadDataStreamNameFormatChecker(currentPath string) {
-	gojsonschema.FormatCheckers.Add(dataStreamNameFormat, RelativePathChecker{
-		currentPath: filepath.Join(currentPath, "data_stream"),
-	})
-}
-
-func unloadDataStreamNameFormatChecker() {
-	gojsonschema.FormatCheckers.Remove(dataStreamNameFormat)
 }

--- a/code/go/internal/validator/folder_item_spec.go
+++ b/code/go/internal/validator/folder_item_spec.go
@@ -8,13 +8,11 @@ import (
 	"regexp"
 	"sync"
 
-	"github.com/elastic/package-spec/code/go/internal/validator/semantic"
-
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 
+	ve "github.com/elastic/package-spec/code/go/internal/errors"
+	"github.com/elastic/package-spec/code/go/internal/validator/semantic"
 	"github.com/elastic/package-spec/code/go/internal/yamlschema"
 )
 

--- a/code/go/internal/validator/folder_item_spec_errors.go
+++ b/code/go/internal/validator/folder_item_spec_errors.go
@@ -1,9 +1,11 @@
 package validator
 
+import "github.com/elastic/package-spec/code/go/internal/validator/semantic"
+
 func adjustErrorDescription(description string) string {
-	if description == "Does not match format '" + relativePathFormat + "'" {
+	if description == "Does not match format '"+semantic.RelativePathFormat+"'" {
 		return "relative path is invalid or target doesn't exist"
-	} else if description == "Does not match format '" + dataStreamNameFormat + "'" {
+	} else if description == "Does not match format '"+semantic.DataStreamNameFormat+"'" {
 		return "data stream doesn't exist"
 	}
 	return description

--- a/code/go/internal/validator/semantic/format_checkers.go
+++ b/code/go/internal/validator/semantic/format_checkers.go
@@ -1,0 +1,61 @@
+package semantic
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+const (
+	RelativePathFormat   = "relative-path"
+	DataStreamNameFormat = "data-stream-name"
+)
+
+// relativePathChecker is responsible for checking presence of the file path
+type relativePathChecker struct {
+	currentPath string
+}
+
+// IsFormat method checks if the path exists.
+func (r relativePathChecker) IsFormat(input interface{}) bool {
+	asString, ok := input.(string)
+	if !ok {
+		return false
+	}
+
+	path := filepath.Join(r.currentPath, asString)
+	_, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// LoadRelativePathFormatChecker loads the relative-path format checker into the
+// json-schema validation library.
+func LoadRelativePathFormatChecker(currentPath string) {
+	gojsonschema.FormatCheckers.Add(RelativePathFormat, relativePathChecker{
+		currentPath: currentPath,
+	})
+}
+
+// UnloadRelativePathFormatChecker unloads the relative-path format checker from the
+// json-schema validation library.
+func UnloadRelativePathFormatChecker() {
+	gojsonschema.FormatCheckers.Remove(RelativePathFormat)
+}
+
+// LoadDataStreamNameFormatChecker loads the data-stream-name format checker into the
+// json-schema validation library.
+func LoadDataStreamNameFormatChecker(currentPath string) {
+	gojsonschema.FormatCheckers.Add(DataStreamNameFormat, relativePathChecker{
+		currentPath: filepath.Join(currentPath, "data_stream"),
+	})
+}
+
+// UnloadDataStreamNameFormatChecker unloads the data-stream-name format checker from the
+// json-schema validation library.
+func UnloadDataStreamNameFormatChecker() {
+	gojsonschema.FormatCheckers.Remove(DataStreamNameFormat)
+}

--- a/code/go/internal/validator/semantic/format_checkers.go
+++ b/code/go/internal/validator/semantic/format_checkers.go
@@ -8,7 +8,15 @@ import (
 )
 
 const (
-	RelativePathFormat   = "relative-path"
+	// RelativePathFormat defines the ID of the relative path format checker. This format checker
+	// should be used when a field's value refers to a relative filesystem path. The checker will
+	// ensure that the location pointed to by that relative filesystem path actually exists on
+	// the filesystem, relative to the file in which the field is defined.
+	RelativePathFormat = "relative-path"
+
+	// DataStreamNameFormat defines the ID of the data stream name format checker. This format checker
+	// should be used when a field's value refers to a data stream name. The checker will ensure
+	// that a folder with that data stream name exists on the filesystem.
 	DataStreamNameFormat = "data-stream-name"
 )
 


### PR DESCRIPTION
## What does this PR do?

This PR relocates the format checkers implementation into the new `semantic` package.

## Why is it important?

With this change, all non-declarative package validation rules are contained in a single place, the `semantic` package. This will make porting such rules to another language easier.

## Checklist

- [ ] ~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/master/test/packages) that prove my change is effective.~ Test packages already exist.
- [ ] ~I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/master/versions/1/changelog.yml).~ No changes to spec.

## Related issues

- Follow up to https://github.com/elastic/package-spec/pull/160.
