### PR TITLE
Fix package validation on Windows

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,11 +50,26 @@ pipeline {
      Test the source code.
      */
     stage('Test') {
-      steps {
-        cleanup()
-        withMageEnv(){
-          dir("${BASE_DIR}"){
-            sh(label: 'Test', script: 'make test')
+      parallel {
+        stage('Test on Linux') {
+          steps {
+            cleanup()
+            withMageEnv(){
+              dir("${BASE_DIR}"){
+                sh(label: 'Test', script: 'make test')
+              }
+            }
+          }
+        }
+        stage('Test on Windows') {
+          agent { label 'windows-10' }
+          steps {
+            cleanup()
+            dir("${BASE_DIR}"){
+              withMageEnv(){
+                bat(label: 'Test', script: 'go test -v ./code/go/...')
+              }
+            }
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
     stage('Test') {
       parallel {
         stage('Test on Linux') {
+          options { skipDefaultCheckout() }
           steps {
             cleanup()
             withMageEnv(){
@@ -63,10 +64,11 @@ pipeline {
         }
         stage('Test on Windows') {
           agent { label 'windows-10' }
+          options { skipDefaultCheckout() }
           steps {
             cleanup()
-            dir("${BASE_DIR}"){
-              withMageEnv(){
+            withMageEnv(){
+              dir("${BASE_DIR}"){
                 bat(label: 'Test', script: 'go test -v ./code/go/...')
               }
             }

--- a/code/go/internal/fspath/fspath.go
+++ b/code/go/internal/fspath/fspath.go
@@ -7,7 +7,7 @@ package fspath
 import (
 	"io/fs"
 	"os"
-	"path/filepath"
+	"path"
 )
 
 // FS implements the fs interface and can also show a path where the fs is located.
@@ -26,7 +26,7 @@ type fsDir struct {
 
 // Path returns a path for the given names, based on the location of the file system.
 func (fs *fsDir) Path(names ...string) string {
-	return filepath.Join(append([]string{fs.path}, names...)...)
+	return path.Join(append([]string{fs.path}, names...)...)
 }
 
 // DirFS returns a file system for a directory, it keeps the path to implement the FS interface.

--- a/code/go/internal/validator/folder_item_spec.go
+++ b/code/go/internal/validator/folder_item_spec.go
@@ -7,7 +7,7 @@ package validator
 import (
 	"fmt"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"regexp"
 	"sync"
 
@@ -103,7 +103,7 @@ func (s *folderItemSpec) validateSchema(schemaFsys fs.FS, fsys fs.FS, folderSpec
 		return nil // item's schema is not defined
 	}
 
-	schemaPath := filepath.Join(filepath.Dir(folderSpecPath), s.Ref)
+	schemaPath := path.Join(path.Dir(folderSpecPath), s.Ref)
 	schemaLoader := yamlschema.NewReferenceLoaderFileSystem("file:///"+schemaPath, schemaFsys)
 
 	// validation with schema
@@ -120,8 +120,8 @@ func (s *folderItemSpec) validateSchema(schemaFsys fs.FS, fsys fs.FS, folderSpec
 		formatCheckersMutex.Unlock()
 	}()
 
-	semantic.LoadRelativePathFormatChecker(fsys, filepath.Dir(itemPath), s.Limits.RelativePathSizeLimit)
-	semantic.LoadDataStreamNameFormatChecker(fsys, filepath.Dir(itemPath))
+	semantic.LoadRelativePathFormatChecker(fsys, path.Dir(itemPath), s.Limits.RelativePathSizeLimit)
+	semantic.LoadDataStreamNameFormatChecker(fsys, path.Dir(itemPath))
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
 		return ve.ValidationErrors{err}

--- a/code/go/internal/validator/package.go
+++ b/code/go/internal/validator/package.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
@@ -33,7 +33,7 @@ func (p *Package) Open(name string) (fs.File, error) {
 
 // Path returns a path meaningful for the user.
 func (p *Package) Path(names ...string) string {
-	return filepath.Join(append([]string{p.location}, names...)...)
+	return path.Join(append([]string{p.location}, names...)...)
 }
 
 // NewPackage creates a new Package from a path to the package's root folder

--- a/code/go/internal/validator/package_test.go
+++ b/code/go/internal/validator/package_test.go
@@ -47,4 +47,3 @@ func TestNewPackage(t *testing.T) {
 		})
 	}
 }
-

--- a/code/go/internal/validator/semantic/format_checkers.go
+++ b/code/go/internal/validator/semantic/format_checkers.go
@@ -6,7 +6,7 @@ package semantic
 
 import (
 	"io/fs"
-	"path/filepath"
+	"path"
 
 	"github.com/xeipuuv/gojsonschema"
 
@@ -40,7 +40,7 @@ func (r relativePathChecker) IsFormat(input interface{}) bool {
 		return false
 	}
 
-	path := filepath.Join(r.currentPath, asString)
+	path := path.Join(r.currentPath, asString)
 	info, err := fs.Stat(r.fsys, path)
 	if err != nil {
 		return false
@@ -77,7 +77,7 @@ func UnloadRelativePathFormatChecker() {
 func LoadDataStreamNameFormatChecker(fsys fs.FS, currentPath string) {
 	gojsonschema.FormatCheckers.Add(DataStreamNameFormat, relativePathChecker{
 		fsys:        fsys,
-		currentPath: filepath.Join(currentPath, "data_stream"),
+		currentPath: path.Join(currentPath, "data_stream"),
 	})
 }
 

--- a/code/go/internal/validator/semantic/types_test.go
+++ b/code/go/internal/validator/semantic/types_test.go
@@ -1,0 +1,54 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package semantic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataStreamFromFieldsPath(t *testing.T) {
+	cases := []struct {
+		pkgRoot    string
+		fieldsFile string
+		expected   string
+		fail       bool
+	}{
+		{
+			pkgRoot:    "package",
+			fieldsFile: "package/data_stream/foo/fields/some-fields.yml",
+			expected:   "foo",
+		},
+		{
+			pkgRoot:    "package/",
+			fieldsFile: "package/data_stream/foo/fields/some-fields.yml",
+			expected:   "foo",
+		},
+		{
+			pkgRoot:    "/package/",
+			fieldsFile: "/package/data_stream/foo/fields/some-fields.yml",
+			expected:   "foo",
+		},
+		{
+			pkgRoot:    "/package/",
+			fieldsFile: "/package/fields/some-fields.yml",
+			fail:       true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.pkgRoot+"_"+c.fieldsFile, func(t *testing.T) {
+			dataStream, err := dataStreamFromFieldsPath(c.pkgRoot, c.fieldsFile)
+			if c.fail {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, c.expected, dataStream)
+			}
+		})
+	}
+}

--- a/code/go/internal/validator/semantic/validate_field_groups_test.go
+++ b/code/go/internal/validator/semantic/validate_field_groups_test.go
@@ -6,7 +6,7 @@ package semantic
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +27,7 @@ func TestValidateFieldGroups_Bad(t *testing.T) {
 
 	fileError := func(name string, expected string) string {
 		return fmt.Sprintf(`file "%s" is invalid: %s`,
-			filepath.Join(pkgRoot, name),
+			path.Join(pkgRoot, name),
 			expected)
 	}
 

--- a/code/go/internal/validator/semantic/validate_kibana_matching_object_ids.go
+++ b/code/go/internal/validator/semantic/validate_kibana_matching_object_ids.go
@@ -6,7 +6,7 @@ package semantic
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -23,7 +23,7 @@ import (
 func ValidateKibanaObjectIDs(fsys fspath.FS) ve.ValidationErrors {
 	var errs ve.ValidationErrors
 
-	filePaths := filepath.Join("kibana", "*", "*.json")
+	filePaths := path.Join("kibana", "*", "*.json")
 	objectFiles, err := pkgpath.Files(fsys, filePaths)
 	if err != nil {
 		errs = append(errs, errors.Wrap(err, "error finding Kibana object files"))
@@ -40,7 +40,7 @@ func ValidateKibanaObjectIDs(fsys fspath.FS) ve.ValidationErrors {
 		}
 
 		// Special case: object is of type 'security_rule'
-		if filepath.Base(filepath.Dir(filePath)) == "security_rule" {
+		if path.Base(path.Dir(filePath)) == "security_rule" {
 			ruleID, err := objectFile.Values("$.attributes.rule_id")
 			if err != nil {
 				errs = append(errs, errors.Wrapf(err, "unable to get rule ID in file [%s]", fsys.Path(filePath)))
@@ -54,8 +54,8 @@ func ValidateKibanaObjectIDs(fsys fspath.FS) ve.ValidationErrors {
 		}
 
 		// fileID == filename without the extension == expected ID of Kibana object defined inside file.
-		fileName := filepath.Base(filePath)
-		fileExt := filepath.Ext(filePath)
+		fileName := path.Base(filePath)
+		fileExt := path.Ext(filePath)
 		fileID := strings.Replace(fileName, fileExt, "", -1)
 		if fileID != objectID {
 			err := fmt.Errorf("kibana object file [%s] defines non-matching ID [%s]", fsys.Path(filePath), objectID)

--- a/code/go/internal/yamlschema/schema_loader.go
+++ b/code/go/internal/yamlschema/schema_loader.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"io/ioutil"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -75,7 +76,18 @@ func (l *yamlReferenceLoader) LoadJSON() (interface{}, error) {
 }
 
 func (l *yamlReferenceLoader) JsonReference() (gojsonreference.JsonReference, error) {
-	return gojsonreference.NewJsonReference(l.JsonSource().(string))
+	r, err := gojsonreference.NewJsonReference(l.JsonSource().(string))
+	if err != nil {
+		return r, err
+	}
+
+	// gojsonreference uses filepath to decide if the reference has a full file path,
+	// and in Windows it has additional special handling.
+	// Here we are operating on a fs.FS, where '/' is always used as separator, also on
+	// Windows. Override the value with the result of `path.IsAbs`.
+	r.HasFullFilePath = path.IsAbs(r.GetUrl().Path)
+
+	return r, nil
 }
 
 func (l *yamlReferenceLoader) LoaderFactory() gojsonschema.JSONLoaderFactory {

--- a/code/go/pkg/validator/limits_test.go
+++ b/code/go/pkg/validator/limits_test.go
@@ -281,7 +281,7 @@ func (f *mockFile) WithGeneratedFiles(n int, suffix string, size spectypes.FileS
 }
 
 func (f *mockFile) addFileWithDirs(file *mockFile) {
-	parts := strings.Split(file.stat.name, string(os.PathSeparator))
+	parts := strings.Split(file.stat.name, "/")
 	dir := f
 	for i, part := range parts[:len(parts)-1] {
 		d, err := dir.findFile(part)
@@ -305,7 +305,7 @@ func (f *mockFile) findFile(name string) (*mockFile, error) {
 		return f, nil
 	}
 	name = path.Clean(name)
-	parts := strings.SplitN(name, string(os.PathSeparator), 2)
+	parts := strings.SplitN(name, "/", 2)
 
 	if len(parts) == 0 {
 		panic("path should not be empty here")

--- a/code/go/pkg/validator/limits_test.go
+++ b/code/go/pkg/validator/limits_test.go
@@ -220,6 +220,9 @@ type mockFile struct {
 }
 
 func newMockFile(name string) *mockFile {
+	if os.PathSeparator != '/' {
+		name = strings.ReplaceAll(name, "/", string(os.PathSeparator))
+	}
 	return &mockFile{
 		stat: mockFileInfo{
 			name:  name,

--- a/code/go/pkg/validator/limits_test.go
+++ b/code/go/pkg/validator/limits_test.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -220,9 +220,6 @@ type mockFile struct {
 }
 
 func newMockFile(name string) *mockFile {
-	if os.PathSeparator != '/' {
-		name = strings.ReplaceAll(name, "/", string(os.PathSeparator))
-	}
 	return &mockFile{
 		stat: mockFileInfo{
 			name:  name,
@@ -290,7 +287,7 @@ func (f *mockFile) addFileWithDirs(file *mockFile) {
 		d, err := dir.findFile(part)
 		if err == nil {
 			if !d.stat.isDir {
-				panic(strings.Join(parts[:i], string(os.PathSeparator)) + " is not a directory")
+				panic(path.Join(parts[:i]...) + " is not a directory")
 			}
 			dir = d
 		} else {
@@ -307,7 +304,7 @@ func (f *mockFile) findFile(name string) (*mockFile, error) {
 	if name == "." {
 		return f, nil
 	}
-	name = filepath.Clean(name)
+	name = path.Clean(name)
 	parts := strings.SplitN(name, string(os.PathSeparator), 2)
 
 	if len(parts) == 0 {

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -6,6 +6,7 @@ package validator
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -196,7 +197,7 @@ func TestValidateBadKibanaIDs(t *testing.T) {
 			var c int
 			for itemFolder, invalidItems := range invalidItemsPerFolder {
 				for _, invalidItem := range invalidItems {
-					objectFilePath := filepath.Join(pkgRootPath, itemFolder, invalidItem)
+					objectFilePath := path.Join(pkgRootPath, itemFolder, invalidItem)
 					expected := fmt.Sprintf("kibana object file [%s] defines non-matching ID", objectFilePath)
 
 					var found bool
@@ -225,8 +226,7 @@ func TestValidateMissingReqiredFields(t *testing.T) {
 
 	for pkgName, expectedErrors := range tests {
 		t.Run(pkgName, func(t *testing.T) {
-			pkgRootPath := filepath.Join("..", "..", "..", "..", "test", "packages", pkgName)
-
+			pkgRootPath := path.Join("..", "..", "..", "..", "test", "packages", pkgName)
 			err := ValidateFromPath(pkgRootPath)
 			if len(expectedErrors) == 0 {
 				assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -24,4 +24,4 @@ require (
 	golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 // indirect
 )
 
-replace github.com/xeipuuv/gojsonschema => github.com/jsoriano/gojsonschema v1.2.1-0.20220622174425-9a973da8ffff
+replace github.com/xeipuuv/gojsonschema => github.com/elastic/gojsonschema v1.2.1-0.20220622182608-92eeb544ec83

--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,5 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 // indirect
 )
+
+replace github.com/xeipuuv/gojsonschema => github.com/jsoriano/gojsonschema v1.2.1-0.20220622174425-9a973da8ffff

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,10 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-licenser v0.3.1 h1:RmRukU/JUmts+rpexAw0Fvt2ly7VVu6mw8z4HrEzObU=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
+github.com/elastic/gojsonschema v1.2.1-0.20220622182608-92eeb544ec83 h1:fZyZz7rACW3PCpQxSU58rtkbETGnJxlA/doo6De1QPU=
+github.com/elastic/gojsonschema v1.2.1-0.20220622182608-92eeb544ec83/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
-github.com/jsoriano/gojsonschema v1.2.1-0.20220622174425-9a973da8ffff h1:QIirn7aXrxREdYSMZMtFwhhh7PyMqg7HvzAVwn6RHgk=
-github.com/jsoriano/gojsonschema v1.2.1-0.20220622174425-9a973da8ffff/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/elastic/go-licenser v0.3.1 h1:RmRukU/JUmts+rpexAw0Fvt2ly7VVu6mw8z4HrE
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
+github.com/jsoriano/gojsonschema v1.2.1-0.20220622174425-9a973da8ffff h1:QIirn7aXrxREdYSMZMtFwhhh7PyMqg7HvzAVwn6RHgk=
+github.com/jsoriano/gojsonschema v1.2.1-0.20220622174425-9a973da8ffff/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -25,8 +27,6 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
-github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
-github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -7,6 +7,9 @@
     - description: Add setting to configure index mode for data streams
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/357
+    - description: Fix package validation on Windows
+      type: bugfix
+      link: https://github.com/elastic/package-spec/pull/358
 - version: 1.11.0
   changes:
     - description: Enable development resources for input packages


### PR DESCRIPTION
## What does this PR do?

Use `path` instead of `path/filepath` for operations on paths for files in `fs.FS` filesystems.

`fs.FS` uses `/` as path separator also in Windows, so operations with paths in these filesystems should be done with `path` instead of `filepath`.

Add a fork for `gojsonschema` with [a fix](https://github.com/xeipuuv/gojsonschema/compare/master...elastic:package-spec) for references on Windows using `fs.FS`.

A new testing stage is added for Windows to validate these changes.

## Why is it important?

To fix validation of packages in Windows.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/elastic-package/issues/860.
