### PR TITLE
Add time series index settings

### DIFF
--- a/test/packages/bad_time_series/data_stream/example/fields/fields.yml
+++ b/test/packages/bad_time_series/data_stream/example/fields/fields.yml
@@ -4,6 +4,9 @@
   - name: agent.id
     type: keyword
     dimension: true
+  - name: agent.ip
+    type: ip
+    dimensiont: true
   - name: agent.call_count
     type: long
     metric_type: counter

--- a/test/packages/bad_time_series/data_stream/example/manifest.yml
+++ b/test/packages/bad_time_series/data_stream/example/manifest.yml
@@ -9,3 +9,11 @@ streams:
         type: text
         title: Period
         default: 10s
+
+elasticsearch:
+  index_template:
+    settings:
+      # This should produce an error because this field is not a keyword.
+      index.routing_path: "example.agent.ip"
+    data_stream:
+      index_mode: "time_series"

--- a/test/packages/time_series/data_stream/example/manifest.yml
+++ b/test/packages/time_series/data_stream/example/manifest.yml
@@ -15,3 +15,6 @@ elasticsearch:
     settings:
       # Defaults to 16
       index.mapping.dimension_fields.limit: 32
+      index.routing_path: "example.agent.id"
+    data_stream:
+      index_mode: "time_series"

--- a/versions/1/data_stream/manifest.spec.yml
+++ b/versions/1/data_stream/manifest.spec.yml
@@ -202,6 +202,16 @@ spec:
                   type: string
               required:
               - name
+            data_stream:
+              description: Data stream settings
+              type: object
+              additionalProperties: false
+              properties:
+                index_mode:
+                  description: Index mode
+                  type: string
+                  enum:
+                  - time_series
         privileges:
           description: Elasticsearch privilege requirements
           type: object


### PR DESCRIPTION
## What does this PR do?

Checks that settings for time series indexes are supported.

Settings needed:
* `index.routing_path` in the index settings. This routing path must be a keyword dimension.
* `index_mode` in the data stream settings.

## Why is it important?

To improve support for time series data in the context of https://github.com/elastic/elasticsearch/issues/74660.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/package-spec/issues/311
