### PR TITLE
Remove unused content attribute from the spec

### DIFF
--- a/code/go/internal/validator/common_spec.go
+++ b/code/go/internal/validator/common_spec.go
@@ -10,10 +10,9 @@ import (
 )
 
 type commonSpec struct {
-	AdditionalContents bool                   `yaml:"additionalContents"`
-	Content            map[string]interface{} `yaml:"content"`
-	Contents           []folderItemSpec       `yaml:"contents"`
-	DevelopmentFolder  bool                   `yaml:"developmentFolder"`
+	AdditionalContents bool             `yaml:"additionalContents"`
+	Contents           []folderItemSpec `yaml:"contents"`
+	DevelopmentFolder  bool             `yaml:"developmentFolder"`
 }
 
 func setDefaultValues(spec *commonSpec) error {

--- a/code/go/internal/validator/folder_item_spec.go
+++ b/code/go/internal/validator/folder_item_spec.go
@@ -79,8 +79,6 @@ func (s *folderItemSpec) validate(fs fs.FS, folderSpecPath string, itemPath stri
 	if s.Ref != "" {
 		schemaPath := filepath.Join(filepath.Dir(folderSpecPath), s.Ref)
 		schemaLoader = yamlschema.NewReferenceLoaderFileSystem("file:///"+schemaPath, fs)
-	} else if s.Content != nil {
-		schemaLoader = yamlschema.NewRawLoaderFileSystem(s.Content, fs)
 	} else {
 		return nil // item's schema is not defined
 	}

--- a/code/go/internal/yamlschema/schema_loader.go
+++ b/code/go/internal/yamlschema/schema_loader.go
@@ -32,19 +32,9 @@ type rawReferenceLoader struct {
 	source interface{}
 }
 
-var _ gojsonschema.JSONLoader = new(rawReferenceLoader)
-
 // NewReferenceLoaderFileSystem method creates new instance of `yamlReferenceLoader`.
 func NewReferenceLoaderFileSystem(source string, fs fs.FS) gojsonschema.JSONLoader {
 	return &yamlReferenceLoader{
-		fs:     fs,
-		source: source,
-	}
-}
-
-// NewRawLoaderFileSystem method creates new instance of `rawReferenceLoader`
-func NewRawLoaderFileSystem(source interface{}, fs fs.FS) gojsonschema.JSONLoader {
-	return &rawReferenceLoader{
 		fs:     fs,
 		source: source,
 	}
@@ -89,24 +79,6 @@ func (l *yamlReferenceLoader) JsonReference() (gojsonreference.JsonReference, er
 }
 
 func (l *yamlReferenceLoader) LoaderFactory() gojsonschema.JSONLoaderFactory {
-	return &fileSystemYAMLLoaderFactory{
-		fs: l.fs,
-	}
-}
-
-func (l *rawReferenceLoader) JsonSource() interface{} {
-	return l.source
-}
-
-func (l *rawReferenceLoader) LoadJSON() (interface{}, error) {
-	return l.source, nil
-}
-
-func (l *rawReferenceLoader) JsonReference() (gojsonreference.JsonReference, error) {
-	return gojsonreference.NewJsonReference("#")
-}
-
-func (l *rawReferenceLoader) LoaderFactory() gojsonschema.JSONLoaderFactory {
 	return &fileSystemYAMLLoaderFactory{
 		fs: l.fs,
 	}


### PR DESCRIPTION
## What does this PR do?

Remove unused attribute from common folder items spec. 

## Why is it important?

Cleanup.

To implement limits checking (https://github.com/elastic/package-spec/issues/162) I am considering to create a set of structures, separated to the spec ones, that keep information about the files found, such as size, and maybe their content. Such an attribute would belong there.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective. -> Tests pass after removing this code.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml). -> No user-facing change.