### PR TITLE
Add support for match_only_text field type

### DIFF
--- a/test/packages/good/data_stream/foo/fields/some_fields.yml
+++ b/test/packages/good/data_stream/foo/fields/some_fields.yml
@@ -32,3 +32,6 @@
 - name: vehicle_type
   type: constant_keyword
   value: truck
+- name: error.message
+  description: Error message.
+  type: match_only_text

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -13,6 +13,9 @@
   - description: Fix validation of dimension fields inside objects
     type: bugfix
     link: https://github.com/elastic/package-spec/pull/279
+  - description: Add support for match_only_text field type
+    type: enhancement
+    link: https://github.com/elastic/package-spec/issues/284
 - version: 1.4.1
   changes:
   - description: ML model file name now matches the id of the model.

--- a/versions/1/data_stream/fields/fields.spec.yml
+++ b/versions/1/data_stream/fields/fields.spec.yml
@@ -22,6 +22,7 @@ spec:
         - histogram
         - constant_keyword
         - text
+        - match_only_text
         - keyword
         - long
         - integer


### PR DESCRIPTION
## What does this PR do?

Add support for [`match_only_text`](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/text.html#match-only-text-field-type) field type.

## Why is it important?

It is already used in ECS, and in packages that import these fields from there.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Discovered while trying #283 with zip files created with `elastic-package build --zip`.
