### PR TITLE
Add flag to enable time series data streams

### DIFF
--- a/test/packages/time_series/data_stream/example/manifest.yml
+++ b/test/packages/time_series/data_stream/example/manifest.yml
@@ -11,6 +11,7 @@ streams:
         default: 10s
 
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     settings:
       # Defaults to 16

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -4,9 +4,9 @@
 ##
 - version: 1.11.1-next
   changes:
-    - description: Prepare for next patch release
+    - description: Add setting to configure index mode for data streams
       type: enhancement
-      link: https://github.com/elastic/package-spec/pull/353
+      link: https://github.com/elastic/package-spec/pull/357
 - version: 1.11.0
   changes:
     - description: Enable development resources for input packages

--- a/versions/1/integration/data_stream/manifest.spec.yml
+++ b/versions/1/integration/data_stream/manifest.spec.yml
@@ -181,6 +181,15 @@ spec:
       type: object
       additionalProperties: false
       properties:
+        index_mode:
+          description: |-
+            Index mode to use. Index mode can be used to enable use case specific functionalities.
+            This setting must be installed in the composable index template, not in the package component templates.
+          type: string
+          enum:
+          - "time_series" # Enables time series data streams https://www.elastic.co/guide/en/elasticsearch/reference/master/tsds.html
+          examples:
+          - "time_series"
         index_template:
           description: Index template definition
           type: object


### PR DESCRIPTION
## What does this PR do?

Add a new setting to configure index mode for a data stream.

It is added as a new setting, instead of using `elasticsearch.index_template`, because it needs to be installed in the composable index template, and the other settings are installed in the `@package` component template. This was tried in https://github.com/elastic/integrations/pull/3119.

## Why is it important?

To allow to enable time series mode in data streams (https://www.elastic.co/guide/en/elasticsearch/reference/master/tsds.html#time-series-mode).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #311