### PR TITLE
Recover files used by docs builds

### DIFF
--- a/versions/1/integration/_dev/spec.yml
+++ b/versions/1/integration/_dev/spec.yml
@@ -1,0 +1,14 @@
+spec:
+  additionalContents: false
+  developmentFolder: true
+  contents:
+    - description: Folder containing resources related to building the package.
+      type: folder
+      name: build
+      required: false
+      $ref: "./build/spec.yml"
+    - description: Folder containing configuration related to deploying the package's integration service(s)
+      type: folder
+      name: deploy
+      required: false
+      $ref: "./deploy/spec.yml"

--- a/versions/1/integration/changelog.spec.yml
+++ b/versions/1/integration/changelog.spec.yml
@@ -1,0 +1,44 @@
+##
+## Describes the specification for the package's CHANGELOG file
+##
+spec:
+  # Everything under here follows JSON schema (https://json-schema.org/), written as YAML for readability
+  type: array
+  items:
+    type: object
+    additionalProperties: false
+    properties:
+      version:
+        description: Package version.
+        $ref: "./manifest.spec.yml#/definitions/version"
+      changes:
+        description: List of changes in package version.
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            description:
+              description: Description of change.
+              type: string
+              examples:
+              - "Fix broken template"
+            type:
+              description: Type of change.
+              type: string
+              enum:
+              - "breaking-change"
+              - "bugfix"
+              - "enhancement"
+            link:
+              description: Link to issue or PR describing change in detail.
+              type: string
+              examples:
+              - "https://github.com/elastic/integrations/pull/550"
+          required:
+          - description
+          - type
+          - link
+    required:
+    - version
+    - changes

--- a/versions/1/integration/data_stream/spec.yml
+++ b/versions/1/integration/data_stream/spec.yml
@@ -1,0 +1,80 @@
+spec:
+  additionalContents: false
+  totalContentsLimit: 500
+  contents:
+  - description: Folder containing a single data stream definition
+    type: folder
+    pattern: '^([a-z0-9]{2}|[a-z0-9][a-z0-9_]+[a-z0-9])$'
+    required: true
+    additionalContents: false
+    contents:
+    - description: A data stream's manifest file
+      type: file
+      contentMediaType: "application/x-yaml"
+      sizeLimit: 5MB
+      name: "manifest.yml"
+      required: true
+      $ref: "./manifest.spec.yml"
+    - description: Folder containing field definitions
+      type: folder
+      name: fields
+      required: true
+      $ref: "./fields/spec.yml"
+    - description: Folder containing agent-related definitions
+      type: folder
+      name: agent
+      required: false
+      additionalContents: false
+      $ref: "./agent/spec.yml"
+    - description: Folder containing Elasticsearch assets
+      type: folder
+      name: elasticsearch
+      additionalContents: false
+      contents:
+      - description: Folder containing Elasticsearch ILM Policy Definition
+        type: folder
+        name: ilm
+        additionalContents: false
+        contents:
+        - description: Supporting ILM policy definitions in YAML
+          type: file
+          pattern: '^.+\.yml$'
+          # TODO Determine if special handling of `---` is required (issue: https://github.com/elastic/package-spec/pull/54)
+          contentMediaType: "application/x-yaml; require-document-dashes=true"
+          required: false
+        - description: Supporting ILM policy definitions in JSON
+          type: file
+          pattern: '^.+\.json$'
+          contentMediaType: "application/json"
+          required: false
+      - description: Folder containing Elasticsearch Ingest Node pipeline definitions
+        type: folder
+        name: ingest_pipeline
+        additionalContents: false
+        contents:
+        - description: Supporting ingest pipeline definitions in YAML
+          type: file
+          pattern: '^.+\.yml$'
+          # TODO Determine if special handling of `---` is required (issue: https://github.com/elastic/package-spec/pull/54)
+          contentMediaType: "application/x-yaml; require-document-dashes=true"
+          required: false
+        - description: Supporting ingest pipeline definitions in JSON
+          type: file
+          pattern: '^.+\.json$'
+          contentMediaType: "application/json"
+          required: false
+    - description: Sample event file
+      type: file
+      name: "sample_event.json"
+      contentMediaType: "application/json"
+      required: false
+    - description: Folder containing testing related files and sub-folders
+      type: folder
+      name: "test"
+      required: false
+    - description: Folder containing development resources
+      type: folder
+      name: _dev
+      required: false
+      visibility: private
+      $ref: "./_dev/spec.yml"

