### PR TITLE
Add threat_intel package category

### DIFF
--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -4,7 +4,7 @@
 ##
 - version: 1.12.2-next
   changes:
-  - description: Add thread_intel category
+  - description: Add threat_intel category
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/366
 - version: 1.12.1

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -4,9 +4,9 @@
 ##
 - version: 1.12.2-next
   changes:
-  - description: Prepare for next version
+  - description: Add thread_intel category
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/364
+    link: https://github.com/elastic/package-spec/pull/365
 - version: 1.12.1
   changes:
   - description: Use fork of gojsonschema instead of replace

--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -6,7 +6,7 @@
   changes:
   - description: Add thread_intel category
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/365
+    link: https://github.com/elastic/package-spec/pull/366
 - version: 1.12.1
   changes:
   - description: Use fork of gojsonschema instead of replace

--- a/versions/1/integration/manifest.spec.yml
+++ b/versions/1/integration/manifest.spec.yml
@@ -32,6 +32,7 @@ spec:
           - productivity
           - security
           - support
+          - thread_intel
           - ticketing
           - version_control
           - web

--- a/versions/1/integration/manifest.spec.yml
+++ b/versions/1/integration/manifest.spec.yml
@@ -32,7 +32,7 @@ spec:
           - productivity
           - security
           - support
-          - thread_intel
+          - threat_intel
           - ticketing
           - version_control
           - web


### PR DESCRIPTION
## What does this PR do?

Add threat intel category.

## Why is it important?

Closes https://github.com/elastic/package-spec/issues/222

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Part of https://github.com/elastic/package-spec/issues/222.