### PR TITLE
Add map as another reference type to check to show warnings

### DIFF
--- a/code/go/internal/validator/semantic/validate_visualizations_used_by_value.go
+++ b/code/go/internal/validator/semantic/validate_visualizations_used_by_value.go
@@ -57,10 +57,12 @@ func ValidateVisualizationsUsedByValue(fsys fspath.FS) ve.ValidationErrors {
 			for _, ref := range references[1:] {
 				s = fmt.Sprintf("%s, %s (%s)", s, ref.ID, ref.Type)
 			}
+
+			message := fmt.Sprintf("Warning: references found in dashboard %s: %s", filePath, s)
 			if warningsAsErrors {
-				errs = append(errs, errors.Errorf("Warning: references found in dashboard %s: %s", filePath, s))
+				errs = append(errs, errors.New(message))
 			} else {
-				log.Printf("Warning: references found in dashboard %s: %s", filePath, s)
+				log.Printf(message)
 			}
 
 		}
@@ -82,7 +84,7 @@ func anyReference(val interface{}) ([]reference, error) {
 	var references []reference
 	for _, reference := range allReferences {
 		switch reference.Type {
-		case "lens", "visualization":
+		case "lens", "visualization", "map":
 			references = append(references, reference)
 		}
 	}

--- a/code/go/internal/validator/semantic/validate_visualizations_used_by_value_test.go
+++ b/code/go/internal/validator/semantic/validate_visualizations_used_by_value_test.go
@@ -77,18 +77,34 @@ func TestAnyReference(t *testing.T) {
 				},
 				map[string]interface{}{
 					"id":   "4",
-					"name": "panel_1",
+					"name": "panel_2",
 					"type": "map",
 				},
 				map[string]interface{}{
 					"id":   "42",
-					"name": "panel_1",
+					"name": "panel_3",
 					"type": "index-pattern",
+				},
+				map[string]interface{}{
+					"id":   "44",
+					"name": "panel_4",
+					"type": "search",
+				},
+				map[string]interface{}{
+					"id":   "45",
+					"name": "panel_5",
+					"type": "tag",
+				},
+				map[string]interface{}{
+					"id":   "50",
+					"name": "panel_6",
+					"type": "dashboard",
 				},
 			},
 			[]reference{
 				{"12345", "panel_0", "visualization"},
 				{"9000", "panel_1", "lens"},
+				{"4", "panel_2", "map"},
 			},
 		},
 		{

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -12,9 +12,9 @@
     link: https://github.com/elastic/package-spec/issues/331
 - version: 1.18.1-next
   changes:
-  - description: Prepare for next patch release
+  - description: Add map as another reference type to check to show warnings
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/411
+    link: https://github.com/elastic/package-spec/pull/414
 - version: 1.18.0
   changes:
   - description: Update Go runtime to 1.19.1.


### PR DESCRIPTION
## What does this PR do?

This PR updates validation rule that shows warnings in case of reference types to include "map" as another element to be taken into account according to https://github.com/elastic/package-spec/issues/316#issuecomment-1245377202.

Follow up of this PR https://github.com/elastic/package-spec/pull/389


## Checklist

~~- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Relates #316 