--- a/versions/1/integration/docs/spec.yml
+++ b/versions/1/integration/docs/spec.yml
@@ -1,0 +1,13 @@
+  spec:
+    additionalContents: false
+    contents:
+    - description: Main README file
+      type: file
+      contentMediaType: "text/markdown"
+      name: "README.md"
+      required: true
+    - description: Other README files (can be used by policy templates)
+      type: file
+      contentMediaType: "text/markdown"
+      pattern: '^.+.md'
+      required: false

--- a/versions/1/integration/kibana/spec.yml
+++ b/versions/1/integration/kibana/spec.yml
@@ -1,0 +1,121 @@
+  spec:
+    additionalContents: false
+    contents:
+    - description: Folder containing Kibana dashboard assets
+      type: folder
+      name: dashboard
+      required: false
+      contents:
+      - description: A dashboard asset file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'
+        forbiddenPatterns:
+          - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden
+    - description: Folder containing Kibana visualization assets
+      type: folder
+      name: visualization
+      required: false
+      contents:
+      - description: A visualization asset file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'
+        forbiddenPatterns:
+          - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden
+    - description: Folder containing Kibana saved search assets
+      type: folder
+      name: search
+      required: false
+      contents:
+      - description: A saved search asset file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'
+        forbiddenPatterns:
+          - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden
+    - description: Folder containing Kibana map assets
+      type: folder
+      name: map
+      required: false
+      contents:
+      - description: A map asset file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'
+        forbiddenPatterns:
+          - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden
+    - description: Folder containing Kibana lens assets
+      type: folder
+      name: lens
+      required: false
+      contents:
+        - description: A lens asset file
+          type: file
+          contentMediaType: "application/json"
+          pattern: '^{PACKAGE_NAME}-.+\.json$'
+          forbiddenPatterns:
+            - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden
+    - description: Folder containing Kibana index pattern assets
+      type: folder
+      name: "index_pattern"
+      required: false
+      contents:
+      - description: An index pattern asset file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^.+\.json$'
+    - description: Folder containing rules
+      type: folder
+      name: "security_rule"
+      required: false
+      contents:
+      - description: An individual rule file for the detection engine
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^.+\.json$'
+    - description: Folder containing CSP rule templates
+      type: folder
+      name: "csp_rule_template"
+      required: false
+      contents:
+      - description: An individual CSP rule template file for the cloud security posture management solution
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^.+\.json$'
+    - description: Folder containing ML module assets
+      type: folder
+      name: ml_module
+      required: false
+      contents:
+        - description: An ML module asset file
+          type: file
+          contentMediaType: "application/json"
+          pattern: '^{PACKAGE_NAME}-.+\.json$'
+    - description: Folder containing Kibana tags
+      type: folder
+      name: tag
+      required: false
+      contents:
+      - description: A dashboard tag file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'
+    - description: Folder containing Osquery pack assets
+      type: folder
+      name: osquery_pack_asset
+      required: false
+      contents:
+      - description: An osquery pack asset file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'
+    - description: Folder containing Osquery saved queries
+      type: folder
+      name: osquery_saved_query
+      required: false
+      contents:
+      - description: An osquery saved query file
+        type: file
+        contentMediaType: "application/json"
+        pattern: '^{PACKAGE_NAME}-.+\.json$'

