### PR TITLE
Increase fields limit

### DIFF
--- a/code/go/pkg/validator/limits_test.go
+++ b/code/go/pkg/validator/limits_test.go
@@ -77,7 +77,7 @@ func TestLimitsValidation(t *testing.T) {
 		{
 			title: "fieldsPerDataStreamLimit exceeded",
 			fsys: newMockFS().Good().WithFiles(
-				newMockFile("data_stream/foo/fields/many-fields.yml").WithContent(generateFields(1500)),
+				newMockFile("data_stream/foo/fields/many-fields.yml").WithContent(generateFields(2500)),
 			),
 			valid: false,
 		},

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -2,11 +2,14 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom.
 ##
-- version: 1.5.1-next
+- version: 1.6.0
   changes:
   - description: Validate required fields
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/291
+  - description: Increase fields limit from 1024 to 2048.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/294
 - version: 1.5.0
   changes:
   - description: Add kibana/csp-rule-template asset

--- a/versions/1/spec.yml
+++ b/versions/1/spec.yml
@@ -11,7 +11,7 @@ spec:
   sizeLimit: 150MB
   configurationSizeLimit: 5MB
   relativePathSizeLimit: 3MB
-  fieldsPerDataStreamLimit: 1024
+  fieldsPerDataStreamLimit: 2048
   contents:
   - description: The main package manifest file
     type: file


### PR DESCRIPTION
## What does this PR do?

Increase fields limit per datastream to 2048.

## Why is it important?

There are datastreams with more than 1500 fields.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
