### PR TITLE
Add support for Kibana tags

### DIFF
--- a/test/packages/good/kibana/tag/good-tag-abc-1.json
+++ b/test/packages/good/kibana/tag/good-tag-abc-1.json
@@ -5,7 +5,7 @@
         "name": "abc"
     },
     "coreMigrationVersion": "7.15.0",
-    "id": "abc",
+    "id": "good-tag-abc-1",
     "references": [],
     "type": "tag"
 }

--- a/test/packages/good/kibana/tag/good-tag-abc-1.json
+++ b/test/packages/good/kibana/tag/good-tag-abc-1.json
@@ -1,0 +1,11 @@
+{
+    "attributes": {
+        "color": "#e20b7f",
+        "description": "",
+        "name": "abc"
+    },
+    "coreMigrationVersion": "7.15.0",
+    "id": "abc",
+    "references": [],
+    "type": "tag"
+}

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -7,6 +7,9 @@
   - description: Prepare v1.1.1-next
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/?
+  - description: Add tag support for elastic export
+    type: bugfix
+    link: https://github.com/elastic/package-spec/pull/223
 - version: 1.1
   changes:
   - description: Prepare for 1.0.1

--- a/versions/1/kibana/spec.yml
+++ b/versions/1/kibana/spec.yml
@@ -83,7 +83,7 @@
           type: file
           contentMediaType: "application/json"
           pattern: '^{PACKAGE_NAME}-.+\.json$'
-    - description: Folder containing Kibana dashboard assets
+    - description: Folder containing Kibana tags
       type: folder
       name: tag
       required: false
@@ -92,5 +92,3 @@
         type: file
         contentMediaType: "application/json"
         pattern: '^{PACKAGE_NAME}-.+\.json$'
-        forbiddenPatterns:
-          - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden

--- a/versions/1/kibana/spec.yml
+++ b/versions/1/kibana/spec.yml
@@ -83,3 +83,14 @@
           type: file
           contentMediaType: "application/json"
           pattern: '^{PACKAGE_NAME}-.+\.json$'
+    - description: Folder containing Kibana dashboard assets
+      type: folder
+      name: tag
+      required: false
+      contents:
+      - description: A dashboard tag file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'
+        forbiddenPatterns:
+          - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden


### PR DESCRIPTION
Missing tag entry which cause elastic-package lint to fail.
Tag files are created when you add tag to a dashboard and then try to export it with elastic-package export