--- a/versions/1/integration/manifest.spec.yml
+++ b/versions/1/integration/manifest.spec.yml
@@ -1,0 +1,350 @@
+##
+## Describes the specification for the integration package's main manifest.yml file
+##
+spec:
+  # Everything under here follows JSON schema (https://json-schema.org/), written as YAML for readability
+  type: object
+  additionalProperties: false
+  definitions:
+    categories:
+      description: Categories to which this package belongs.
+      type: array
+      items:
+        type: string
+        enum:
+          - aws
+          - azure
+          - cloud
+          - config_management
+          - containers
+          - crm
+          - custom
+          - datastore
+          - elastic_stack
+          - google_cloud
+          - kubernetes
+          - languages
+          - message_queue
+          - monitoring
+          - network
+          - notification
+          - os_system
+          - productivity
+          - security
+          - support
+          - threat_intel
+          - ticketing
+          - version_control
+          - web
+        examples:
+          - web
+    conditions:
+      description: Conditions under which this package can be installed.
+      type: object
+      additionalProperties: false
+      properties:
+        elastic:
+          description: Elastic conditions
+          type: object
+          additionalProperties: false
+          properties:
+            subscription:
+              description: The subscription required for this package.
+              type: string
+              enum:
+              - basic
+              - gold
+              - platinum
+              - enterprise
+              default: basic
+              examples:
+              - basic
+        kibana:
+          description: Kibana conditions
+          type: object
+          additionalProperties: false
+          properties:
+            version:
+              type: string
+              description: Kibana versions compatible with this package.
+              examples:
+                - ">=7.9.0"
+    icons:
+      description: List of icons for by this package.
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          src:
+            description: Relative path to the icon's image file.
+            type: string
+            format: relative-path
+            examples:
+              - "/img/logo_apache.svg"
+          title:
+            description: Title of icon.
+            type: string
+            examples:
+              - "Apache Logo"
+          size:
+            description: Size of the icon.
+            type: string
+            examples:
+              - "32x32"
+          type:
+            description: MIME type of the icon image file.
+            type: string
+            examples:
+              - "image/svg+xml"
+          dark_mode:
+            description: Is this icon to be shown in dark mode?
+            type: boolean
+            default: false
+        required:
+          - src
+    screenshots:
+      description: List of screenshots of Kibana assets created by this package.
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          src:
+            description: Relative path to the screenshot's image file.
+            type: string
+            format: relative-path
+            examples:
+              - "/img/apache_httpd_server_status.png"
+          title:
+            description: Title of screenshot.
+            type: string
+            examples:
+              - "Apache HTTPD Server Status"
+          size:
+            description: Size of the screenshot.
+            type: string
+            examples:
+              - "1215x1199"
+          type:
+            description: MIME type of the screenshot image file.
+            type: string
+            examples:
+              - "image/png"
+        required:
+          - src
+          - title
+    source:
+      description: Information about the source of the package.
+      type: object
+      additionalProperties: false
+      properties:
+        license:
+          description: Identifier of the license of the package, as specified in https://spdx.org/licenses/.
+          type: string
+          enum:
+            - "Apache-2.0"
+            - "Elastic-2.0"
+          examples:
+            - "Elastic-2.0"
+    version:
+      description: Version of the package, following semantic versioning. It can include pre-release labels.
+      type: string
+      pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+      examples:
+        - "1.0.0"
+        - "1.0.0-beta1"
+        - "1.0.0-SNAPSHOT"
+        - "1.0.0-next"
+    owner:
+      type: object
+      additionalProperties: false
+      properties:
+        github:
+          description: GitHub repository name of package maintainer.
+          type: string
+          pattern: '^(([a-zA-Z0-9-]+)|([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+))$'
+      required:
+        - github
+  properties:
+    format_version:
+      description: The version of the package specification format used by this package.
+      $ref: "#/definitions/version"
+    name:
+      description: The name of the package.
+      type: string
+      pattern: '^[a-z0-9_]+$'
+      examples:
+      - apache
+    title:
+      description: The title of the package.
+      type: string
+      examples:
+      - Apache
+    description:
+      description: A longer description of the package.
+      type: string
+      examples:
+      - Apache Integration
+    version:
+      description: The version of the package.
+      $ref: "#/definitions/version"
+    source:
+      $ref: "#/definitions/source"
+    type:
+      description: The type of package.
+      type: string
+      enum:
+      - integration
+      examples:
+      - integration
+    release:
+      description: The stability of the package (deprecated, use prerelease tags in the version).
+      deprecated: true # See https://github.com/elastic/package-spec/issues/225
+      type: string
+      enum:
+      - experimental
+      - beta
+      - ga
+      default: ga
+      examples:
+      - experimental
+    categories:
+      $ref: "#/definitions/categories"
+    conditions:
+      $ref: "#/definitions/conditions"
+    policy_templates:
+      description: List of policy templates offered by this package.
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          name:
+            description: Name of policy template.
+            type: string
+            examples:
+              - apache
+          title:
+            description: Title of policy template.
+            type: string
+            examples:
+              - Apache logs and metrics
+          categories:
+            $ref: "#/definitions/categories"
+          description:
+            description: Longer description of policy template.
+            type: string
+            examples:
+              - Collect logs and metrics from Apache instances
+          data_streams:
+            description: List of data streams compatible with the policy template.
+            type: array
+            items:
+              type: string
+              description: Data stream name
+              format: data-stream-name
+              examples:
+                - ec2_logs
+                - spamfirewall
+                - access
+          inputs:
+            description: List of inputs supported by policy template.
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              properties:
+                type:
+                  description: Type of input.
+                  type: string
+                title:
+                  description: Title of input.
+                  type: string
+                  examples:
+                    - Collect logs from Apache instances
+                description:
+                  description: Longer description of input.
+                  type: string
+                  examples:
+                    - Collecting Apache access and error logs
+                template_path:
+                  description: Path of the config template for the input.
+                  type: string
+                  examples:
+                    - ./agent/input/template.yml.hbs
+                input_group:
+                  description: Name of the input group
+                  type: string
+                  enum:
+                    - logs
+                    - metrics
+                multi:
+                  description: Can input be defined multiple times
+                  type: boolean
+                  default: false
+                vars:
+                  $ref: "./data_stream/manifest.spec.yml#/definitions/vars"
+              required:
+                - type
+                - title
+                - description
+          multiple:
+            type: boolean
+          icons:
+            $ref: "#/definitions/icons"
+          screenshots:
+            $ref: "#/definitions/screenshots"
+          vars:
+            $ref: "./data_stream/manifest.spec.yml#/definitions/vars"
+        required:
+          - name
+          - title
+          - description
+    icons:
+      $ref: "#/definitions/icons"
+    screenshots:
+      $ref: "#/definitions/screenshots"
+    vars:
+      $ref: "./data_stream/manifest.spec.yml#/definitions/vars"
+    owner:
+      $ref: "#/definitions/owner"
+    elasticsearch:
+      description: Elasticsearch requirements
+      type: object
+      additionalProperties: false
+      properties:
+        privileges:
+          description: Elasticsearch privilege requirements
+          type: object
+          additionalProperties: false
+          properties:
+            cluster:
+              # Available cluster privileges are available at https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-privileges.html#privileges-list-cluster
+              description: Elasticsearch cluster privilege requirements
+              type: array
+              items:
+                type: string
+  required:
+  - format_version
+  - name
+  - title
+  - description
+  - version
+  - type
+  - owner
+
+versions:
+  - before: 2.0.0
+    patch:
+      - op: add
+        path: "/properties/license"
+        value:
+          description: The license under which the package is being released (deprecated, use subscription instead).
+          deprecated: true # See https://github.com/elastic/package-spec/issues/298.
+          type: string
+          enum:
+          - basic
+          default: basic
+          examples:
+          - basic

