### PR TITLE
Allow defining an external field as dimension

### DIFF
--- a/code/go/internal/validator/semantic/types.go
+++ b/code/go/internal/validator/semantic/types.go
@@ -23,6 +23,7 @@ type field struct {
 	Unit       string `yaml:"unit"`
 	MetricType string `yaml:"metric_type"`
 	Dimension  bool   `yaml:"dimension"`
+	External   string `yaml:"external"`
 
 	Fields fields `yaml:"fields"`
 }

--- a/code/go/internal/validator/semantic/validate_dimensions.go
+++ b/code/go/internal/validator/semantic/validate_dimensions.go
@@ -18,7 +18,7 @@ func ValidateDimensionFields(pkgRoot string) errors.ValidationErrors {
 
 func validateDimensionField(fieldsFile string, f field) errors.ValidationErrors {
 	if f.External != "" {
-		// External fields can be used as dimensions, but we cannot resolve
+		// TODO: External fields can be used as dimensions, but we cannot resolve
 		// them at this point, so accept them as they are by now.
 		return nil
 	}

--- a/code/go/internal/validator/semantic/validate_dimensions.go
+++ b/code/go/internal/validator/semantic/validate_dimensions.go
@@ -17,6 +17,11 @@ func ValidateDimensionFields(pkgRoot string) errors.ValidationErrors {
 }
 
 func validateDimensionField(fieldsFile string, f field) errors.ValidationErrors {
+	if f.External != "" {
+		// External fields can be used as dimensions, but we cannot resolve
+		// them at this point, so accept them as they are by now.
+		return nil
+	}
 	if f.Dimension && !isAllowedDimensionType(f.Type) {
 		return errors.ValidationErrors{fmt.Errorf(`file "%s" is invalid: field "%s" of type %s can't be a dimension, allowed types for dimensions: %s`, fieldsFile, f.Name, f.Type, strings.Join(allowedDimensionTypes, ", "))}
 	}

--- a/code/go/internal/validator/semantic/validate_dimensions_test.go
+++ b/code/go/internal/validator/semantic/validate_dimensions_test.go
@@ -69,6 +69,15 @@ func TestValidateDimensionFields(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			title: "external field as dimension should be supported",
+			field: field{
+				Name:      "container.id",
+				External:  "ecs",
+				Dimension: true,
+			},
+			valid: true,
+		},
 	}
 
 	for _, c := range cases {

--- a/test/packages/time_series/data_stream/example/fields/ecs.yml
+++ b/test/packages/time_series/data_stream/example/fields/ecs.yml
@@ -1,0 +1,3 @@
+- name: container.id
+  external: ecs
+  dimension: true

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -12,7 +12,7 @@
     link: https://github.com/elastic/package-spec/pull/236
   - description: Add support for dimension fields from external sources.
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/
+    link: https://github.com/elastic/package-spec/pull/248
 - version: 1.2.0
   changes:
   - description: Add tag support for elastic export

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -10,6 +10,9 @@
   - description: Add support for dimension fields.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/236
+  - description: Add support for dimension fields from external sources.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/
 - version: 1.2.0
   changes:
   - description: Add tag support for elastic export


### PR DESCRIPTION
## What does this PR do?

Allow defining external fields as dimensions.

## Why is it important?

There will be cases where an ECS field needs to be defined as dimension, see https://github.com/elastic/package-spec/issues/247.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/master/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/master/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Part of https://github.com/elastic/package-spec/issues/247
