### PR TITLE
Prepare 1.4.1 release

### DIFF
--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -2,7 +2,7 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom.
 ##
-- version: 1.4.1-next
+- version: 1.4.1
   changes:
   - description: ML model file name now matches the id of the model.
     type: enhancement


### PR DESCRIPTION
Prepare 1.4.1 release.

Releasing as a patch release because changes included are mostly refinements or fixes on existing features.