### PR TITLE
adjust fields name pattern

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -17,7 +17,7 @@
     link: https://github.com/elastic/package-spec/pull/398
   - description: Adjust field name pattern to support '/'.
     type: enhancement
-    link: https://github.com/elastic/package-spec/issues/331
+    link: https://github.com/elastic/package-spec/issues/402
 - version: 1.16.0
   changes:
   - description: New version validation. Internal changes to start preparing major version 2.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -15,6 +15,9 @@
   - description: Prepare for next patch release
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/398
+  - description: Adjust field name pattern to support '/'.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/issues/331
 - version: 1.16.0
   changes:
   - description: New version validation. Internal changes to start preparing major version 2.

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -13,7 +13,7 @@ spec:
           Name of field. Names containing dots are automatically split into
           sub-fields.
         type: string
-        pattern: '^[\-*_@A-Za-z0-9]+(\.[\-*_@A-Za-z0-9]+)*$'
+        pattern: '^[\-*_\/@A-Za-z0-9]+(\.[\-*_\/@A-Za-z0-9]+)*$'
       type:
         description: Datatype of field
         type: string

--- a/test/packages/good/data_stream/foo/fields/some_fields.yml
+++ b/test/packages/good/data_stream/foo/fields/some_fields.yml
@@ -49,3 +49,7 @@
   type: keyword
 - name: name-with-dash
   type: keyword
+- name: a/b
+  type: keyword
+- name: a/b.c/d
+  type: keyword


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

Add missing character `/` to fields name patter of the fields spec.

we already have some fields with `/` , like k8s `labels.*`, example - https://github.com/elastic/integrations/blob/main/packages/kubernetes/data_stream/state_container/sample_event.json#L36-L45, likely `annotations.*` fields as well. I think it was just never added to `fields.yml` with `/` , as those fields are defined with wildcard:
```
- name: labels.*
  type: object
  object_type: keyword
```
## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
