### PR TITLE
Fix validation of dimension fields inside objects

### DIFF
--- a/code/go/internal/validator/semantic/validate_field_groups.go
+++ b/code/go/internal/validator/semantic/validate_field_groups.go
@@ -24,12 +24,5 @@ func validateFieldUnit(fieldsFile string, f field) errors.ValidationErrors {
 		return errors.ValidationErrors{fmt.Errorf(`file "%s" is invalid: field "%s" can't have metric type property'`, fieldsFile, f.Name)}
 	}
 
-	var vErrs errors.ValidationErrors
-	for _, aField := range f.Fields {
-		errs := validateFieldUnit(fieldsFile, aField)
-		if len(errs) > 0 {
-			vErrs = append(vErrs, errs...)
-		}
-	}
-	return vErrs
+	return nil
 }

--- a/code/go/internal/validator/semantic/validate_field_groups_test.go
+++ b/code/go/internal/validator/semantic/validate_field_groups_test.go
@@ -31,8 +31,8 @@ func TestValidateFieldGroups_Bad(t *testing.T) {
 
 	errs := ValidateFieldGroups(pkgRoot)
 	if assert.Len(t, errs, 3) {
-		assert.Equal(t, fileError("data_stream/bar/fields/hello-world.yml", `field "bbb" can't have unit property'`), errs[0].Error())
-		assert.Equal(t, fileError("data_stream/bar/fields/hello-world.yml", `field "eee" can't have unit property'`), errs[1].Error())
+		assert.Equal(t, fileError("data_stream/bar/fields/hello-world.yml", `field "aaa.bbb" can't have unit property'`), errs[0].Error())
+		assert.Equal(t, fileError("data_stream/bar/fields/hello-world.yml", `field "ddd.eee" can't have unit property'`), errs[1].Error())
 		assert.Equal(t, fileError("data_stream/foo/fields/bad-file.yml", `field "fff" can't have metric type property'`), errs[2].Error())
 	}
 }

--- a/test/packages/bad_time_series/data_stream/example/fields/fields.yml
+++ b/test/packages/bad_time_series/data_stream/example/fields/fields.yml
@@ -1,13 +1,16 @@
-- name: example.agent.id
-  type: keyword
-  dimension: true
-- name: example.agent.call_count
-  type: long
-  metric_type: counter
-- name: example.agent.current_count
-  type: long
-  metric_type: gauge
-- name: example.agent.call_duration
-  type: histogram
-  metric_type: gauge
-  dimension: true # This should fail, a histogram cannot be a dimension.
+- name: example
+  type: group
+  fields:
+  - name: agent.id
+    type: keyword
+    dimension: true
+  - name: agent.call_count
+    type: long
+    metric_type: counter
+  - name: agent.current_count
+    type: long
+    metric_type: gauge
+  - name: agent.call_duration
+    type: histogram
+    metric_type: gauge
+    dimension: true # This should fail, a histogram cannot be a dimension.

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -10,6 +10,9 @@
   - description: Add kibana/csp-rule-template asset
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/276
+  - description: Fix validation of dimension fields inside objects
+    type: bugfix
+    link: https://github.com/elastic/package-spec/pull/279
 - version: 1.4.1
   changes:
   - description: ML model file name now matches the id of the model.


### PR DESCRIPTION
## What does this PR do?

There is a helper to visit a function with all the fields in a package, this helper was not visiting fields nested inside objects. Modify it to visit also nested fields, and "flatten" their names to give better information in error messages.

## Why is it important?

* Fixes validation of dimension fields.
* Error messages on fields validation provide now the full name of the field.
* Reduces the risk of incorrectly using this helper again (as was happening to me in https://github.com/elastic/package-spec/pull/278).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Discovered in https://github.com/elastic/package-spec/pull/278.
