### PR TITLE
Remove unneeded wrapping of prerelease tag checking error

### DIFF
--- a/code/go/internal/validator/semantic/validate_prerelease.go
+++ b/code/go/internal/validator/semantic/validate_prerelease.go
@@ -89,11 +89,9 @@ func validatePrereleaseTag(tag string) error {
 		}
 	}
 
-	return ve.ValidationErrors{
-		fmt.Errorf("prerelease tag (%s) should be one of [%s], or one of [%s] followed by numbers",
-			tag,
-			strings.Join(literalPrereleases, ", "),
-			strings.Join(numberedPrereleases, ", "),
-		),
-	}
+	return fmt.Errorf("prerelease tag (%s) should be one of [%s], or one of [%s] followed by numbers",
+		tag,
+		strings.Join(literalPrereleases, ", "),
+		strings.Join(numberedPrereleases, ", "),
+	)
 }


### PR DESCRIPTION
## What does this PR do?

This error is being wrapped with a validation error, but it shouldn't, this causes errors to be logged like this:
```
found 3 validation errors:
1. current manifest version doesn't have changelog entry
2. https://github.com/elastic/apm-server/: issue number in changelog link should be a positive number
3. found 1 validation error:
1. prerelease tag (SNAPSHOT-1658753810) should be one of [next, SNAPSHOT], or one of [beta, rc, preview] followed by numbers
```

## Why is it important?

Avoid confusion in logged errors.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~
- [ ] ~~I have added an entry in [`versions/N/changelog.yml`](https://github.com/elastic/package-spec/blob/main/versions/1/changelog.yml).~~
