### PR TITLE
Remove removed merge options of mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,9 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=package-spec/pr-merge
+      - check-success=CLA
+
 pull_request_rules:
   - name: automatic merge of bot 🤖
     conditions:
@@ -6,6 +12,6 @@ pull_request_rules:
       - base=master
       - author~=^dependabot(|-preview)\[bot\]$
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default


### PR DESCRIPTION
Fixes mergify configuration, `strict` option was removed on Jan 10. See https://blog.mergify.com/strict-mode-deprecation/.