### PR TITLE
[Osquery] Add Kibana/osquery-saved-query

### DIFF
--- a/test/packages/good/kibana/osquery_saved_query/good-osquery-saved-query-1.json
+++ b/test/packages/good/kibana/osquery_saved_query/good-osquery-saved-query-1.json
@@ -11,7 +11,7 @@
         "version": "1"
     },
     "coreMigrationVersion": "8.3.0",
-    "id": "osquery_manager-2de24900-b4a9-11ec-8f39-bf9c07530bbb",
+    "id": "good-osquery-saved-query-1",
     "references": [],
     "type": "osquery-saved-query",
     "updated_at": "2022-04-05T06:25:25.395Z",

--- a/test/packages/good/kibana/osquery_saved_query/good-osquery-saved-query-1.json
+++ b/test/packages/good/kibana/osquery_saved_query/good-osquery-saved-query-1.json
@@ -1,0 +1,19 @@
+{
+    "attributes": {
+        "created_at": "2022-04-05T06:25:25.392Z",
+        "created_by": "elastic",
+        "description": "A list of applications configured to launch when a system reboots.",
+        "id": "Persistence",
+        "interval": "3600",
+        "query": "select * from startup_items;",
+        "updated_at": "2022-04-05T06:25:25.392Z",
+        "updated_by": "elastic",
+        "version": "1"
+    },
+    "coreMigrationVersion": "8.3.0",
+    "id": "osquery_manager-2de24900-b4a9-11ec-8f39-bf9c07530bbb",
+    "references": [],
+    "type": "osquery-saved-query",
+    "updated_at": "2022-04-05T06:25:25.395Z",
+    "version": "Wzc1MSwxXQ=="
+}

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -2,16 +2,14 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom.
 ##
-- version: 1.8.0
-  changes:
-  - description: Add Kibana/osquery-saved-query
-    type: enhancement
-    link: https://github.com/elastic/package-spec/pull/321
 - version: 1.7.1-next
   changes:
   - description: Validate that fields are only defined once per data stream.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/309
+  - description: Add Kibana/osquery-saved-query
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/321
 - version: 1.7.0
   changes:
   - description: Add kibana/osquery-pack-asset

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -2,6 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom.
 ##
+- version: 1.8.0
+  changes:
+  - description: Add Kibana/osquery-saved-query
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/321
 - version: 1.7.1-next
   changes:
   - description: Validate that fields are only defined once per data stream.

--- a/versions/1/kibana/spec.yml
+++ b/versions/1/kibana/spec.yml
@@ -110,3 +110,12 @@
         type: file
         contentMediaType: "application/json"
         pattern: '^{PACKAGE_NAME}-.+\.json$'
+    - description: Folder containing Osquery saved queries
+      type: folder
+      name: osquery_saved_query
+      required: false
+      contents:
+      - description: An osquery saved query file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'


### PR DESCRIPTION
## What does this PR do?

Adds support for `kibana/osquery-saved-query`

## Why is it important?

We want to be able to ship `osquery_saved_query` with `osquery_manager` integration, so the user can start using Osquery with the set of prebuilt saved queries.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

[Relates https://github.com/elastic/integrations/pull/2851](https://github.com/elastic/integrations/pull/2998)
[Relates https://github.com/elastic/kibana/pull/128109](https://github.com/elastic/kibana/pull/129461)
