### PR TITLE
Support configuration of dimension fields limit

### DIFF
--- a/test/packages/time_series/data_stream/example/manifest.yml
+++ b/test/packages/time_series/data_stream/example/manifest.yml
@@ -9,3 +9,9 @@ streams:
         type: text
         title: Period
         default: 10s
+
+elasticsearch:
+  index_template:
+    settings:
+      # Defaults to 16
+      index.mapping.dimension_fields.limit: 32


### PR DESCRIPTION
## What does this PR do?

Adds support to increase the limit of dimension fields [`index.mapping.dimension_fields.limit`](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/index-modules.html#dynamic-index-settings).

At the end it only adds a test case because index template settings are already supported.

## Why is it important?

An index can have by default a maximum of 16 dimension fields. For some cases it may be needed to increase this limit.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/master/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/master/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Related to https://github.com/elastic/package-spec/issues/215
