### PR TITLE
Document and validate object_type

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -18,6 +18,9 @@
   - description: Add map as another reference type to check to show warnings
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/414
+  - description: Document and validate `object_type` and `object_type_mapping_type`.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/417
 - version: 1.18.0
   changes:
   - description: Update Go runtime to 1.19.1.

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -14,6 +14,7 @@ spec:
           sub-fields.
         type: string
         pattern: '^[\-*_\/@A-Za-z0-9]+(\.[\-*_\/@A-Za-z0-9]+)*$'
+
       type:
         description: Datatype of field
         type: string
@@ -234,8 +235,43 @@ spec:
 
       object_type:
         description: >
-          Required for `type: array` to specify the data type in the array.
+          Type of the members of the object when `type: object` is used. In
+          these cases a dynamic template is created so direct subobjects of
+          this field have the type indicated.
+          When `object_type_mapping_type` is also used, the dynamic mapping is
+          only applied to values that have the given type, as detected by the
+          JSON parser.
         type: string
+        enum:
+          - boolean
+          - byte
+          - double
+          - float
+          - histogram
+          - keyword
+          - long
+          - object
+          - short
+          - text
+
+      object_type_mapping_type:
+        description: >
+          Type that members of a field of with `type: object` must have in the
+          source document.
+          This type corresponds to the data type detected by the JSON parser,
+          and is translated to the `match_mapping_type` parameter of
+          Elasticsearch dynamic templates.
+        type: string
+        enum:
+          - '*'
+          - array
+          - double
+          - 'false'
+          - long
+          - 'null'
+          - object
+          - string
+          - 'true'
 
       path:
         description: >


### PR DESCRIPTION
Document and validate the accepted values for `object_type` and `object_type_mapping_type`.

Adding the list of accepted values could be a breaking change, but this is not heavily used, and when used, it is only with a reduced subset of the values accepted in this PR. I could apply this only for 2.0.0 if this is a concern.

Implemented in Kibana in https://github.com/elastic/kibana/pull/137772.

Reference to the use in the `array` type removed because of https://github.com/elastic/package-spec/pull/412.

Fixes https://github.com/elastic/package-spec/issues/415
Fixes https://github.com/elastic/package-spec/issues/416
