### PR TITLE
Add kibana/csp-rule-remplate asset type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ For a quick overview, these are the assets typically found in an Elastic Package
   * Map
   * Search
   * Security rules
+  * CSP (cloud security posture) rule templates
 * Other
   * fields.yml
 

--- a/test/packages/good/kibana/csp_rule_template/good-csp-rule-template-abc-1.json
+++ b/test/packages/good/kibana/csp_rule_template/good-csp-rule-template-abc-1.json
@@ -1,0 +1,22 @@
+{
+  "attributes": {
+    "benchmark_rule_id": "1.1.1",
+    "rego_rule_id": "cis_k8s.cis_1_1_1",
+    "name": "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)",
+    "description": "'Disable anonymous requests to the API server",
+    "rationale": "When enabled, requests that are not rejected by other configured authentication methods\nare treated as anonymous requests. These requests are then served by the API server. You\nshould rely on authentication to authorize access and disallow anonymous requests.\nIf you are using RBAC authorization, it is generally considered reasonable to allow\nanonymous access to the API Server for health checks and discovery purposes, and hence\nthis recommendation is not scored. However, you should consider whether anonymous\ndiscovery is an acceptable risk for your purposes.",
+    "impact": "Anonymous requests will be rejected.",
+    "default_value": "By default, anonymous access is enabled.",
+    "remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kubeapiserver.yaml on the master node and set the below parameter.\n--anonymous-auth=false",
+    "enabled": true,
+    "muted": false,
+    "tags": [
+      "Kubernetes",
+      "Containers"
+    ],
+    "benchmark": { "name": "CIS Kubernetes", "version": "1.4.1" },
+    "severity": "low"
+  },
+  "id": "good-csp-rule-template-abc-1",
+  "type": "csp-rule-template"
+}

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -7,6 +7,9 @@
   - description: Prepare for next version
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/275
+  - description: Add kibana/csp-rule-template asset
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/276
 - version: 1.4.1
   changes:
   - description: ML model file name now matches the id of the model.

--- a/versions/1/kibana/spec.yml
+++ b/versions/1/kibana/spec.yml
@@ -74,6 +74,15 @@
         type: file
         contentMediaType: "application/json"
         pattern: '^.+\.json$'
+    - description: Folder containing CSP rule templates
+      type: folder
+      name: "csp_rule_template"
+      required: false
+      contents:
+      - description: An individual CSP rule template file for the cloud security posture management solution
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^.+\.json$'
     - description: Folder containing ML module assets
       type: folder
       name: ml_module


### PR DESCRIPTION
## What does this PR do?

Add a `csp-rule-template` asset type for rules that will be delivered to Security » Cloud security posture » Rules part of Kibana.

## Why is it important?

This change is crucial for the cloud security posture solution, As integration packages for different benchmarks must contain the related `csp-rule-template`s for concrete rules creation in the cloud-security-posture plugin in Kibana.  

## Checklist

- [x] Passed `make update && make check && make test` locally
- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective (Added to the good package example).
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

- Closes https://github.com/elastic/package-spec/issues/263
- Relates https://github.com/elastic/kibana/issues/124149


cc @joshdover @mtojek @ruflin @kfirpeled 