### PR TITLE
Rename the developer-experience team to ecosystem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @elastic/integrations-developer-experience
+* @elastic/ecosystem


### PR DESCRIPTION
This PR renames the `integrations-developer-experience` team to `ecosystem`. 