### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - dependencies
+      - go
+  	open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directory: "/code/go"
     schedule:
       interval: "daily"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     labels:
       - dependencies
       - go
-  	open-pull-requests-limit: 10
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What

Delegate the bump automation to `dependabot`. Please read below

## Why

Simplify recurrent tasks

## Next steps

`Allow` is not supported to declare the list of dependencies to be bumped, something that is supported for some other package systems. See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#allow

The proposal is, delegate the bump automation to dependabot and for each dependency that should not be taking in consideration then:

- ignore it explicitly as stated in https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#creating-ignore-conditions-from-dependabot-ignore

