### PR TITLE
Add field for source license and condition for subscription

### DIFF
--- a/test/packages/good/manifest.yml
+++ b/test/packages/good/manifest.yml
@@ -4,8 +4,11 @@ title: Good package
 description: This package is good.
 version: 1.0.0
 type: integration
+source:
+  license: "Apache-2.0"
 conditions:
   kibana.version: '^7.9.0'
+  elastic.subscription: 'basic'
 policy_templates:
   - name: apache
     title: Apache logs and metrics

--- a/test/packages/sql_input/manifest.yml
+++ b/test/packages/sql_input/manifest.yml
@@ -5,7 +5,10 @@ description: >-
   Execute custom queries against an SQL database and store the results in Elasticsearch.
 type: input
 version: 0.2.0
-license: basic
+source:
+  license: "Apache-2.0"
+conditions:
+  elastic.subscription: basic
 categories:
   - custom
   - datastore

--- a/versions/1/input/manifest.spec.yml
+++ b/versions/1/input/manifest.spec.yml
@@ -28,8 +28,11 @@ spec:
     version:
       description: The version of the package.
       $ref: "../integration/manifest.spec.yml#/definitions/version"
+    source:
+      $ref: "../integration/manifest.spec.yml#/definitions/source"
     license:
-      description: The license under which the package is being released.
+      description: The license under which the package is being released (deprecated, use subscription instead).
+      deprecated: true
       type: string
       enum:
       - basic
@@ -46,20 +49,7 @@ spec:
     categories:
       $ref: "../integration/manifest.spec.yml#/definitions/categories"
     conditions:
-      description: Conditions under which this package can be installed.
-      type: object
-      additionalProperties: false
-      properties:
-        kibana:
-          description: Kibana conditions
-          type: object
-          additionalProperties: false
-          properties:
-            version:
-              type: string
-              description: Kibana versions compatible with this package.
-              examples:
-                - ">=7.9.0"
+      $ref: "../integration/manifest.spec.yml#/definitions/conditions"
     policy_templates:
       description: List of policy templates offered by this package.
       type: array

--- a/versions/1/integration/manifest.spec.yml
+++ b/versions/1/integration/manifest.spec.yml
@@ -37,6 +37,34 @@ spec:
           - web
         examples:
           - web
+    conditions:
+      description: Conditions under which this package can be installed.
+      type: object
+      additionalProperties: false
+      properties:
+        elastic:
+          description: Elastic conditions
+          type: object
+          additionalProperties: false
+          properties:
+            subscription:
+              description: The subscription required for this package.
+              type: string
+              enum:
+              - basic
+              default: basic
+              examples:
+              - basic
+        kibana:
+          description: Kibana conditions
+          type: object
+          additionalProperties: false
+          properties:
+            version:
+              type: string
+              description: Kibana versions compatible with this package.
+              examples:
+                - ">=7.9.0"
     icons:
       description: List of icons for by this package.
       type: array
@@ -98,6 +126,19 @@ spec:
         required:
           - src
           - title
+    source:
+      description: Information about the source of the package.
+      type: object
+      additionalProperties: false
+      properties:
+        license:
+          description: Identifier of the license of the package, as specified in https://spdx.org/licenses/.
+          type: string
+          enum:
+            - "Apache-2.0"
+            - "Elastic-2.0"
+          examples:
+            - "Elastic-2.0"
     version:
       description: Version of the package, following semantic versioning. It can include pre-release labels.
       type: string
@@ -140,8 +181,11 @@ spec:
     version:
       description: The version of the package.
       $ref: "#/definitions/version"
+    source:
+      $ref: "#/definitions/source"
     license:
-      description: The license under which the package is being released.
+      description: The license under which the package is being released (deprecated, use subscription instead).
+      deprecated: true # See https://github.com/elastic/package-spec/issues/298.
       type: string
       enum:
       - basic
@@ -169,20 +213,7 @@ spec:
     categories:
       $ref: "#/definitions/categories"
     conditions:
-      description: Conditions under which this package can be installed.
-      type: object
-      additionalProperties: false
-      properties:
-        kibana:
-          description: Kibana conditions
-          type: object
-          additionalProperties: false
-          properties:
-            version:
-              type: string
-              description: Kibana versions compatible with this package.
-              examples:
-                - ">=7.9.0"
+      $ref: "#/definitions/conditions"
     policy_templates:
       description: List of policy templates offered by this package.
       type: array


### PR DESCRIPTION
## What does this PR do?

* Add a new `source.license` field, with the actual license of the package.
* Add a new `elastic.subscription` field, that allows to optionally declare a required subscription to install a package.
* Deprecate the current `license` field.

## Why is it important?

Current "license" field is referring to the subscription level, and there is no way to indicate the actual license of the package.

See https://github.com/elastic/package-spec/issues/298 for more information.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

- Part of https://github.com/elastic/package-spec/issues/298.