--- a/versions/1/integration/spec.yml
+++ b/versions/1/integration/spec.yml
@@ -1,0 +1,68 @@
+##
+## Entrypoint of "integration packages" specification.
+##
+## Describes the folders and files that make up a package.
+##
+spec:
+  additionalContents: true
+  totalContentsLimit: 65535
+  totalSizeLimit: 250MB
+  sizeLimit: 150MB
+  configurationSizeLimit: 5MB
+  relativePathSizeLimit: 3MB
+  fieldsPerDataStreamLimit: 2048
+  contents:
+  - description: The main package manifest file
+    type: file
+    contentMediaType: "application/x-yaml"
+    sizeLimit: 5MB
+    name: "manifest.yml"
+    required: true
+    $ref: "./manifest.spec.yml"
+  - description: The package's CHANGELOG file
+    type: file
+    contentMediaType: "application/x-yaml"
+    name: "changelog.yml"
+    required: true
+    $ref: "./changelog.spec.yml"
+  - description: The package's NOTICE file
+    type: file
+    contentMediaType: "text/plain"
+    name: "NOTICE.txt"
+    required: false
+  - description: The package's license file
+    type: file
+    contentMediaType: "text/plain"
+    name: "LICENSE.txt"
+    required: false
+  - description: Folder containing data stream definitions
+    type: folder
+    name: data_stream
+    required: false
+    $ref: "./data_stream/spec.yml"
+  - description: Folder containing documentation for the package
+    type: folder
+    name: docs
+    required: true
+    $ref: "./docs/spec.yml"
+  - description: Folder containing agent-related definitions
+    type: folder
+    name: agent
+    required: false
+    $ref: "./agent/spec.yml"
+  - description: Folder containing Kibana assets used by the package
+    type: folder
+    name: kibana
+    required: false
+    $ref: "./kibana/spec.yml"
+  - description: Folder containing development resources
+    type: folder
+    name: _dev
+    required: false
+    visibility: private
+    $ref: "./_dev/spec.yml"
+  - description: Folder containing Elasticsearch assets used by the package
+    type: folder
+    name: elasticsearch
+    required: false
+    $ref: "./elasticsearch/spec.yml"


### PR DESCRIPTION
Workaround to avoid breaking the docs builds till we find a better solution (like #400).

It recovers the files references by docs builds.