### PR TITLE
Use fork of gojsonschema instead of replace

### DIFF
--- a/code/go/internal/validator/folder_item_spec.go
+++ b/code/go/internal/validator/folder_item_spec.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/xeipuuv/gojsonschema"
+	"github.com/elastic/gojsonschema"
 
 	ve "github.com/elastic/package-spec/code/go/internal/errors"
 	"github.com/elastic/package-spec/code/go/internal/spectypes"

--- a/code/go/internal/validator/semantic/format_checkers.go
+++ b/code/go/internal/validator/semantic/format_checkers.go
@@ -8,7 +8,7 @@ import (
 	"io/fs"
 	"path"
 
-	"github.com/xeipuuv/gojsonschema"
+	"github.com/elastic/gojsonschema"
 
 	"github.com/elastic/package-spec/code/go/internal/spectypes"
 )

--- a/code/go/internal/yamlschema/schema_loader.go
+++ b/code/go/internal/yamlschema/schema_loader.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonreference"
-	"github.com/xeipuuv/gojsonschema"
+	"github.com/elastic/gojsonschema"
 	"gopkg.in/yaml.v3"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/creasty/defaults v1.5.2
 	github.com/elastic/go-licenser v0.3.1
+	github.com/elastic/gojsonschema v1.2.1
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
-	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )
@@ -23,5 +23,3 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 // indirect
 )
-
-replace github.com/xeipuuv/gojsonschema => github.com/elastic/gojsonschema v1.2.1-0.20220622182608-92eeb544ec83

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-licenser v0.3.1 h1:RmRukU/JUmts+rpexAw0Fvt2ly7VVu6mw8z4HrEzObU=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
-github.com/elastic/gojsonschema v1.2.1-0.20220622182608-92eeb544ec83 h1:fZyZz7rACW3PCpQxSU58rtkbETGnJxlA/doo6De1QPU=
-github.com/elastic/gojsonschema v1.2.1-0.20220622182608-92eeb544ec83/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/elastic/gojsonschema v1.2.1 h1:cUMbgsz0wyEB4x7xf3zUEvUVDl6WCz2RKcQPul8OsQc=
+github.com/elastic/gojsonschema v1.2.1/go.mod h1:biw5eBS2Z4T02wjATMRSfecfjCmwaDPvuaqf844gLrg=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -2,11 +2,16 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom.
 ##
-- version: 1.12.1-next
+- version: 1.12.2-next
   changes:
   - description: Prepare for next version
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/362
+    link: https://github.com/elastic/package-spec/pull/364
+- version: 1.12.1
+  changes:
+  - description: Use fork of gojsonschema instead of replace
+    type: bugfix
+    link: https://github.com/elastic/package-spec/pull/364
 - version: 1.12.0
   changes:
     - description: Add setting to configure index mode for data streams


### PR DESCRIPTION
Replace is not leveraged on dependant projects. Use directly a fork
including the required changes.

Release 1.12.1 directly with this fix.