### PR TITLE
Don't check type for imported required fields

### DIFF
--- a/code/go/internal/validator/semantic/validate_required_fields.go
+++ b/code/go/internal/validator/semantic/validate_required_fields.go
@@ -46,8 +46,12 @@ func validateRequiredFields(fsys fspath.FS, requiredFields map[string]string) ve
 		if _, ok := foundFields[datastream]; !ok {
 			foundFields[datastream] = make(map[string]struct{})
 		}
-
 		foundFields[datastream][f.Name] = struct{}{}
+
+		// Don't check type for external fields.
+		if f.External != "" {
+			return nil
+		}
 		if f.Type != expectedType {
 			return ve.ValidationErrors{errors.Errorf("expected type %q for required field %q, found %q in %q", expectedType, f.Name, f.Type, fieldsFile)}
 		}

--- a/code/go/internal/validator/semantic/validate_required_fields.go
+++ b/code/go/internal/validator/semantic/validate_required_fields.go
@@ -48,11 +48,11 @@ func validateRequiredFields(fsys fspath.FS, requiredFields map[string]string) ve
 		}
 		foundFields[datastream][f.Name] = struct{}{}
 
-		// Don't check type for external fields.
-		if f.External != "" {
-			return nil
-		}
-		if f.Type != expectedType {
+		// Check if type is the expected one, but only for fields what are
+		// not declared as external. External fields won't have a type in
+		// the definition.
+		// More info in https://github.com/elastic/elastic-package/issues/749
+		if f.External == "" && f.Type != expectedType {
 			return ve.ValidationErrors{errors.Errorf("expected type %q for required field %q, found %q in %q", expectedType, f.Name, f.Type, fieldsFile)}
 		}
 

--- a/test/packages/good/data_stream/foo/fields/base-fields.yml
+++ b/test/packages/good/data_stream/foo/fields/base-fields.yml
@@ -7,6 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
-- name: '@timestamp'
-  type: date
-  description: Event timestamp.

--- a/test/packages/good/data_stream/foo/fields/external-fields.yml
+++ b/test/packages/good/data_stream/foo/fields/external-fields.yml
@@ -1,3 +1,5 @@
+- name: "@timestamp"
+  external: ecs
 - name: event
   type: group
   description: Event family

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -4,9 +4,9 @@
 ##
 - version: 1.10.1-next
   changes:
-    - description: Prepare for the next release
+    - description: Don't check type for imported required fields.
       type: enhancement
-      link: https://github.com/elastic/package-spec/pull/344
+      link: https://github.com/elastic/package-spec/pull/347
 - version: 1.10
   changes:
     - description: Define beta features in spec


### PR DESCRIPTION
## What does this PR do?

External fields don't have a type in the definition. When checking for presence of fields, don't
check the type on these fields.

## Why is it important?

Required fields cannot be imported otherwise, as validation fails for un-resolved fields.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes https://github.com/elastic/elastic-package/issues/749.
