### PR TITLE
Add validation to check top changelog link

### DIFF
--- a/code/go/internal/validator/semantic/version_integrity.go
+++ b/code/go/internal/validator/semantic/version_integrity.go
@@ -186,10 +186,7 @@ func ensureLinksAreValid(links []string) ve.ValidationErrors {
 
 func validateGithub(ghLink *url.URL) error {
 	prNum, err := strconv.Atoi(path.Base(ghLink.Path))
-	if err != nil {
-		return err
-	}
-	if prNum <= 0 {
+	if err != nil || prNum <= 0 {
 		return fmt.Errorf("issue number in changelog link %v should be a positive number", ghLink)
 	}
 	return nil

--- a/code/go/internal/validator/semantic/version_integrity.go
+++ b/code/go/internal/validator/semantic/version_integrity.go
@@ -165,10 +165,12 @@ func ensureLinksAreValid(links []string) ve.ValidationErrors {
 			validateGithub,
 		},
 	}
-	for _, link := range links {
+	for i, link := range links {
 		linkURL, err := url.Parse(link)
 		if err != nil {
-			errs.Append(ve.ValidationErrors{err})
+			errs.Append(ve.ValidationErrors{
+				fmt.Errorf("invalid URL %s at position %d", link, i),
+			})
 			continue
 		}
 		for _, vl := range validateLinks {
@@ -188,7 +190,7 @@ func validateGithub(ghLink *url.URL) error {
 		return err
 	}
 	if prNum <= 0 {
-		return errors.New("issue number in changelog link should be a positive number")
+		return fmt.Errorf("issue number in changelog link %v should be a positive number", ghLink)
 	}
 	return nil
 }

--- a/code/go/internal/validator/semantic/version_integrity.go
+++ b/code/go/internal/validator/semantic/version_integrity.go
@@ -190,7 +190,7 @@ func validateGithub(ghLink *url.URL) error {
 		return err
 	}
 	if prNum == 0 {
-		return errors.New("zero is an invalid pull request number")
+		return errors.New("zero is not a valid pull request number")
 	}
 	return nil
 }

--- a/code/go/internal/validator/semantic/version_integrity.go
+++ b/code/go/internal/validator/semantic/version_integrity.go
@@ -18,7 +18,7 @@ import (
 	"github.com/elastic/package-spec/code/go/internal/pkgpath"
 )
 
-var errGHIssue = errors.New("issue number in changelog link should be a positive number")
+var errGithubIssue = errors.New("issue number in changelog link should be a positive number")
 
 // ChangelogLinkError records the link and the error
 type ChangelogLinkError struct {
@@ -29,7 +29,7 @@ type ChangelogLinkError struct {
 // Is checks if the target matches one of the allowed links errors.
 // Currently checks for github issue/pr links.
 func (e ChangelogLinkError) Is(target error) bool {
-	return target == errGHIssue
+	return target == errGithubIssue
 }
 
 func (e ChangelogLinkError) Error() string {
@@ -204,7 +204,7 @@ func validateGithubLink(ghLink *url.URL) error {
 	if err != nil || prNum <= 0 {
 		return &ChangelogLinkError{
 			ghLink.String(),
-			errGHIssue,
+			errGithubIssue,
 		}
 	}
 	return nil

--- a/code/go/internal/validator/semantic/version_integrity.go
+++ b/code/go/internal/validator/semantic/version_integrity.go
@@ -189,8 +189,8 @@ func validateGithub(ghLink *url.URL) error {
 	if err != nil {
 		return err
 	}
-	if prNum == 0 {
-		return errors.New("zero is not a valid pull request number")
+	if prNum >= 0 {
+		return errors.New("issue number in changelog link should be a positive number")
 	}
 	return nil
 }

--- a/code/go/internal/validator/semantic/version_integrity.go
+++ b/code/go/internal/validator/semantic/version_integrity.go
@@ -169,7 +169,7 @@ func ensureLinksAreValid(links []string) ve.ValidationErrors {
 		linkURL, err := url.Parse(link)
 		if err != nil {
 			errs.Append(ve.ValidationErrors{
-				fmt.Errorf("invalid URL %s %v", link, err),
+				fmt.Errorf("invalid URL %v", err),
 			})
 			continue
 		}

--- a/code/go/internal/validator/semantic/version_integrity.go
+++ b/code/go/internal/validator/semantic/version_integrity.go
@@ -169,7 +169,7 @@ func ensureLinksAreValid(links []string) ve.ValidationErrors {
 		linkURL, err := url.Parse(link)
 		if err != nil {
 			errs.Append(ve.ValidationErrors{
-				fmt.Errorf("invalid URL %s", link),
+				fmt.Errorf("invalid URL %s %v", link, err),
 			})
 			continue
 		}

--- a/code/go/internal/validator/semantic/version_integrity.go
+++ b/code/go/internal/validator/semantic/version_integrity.go
@@ -165,11 +165,11 @@ func ensureLinksAreValid(links []string) ve.ValidationErrors {
 			validateGithub,
 		},
 	}
-	for i, link := range links {
+	for _, link := range links {
 		linkURL, err := url.Parse(link)
 		if err != nil {
 			errs.Append(ve.ValidationErrors{
-				fmt.Errorf("invalid URL %s at position %d", link, i),
+				fmt.Errorf("invalid URL %s", link),
 			})
 			continue
 		}

--- a/code/go/internal/validator/semantic/version_integrity.go
+++ b/code/go/internal/validator/semantic/version_integrity.go
@@ -189,7 +189,7 @@ func validateGithub(ghLink *url.URL) error {
 	if err != nil {
 		return err
 	}
-	if prNum >= 0 {
+	if prNum <= 0 {
 		return errors.New("issue number in changelog link should be a positive number")
 	}
 	return nil

--- a/code/go/internal/validator/semantic/version_integrity_test.go
+++ b/code/go/internal/validator/semantic/version_integrity_test.go
@@ -4,31 +4,35 @@
 
 package semantic
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestChangelogLinks(t *testing.T) {
 
 	var tests = []struct {
-		name        string
-		links       []string
-		expectError bool
+		name      string
+		links     []string
+		numErrors int
 	}{
 		{
-			"ValidLinks",
+			"AllValidLinks",
 			[]string{
 				"https://github.com/elastic/integrations/pull/2897",
 				"https://github.com/elastic/integrations/pull/1001",
 				"https://github.com/elastic/integrations/pull/1",
 			},
-			false,
+			0,
 		},
 		{
-			"InvalidLinks",
+			"AllInvalidLinks",
 			[]string{
 				"https://github.com/elastic/integrations/pull/abcd",
 				"https://github.com/elastic/integrations/pull",
 			},
-			true,
+			2,
 		},
 		{
 			"SomeInvalidLinks",
@@ -36,14 +40,14 @@ func TestChangelogLinks(t *testing.T) {
 				"https://github.com/elastic/integrations/pull/1234",
 				"https://github.com/elastic/integrations/pull",
 			},
-			true,
+			1,
 		},
 		{
 			"BadLink",
 			[]string{
 				"https://github.com/elastic/integrations/pull/0",
 			},
-			true,
+			1,
 		},
 		{
 			"IgnoreCasesOtherThanGithubDotCom",
@@ -51,16 +55,17 @@ func TestChangelogLinks(t *testing.T) {
 				"https://gitlab.com/elastic/integrations/pull/abcd",
 				"https://zzz.com/elastic/integrations/pull/1234",
 			},
-			false,
+			0,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := ensureLinksAreValid(test.links)
-			if test.expectError && err == nil {
+			errs := ensureLinksAreValid(test.links)
+			assert.Equal(t, test.numErrors, len(errs))
+			if test.numErrors > 0 && errs == nil {
 				t.Error("expecting error")
-			} else if !test.expectError && err != nil {
-				t.Errorf("expecting no error while got %v", err)
+			} else if test.numErrors == 0 && errs != nil {
+				t.Errorf("expecting no error while got %v", errs)
 			}
 		})
 	}

--- a/code/go/internal/validator/semantic/version_integrity_test.go
+++ b/code/go/internal/validator/semantic/version_integrity_test.go
@@ -45,6 +45,14 @@ func TestChangelogLinks(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"IgnoreCasesOtherThanGithubDotCom",
+			[]string{
+				"https://gitlab.com/elastic/integrations/pull/abcd",
+				"https://zzz.com/elastic/integrations/pull/1234",
+			},
+			false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/code/go/internal/validator/semantic/version_integrity_test.go
+++ b/code/go/internal/validator/semantic/version_integrity_test.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"testing"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-
 	"github.com/stretchr/testify/assert"
+
+	ve "github.com/elastic/package-spec/code/go/internal/errors"
 )
 
 func TestValidateGithubLink(t *testing.T) {
@@ -24,15 +24,15 @@ func TestValidateGithubLink(t *testing.T) {
 		},
 		{
 			"https://github.com/elastic/integrations/pull/abcd",
-			errGHIssue,
+			errGithubIssue,
 		},
 		{
 			"https://github.com/elastic/integrations/pull/0",
-			errGHIssue,
+			errGithubIssue,
 		},
 		{
 			"https://github.com/elastic/integrations/pull",
-			errGHIssue,
+			errGithubIssue,
 		},
 	}
 	for _, test := range tests {
@@ -71,8 +71,8 @@ func TestEnsureLinksAreValid(t *testing.T) {
 				"https://github.com/elastic/integrations/pull",
 			},
 			ve.ValidationErrors{
-				errGHIssue,
-				errGHIssue,
+				errGithubIssue,
+				errGithubIssue,
 			},
 		},
 		{
@@ -82,7 +82,7 @@ func TestEnsureLinksAreValid(t *testing.T) {
 				"https://github.com/elastic/integrations/pull",
 			},
 			ve.ValidationErrors{
-				errGHIssue,
+				errGithubIssue,
 			},
 		},
 		{

--- a/code/go/internal/validator/semantic/version_integrity_test.go
+++ b/code/go/internal/validator/semantic/version_integrity_test.go
@@ -1,0 +1,59 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package semantic
+
+import "testing"
+
+func TestChangelogLinks(t *testing.T) {
+
+	var tests = []struct {
+		name        string
+		links       []string
+		expectError bool
+	}{
+		{
+			"ValidLinks",
+			[]string{
+				"https://github.com/elastic/integrations/pull/2897",
+				"https://github.com/elastic/integrations/pull/1001",
+				"https://github.com/elastic/integrations/pull/1",
+			},
+			false,
+		},
+		{
+			"InvalidLinks",
+			[]string{
+				"https://github.com/elastic/integrations/pull/abcd",
+				"https://github.com/elastic/integrations/pull",
+			},
+			true,
+		},
+		{
+			"SomeInvalidLinks",
+			[]string{
+				"https://github.com/elastic/integrations/pull/1234",
+				"https://github.com/elastic/integrations/pull",
+			},
+			true,
+		},
+		{
+			"BadLink",
+			[]string{
+				"https://github.com/elastic/integrations/pull/0",
+			},
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ensureLinksAreValid(test.links)
+			if test.expectError && err == nil {
+				t.Error("expecting error")
+			} else if !test.expectError && err != nil {
+				t.Errorf("expecting no error while got %v", err)
+			}
+		})
+	}
+}

--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -68,7 +68,7 @@ func (s Spec) ValidatePackage(pkg Package) ve.ValidationErrors {
 	rules := validationRules{
 		semantic.ValidateKibanaObjectIDs,
 		semantic.ValidateVersionIntegrity,
-		semantic.ValidateTopChangelogLink,
+		semantic.ValidateChangelogLinks,
 		semantic.ValidatePrerelease,
 		semantic.ValidateFieldGroups,
 		semantic.ValidateFieldsLimits(rootSpec.Limits.FieldsPerDataStreamLimit),

--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -68,6 +68,7 @@ func (s Spec) ValidatePackage(pkg Package) ve.ValidationErrors {
 	rules := validationRules{
 		semantic.ValidateKibanaObjectIDs,
 		semantic.ValidateVersionIntegrity,
+		semantic.ValidateTopChangelogLink,
 		semantic.ValidatePrerelease,
 		semantic.ValidateFieldGroups,
 		semantic.ValidateFieldsLimits(rootSpec.Limits.FieldsPerDataStreamLimit),

--- a/test/packages/bad_time_series/changelog.yml
+++ b/test/packages/bad_time_series/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: Initial draft of the package
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/0 # FIXME Replace with the real PR link
+      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link

--- a/test/packages/input_groups/changelog.yml
+++ b/test/packages/input_groups/changelog.yml
@@ -2,4 +2,4 @@
   changes:
     - description: initial release
       type: enhancement
-      link: https://github.com/elastic/package-spec/pull/0
+      link: https://github.com/elastic/package-spec/pull/1

--- a/test/packages/time_series/changelog.yml
+++ b/test/packages/time_series/changelog.yml
@@ -3,4 +3,4 @@
   changes:
     - description: Initial draft of the package
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/0 # FIXME Replace with the real PR link
+      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -2,6 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom.
 ##
+- version: 1.7.2-next
+  changes:
+  - description: Validate top changelog links to have a valid number if it is a github URL.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/324
 - version: 1.7.1-next
   changes:
   - description: Validate that fields are only defined once per data stream.

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -2,13 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom.
 ##
-- version: 1.7.2-next
+- version: 1.7.1-next
   changes:
   - description: Validate top changelog links to have a valid number if it is a github URL.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/324
-- version: 1.7.1-next
-  changes:
   - description: Validate that fields are only defined once per data stream.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/309


### PR DESCRIPTION
## What does this PR do?

On occasion the PR link in the changelog is not updated with the correct number. It is left with `xxxx` or `0` or with no number. The package could get merged to `main` with no check to catch it. This PR adds a validation to check all the changelog entry's links. 

Since the link could technically be any issue tracking system, this change enforces that the base of the path (which is the number) be a valid number (not a `0`) for a github.com URL.

Initial discussion about this is here - https://github.com/elastic/elastic-package/pull/793



## Why is it important?

As explained in the section above.

## Checklist

- [x] I have added unit tests to test the validation.
- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).