### PR TITLE
Disable check to avoid duplicated fields

### DIFF
--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -72,7 +72,8 @@ func (s Spec) ValidatePackage(pkg Package) ve.ValidationErrors {
 		semantic.ValidatePrerelease,
 		semantic.ValidateFieldGroups,
 		semantic.ValidateFieldsLimits(rootSpec.Limits.FieldsPerDataStreamLimit),
-		semantic.ValidateUniqueFields,
+		// Temporarily disabled: https://github.com/elastic/package-spec/issues/331
+		//semantic.ValidateUniqueFields,
 		semantic.ValidateDimensionFields,
 		semantic.ValidateRequiredFields,
 	}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -265,6 +265,7 @@ func TestValidateVersionIntegrity(t *testing.T) {
 }
 
 func TestValidateDuplicatedFields(t *testing.T) {
+	t.Skip("Validation temporarily disabled: https://github.com/elastic/package-spec/issues/331")
 	tests := map[string]string{
 		"bad_duplicated_fields": "field \"event.dataset\" is defined multiple times for data stream \"wrong\", found in: ../../../../test/packages/bad_duplicated_fields/data_stream/wrong/fields/base-fields.yml, ../../../../test/packages/bad_duplicated_fields/data_stream/wrong/fields/ecs.yml",
 	}

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -2,11 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom.
 ##
-- version: 1.8.1-next
+- version: 1.8.1
   changes:
-  - description: Prepare for next version
-    type: enhancement
-    link: https://github.com/elastic/package-spec/pull/330
+  - description: Disable validation of duplicated fields.
+    type: bugfix
+    link: https://github.com/elastic/package-spec/pull/332
 - version: 1.8.0
   changes:
   - description: Validate top changelog links to have a valid number if it is a github URL.


### PR DESCRIPTION
## What does this PR do?

Disables check to avoid duplicated fields definitions, and prepares next release.

## Why is it important?

It conflicts with current implementation of elastic-package, see https://github.com/elastic/package-spec/issues/331.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Related to https://github.com/elastic/package-spec/issues/331