### PR TITLE
[Osquery] Add kibana/osquery-pack-asset

### DIFF
--- a/test/packages/good/kibana/osquery_pack_asset/good-osquery-pack-asset-1.json
+++ b/test/packages/good/kibana/osquery_pack_asset/good-osquery-pack-asset-1.json
@@ -1,0 +1,135 @@
+{
+    "attributes": {
+        "name": "vuln-management",
+        "version": 1,
+        "queries": [
+            {
+                "id": "kernel_info",
+                "interval": 86400,
+                "query": "select * from kernel_info;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "os_version",
+                "interval": 86400,
+                "query": "select * from os_version;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "kextstat",
+                "interval": 86400,
+                "platform": "darwin",
+                "query": "select * from kernel_extensions;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "kernel_modules",
+                "interval": 86400,
+                "platform": "linux",
+                "query": "select * from kernel_modules;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "installed_applications",
+                "interval": 86400,
+                "platform": "darwin",
+                "query": "select * from apps;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "browser_plugins",
+                "interval": 86400,
+                "platform": "darwin",
+                "query": "select browser_plugins.* from users join browser_plugins using (uid);",
+                "version": "1.6.1"
+            },
+            {
+                "id": "safari_extensions",
+                "interval": 86400,
+                "platform": "darwin",
+                "query": "select safari_extensions.* from users join safari_extensions using (uid);",
+                "version": "1.6.1"
+            },
+            {
+                "id": "opera_extensions",
+                "interval": 86400,
+                "platform": "darwin,linux",
+                "query": "select opera_extensions.* from users join opera_extensions using (uid);",
+                "version": "1.6.1"
+            },
+            {
+                "id": "chrome_extensions",
+                "interval": 86400,
+                "query": "select chrome_extensions.* from users join chrome_extensions using (uid);",
+                "version": "1.6.1"
+            },
+            {
+                "id": "firefox_addons",
+                "interval": 86400,
+                "platform": "darwin,linux",
+                "query": "select firefox_addons.* from users join firefox_addons using (uid);",
+                "version": "1.6.1"
+            },
+            {
+                "id": "homebrew_packages",
+                "interval": 86400,
+                "platform": "darwin",
+                "query": "select * from homebrew_packages;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "package_receipts",
+                "interval": 86400,
+                "platform": "darwin",
+                "query": "select * from package_receipts;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "deb_packages",
+                "interval": 86400,
+                "platform": "linux",
+                "query": "select * from deb_packages;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "apt_sources",
+                "interval": 86400,
+                "platform": "linux",
+                "query": "select * from apt_sources;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "portage_packages",
+                "interval": 86400,
+                "platform": "linux",
+                "query": "select * from portage_packages;",
+                "version": "2.0.0"
+            },
+            {
+                "id": "rpm_packages",
+                "interval": 86400,
+                "platform": "linux",
+                "query": "select * from rpm_packages;",
+                "version": "1.4.5"
+            },
+            {
+                "id": "unauthenticated_sparkle_feeds",
+                "interval": 86400,
+                "platform": "darwin",
+                "query": "select feeds.*, p2.value as sparkle_version from (select a.name as app_name, a.path as app_path, a.bundle_identifier as bundle_id, p.value as feed_url from (select name, path, bundle_identifier from apps) a, plist p where p.path = a.path || '/Contents/Info.plist' and p.key = 'SUFeedURL' and feed_url like 'http://%') feeds left outer join plist p2 on p2.path = app_path || '/Contents/Frameworks/Sparkle.framework/Resources/Info.plist' where (p2.key = 'CFBundleShortVersionString' OR coalesce(p2.key, '') = '');",
+                "version": "1.4.5"
+            },
+            {
+                "id": "backdoored_python_packages",
+                "interval": 86400,
+                "platform": "darwin,linux",
+                "query": "select name as package_name, version as package_version, path as package_path from python_packages where package_name = 'acqusition' or package_name = 'apidev-coop' or package_name = 'bzip' or package_name = 'crypt' or package_name = 'django-server' or package_name = 'pwd' or package_name = 'setup-tools' or package_name = 'telnet' or package_name = 'urlib3' or package_name = 'urllib';",
+                "version": "1.4.5"
+            }
+        ]
+    },
+    "coreMigrationVersion": "8.2.0",
+    "id": "good-osquery-pack-asset-1",
+    "references": [],
+    "type": "osquery-pack-asset"
+}

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -7,6 +7,9 @@
   - description: Prepare for next version
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/295
+  - description: Add kibana/osquery-pack-asset
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/299
 - version: 1.6.0
   changes:
   - description: Validate required fields

--- a/versions/1/kibana/spec.yml
+++ b/versions/1/kibana/spec.yml
@@ -101,3 +101,12 @@
         type: file
         contentMediaType: "application/json"
         pattern: '^{PACKAGE_NAME}-.+\.json$'
+    - description: Folder containing Osquery pack assets
+      type: folder
+      name: osquery_pack_asset
+      required: false
+      contents:
+      - description: An osquery pack asset file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'


### PR DESCRIPTION
## What does this PR do?

Adds support for `kibana/osquery-pack-asset`

## Why is it important?

We want to be able to ship `osquery_pack_asset` with `osquery_manager` integration, so the user can start using Osquery with the set of prebuilt packs

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

Relates https://github.com/elastic/integrations/pull/2851
Relates https://github.com/elastic/kibana/pull/128109
