### PR TITLE
add elasticsearch.privileges.cluster support

### DIFF
--- a/test/packages/good/manifest.yml
+++ b/test/packages/good/manifest.yml
@@ -40,4 +40,7 @@ icons:
     title: system
     size: 1000x1000
     type: image/svg+xml
+# /main is a specific action underneath the monitor privilege. Declaring
+# "monitor/main" limits the provided privilege, "monitor", to only the "main"
+# action.
 elasticsearch.privileges.cluster: [monitor/main]

--- a/test/packages/good/manifest.yml
+++ b/test/packages/good/manifest.yml
@@ -40,4 +40,4 @@ icons:
     title: system
     size: 1000x1000
     type: image/svg+xml
-elasticsearch.cluster: [monitor/main]
+elasticsearch.privileges.cluster: [monitor/main]

--- a/test/packages/good/manifest.yml
+++ b/test/packages/good/manifest.yml
@@ -40,3 +40,4 @@ icons:
     title: system
     size: 1000x1000
     type: image/svg+xml
+elasticsearch.cluster: [monitor/main]

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -10,7 +10,7 @@
   - description: Add tag support for elastic export
     type: bugfix
     link: https://github.com/elastic/package-spec/pull/223
-  - description: Add "elasticsearch.cluster" to package manifest
+  - description: Add "elasticsearch.privileges.cluster" to package manifest
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/226
 - version: 1.1

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -10,6 +10,9 @@
   - description: Add tag support for elastic export
     type: bugfix
     link: https://github.com/elastic/package-spec/pull/223
+  - description: Add "elasticsearch.cluster" to package manifest
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/226
 - version: 1.1
   changes:
   - description: Prepare for 1.0.1

--- a/versions/1/manifest.spec.yml
+++ b/versions/1/manifest.spec.yml
@@ -107,7 +107,7 @@ spec:
         - "1.0.0-dev.1"
   properties:
     elasticsearch:
-      description: Elasticsearch cluster requirements
+      description: Elasticsearch requirements
       type: object
       additionalProperties: false
       properties:

--- a/versions/1/manifest.spec.yml
+++ b/versions/1/manifest.spec.yml
@@ -111,11 +111,16 @@ spec:
       type: object
       additionalProperties: false
       properties:
-        cluster:
-          description: Elasticsearch cluster requirements
-          type: array
-          items:
-            type: string
+        privileges:
+          description: Elasticsearch privilege requirements
+          type: object
+          additionalProperties: false
+          properties:
+            cluster:
+              description: Elasticsearch cluster privilege requirements
+              type: array
+              items:
+                type: string
     format_version:
       description: The version of the package specification format used by this package.
       $ref: "#/definitions/version"

--- a/versions/1/manifest.spec.yml
+++ b/versions/1/manifest.spec.yml
@@ -117,6 +117,7 @@ spec:
           additionalProperties: false
           properties:
             cluster:
+              # Available cluster privileges are available at https://www.elastic.co/guide/en/elasticsearch/reference/7.x/security-privileges.html#privileges-list-cluster
               description: Elasticsearch cluster privilege requirements
               type: array
               items:

--- a/versions/1/manifest.spec.yml
+++ b/versions/1/manifest.spec.yml
@@ -106,6 +106,16 @@ spec:
         - "1.0.0-SNAPSHOT"
         - "1.0.0-dev.1"
   properties:
+    elasticsearch:
+      description: Elasticsearch cluster requirements
+      type: object
+      additionalProperties: false
+      properties:
+        cluster:
+          description: Elasticsearch cluster requirements
+          type: array
+          items:
+            type: string
     format_version:
       description: The version of the package specification format used by this package.
       $ref: "#/definitions/version"


### PR DESCRIPTION
## What does this PR do?

add an optional `elasticsearch.cluster` property to the package manifest to define cluster privileges to be assigned to an api key

## Why is it important?

APM server needs additional cluster privileges to access `/` on its elasticsearch output

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/master/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/master/versions/1/changelog.yml).

## Related issues

proposed in https://github.com/elastic/package-spec/issues/224
