### PR TITLE
[CI] use obltGitHubComments

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^\\/test$)')
+		issueCommentTrigger("${obltGitHubComments()}")
   }
   stages {
     /**

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-		issueCommentTrigger("${obltGitHubComments()}")
+    issueCommentTrigger("${obltGitHubComments()}")
   }
   stages {
     /**


### PR DESCRIPTION
## What does this PR do?

Use https://github.com/elastic/apm-pipeline-library/blob/master/vars/obltGitHubComments.txt

## Why is it important?

Avoid hardcoded strings and easy to normalise the GitHub comments in all the oblt projects