### PR TITLE
Prepare release v1.11.0

### DIFF
--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -2,12 +2,15 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom.
 ##
-- version: 1.10.1-next
+- version: 1.11.0
   changes:
+    - description: Enable development resources for input packages
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/350
     - description: Don't check type for imported required fields.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/347
-- version: 1.10
+- version: 1.10.0
   changes:
     - description: Define beta features in spec
       type: enhancement


### PR DESCRIPTION
Meta-issue: https://github.com/elastic/package-spec/issues/319
Related: https://github.com/elastic/elastic-package/pull/840

This PR prepares the next release v1.11.0 to rollout changes around input packages (developer resources).