### PR TITLE
Fix unmarshalling error of transform spec

### DIFF
--- a/versions/1/changelog.yml
+++ b/versions/1/changelog.yml
@@ -7,6 +7,9 @@
   - description: Prepare for next patch release
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/369
+  - description: Fix package build error when using transform
+    type: bugfix
+    link: https://github.com/elastic/package-spec/pull/373
 - version: 1.13.0
   changes:
   - description: Add threat_intel category

--- a/versions/1/integration/elasticsearch/spec.yml
+++ b/versions/1/integration/elasticsearch/spec.yml
@@ -29,8 +29,8 @@ spec:
           contentMediaType: "application/json"
           required: false
     - description: Folder containing Elasticsearch Transforms
-      # https://www.elastic.co/guide/en/elasticsearch/reference/current/transforms.html
       type: folder
       name: transform
       required: false
       $ref: "./transform/spec.yml"
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/transforms.html


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/elastic/package-spec/issues/372

- The comment line seems to throws off `yaml.Unmarshal`.

## Why is it important?

Cannot build package with transforms without this fix.

## Checklist

- [ ] ~~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~
- [x] I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).

## Related issues

- Closes #372 