### PR TITLE
[dependabot][mergify] automate merge and add reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - dependencies
-      - go
+      - automation
+    reviewers:
+      - "mtojek"
+      - "jsoriano"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,5 @@ updates:
     labels:
       - automation
     reviewers:
-      - "mtojek"
-      - "jsoriano"
+      - "elastic/integrations-developer-experience"
     open-pull-requests-limit: 10

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,11 @@
+pull_request_rules:
+  - name: automatic merge of bot 🤖
+    conditions:
+      - check-success=package-spec/pr-merge
+      - check-success=CLA
+      - base=master
+      - author~=^dependabot(|-preview)\[bot\]$
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack


### PR DESCRIPTION
## What does this PR do?

- Add reviewers
- Automerge if CI is happy. Although, if no approval is needed why do we need the reviewers?

## Why is it important?

Look mum no hands!

## Issue

See https://github.com/elastic/integrations/pull/1291#issuecomment-876963997