### PR TITLE
Fix go import paths for v2

### DIFF
--- a/code/go/internal/loader/spec.go
+++ b/code/go/internal/loader/spec.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
-	"github.com/elastic/package-spec/code/go/internal/specschema"
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
-	"github.com/elastic/package-spec/code/go/internal/yamlschema"
+	"github.com/elastic/package-spec/v2/code/go/internal/specschema"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
+	"github.com/elastic/package-spec/v2/code/go/internal/yamlschema"
 )
 
 // LoadSpec loads a package specification for the given version and type.

--- a/code/go/internal/pkgpath/files.go
+++ b/code/go/internal/pkgpath/files.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 // File represents a file in the package.

--- a/code/go/internal/spec_test.go
+++ b/code/go/internal/spec_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 
-	spec "github.com/elastic/package-spec"
-	"github.com/elastic/package-spec/code/go/internal/loader"
+	spec "github.com/elastic/package-spec/v2"
+	"github.com/elastic/package-spec/v2/code/go/internal/loader"
 )
 
 func TestLoadAllBundledVersions(t *testing.T) {

--- a/code/go/internal/specschema/folder_item_spec.go
+++ b/code/go/internal/specschema/folder_item_spec.go
@@ -11,8 +11,8 @@ import (
 	"github.com/creasty/defaults"
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
 )
 
 const (

--- a/code/go/internal/specschema/folder_spec.go
+++ b/code/go/internal/specschema/folder_spec.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
 )
 
 // FolderSpecLoader loads specs from directories.

--- a/code/go/internal/specschema/load_test.go
+++ b/code/go/internal/specschema/load_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
-	"github.com/elastic/package-spec/code/go/internal/yamlschema"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
+	"github.com/elastic/package-spec/v2/code/go/internal/yamlschema"
 )
 
 func TestLoadFolderSpec(t *testing.T) {

--- a/code/go/internal/spectypes/item.go
+++ b/code/go/internal/spectypes/item.go
@@ -7,7 +7,7 @@ package spectypes
 import (
 	"io/fs"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 )
 
 const (

--- a/code/go/internal/spectypes/schema.go
+++ b/code/go/internal/spectypes/schema.go
@@ -8,7 +8,7 @@ import (
 	"io/fs"
 
 	"github.com/Masterminds/semver/v3"
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 )
 
 // FileSchema defines the expected schema for a file.

--- a/code/go/internal/validator/common/helpers.go
+++ b/code/go/internal/validator/common/helpers.go
@@ -10,7 +10,7 @@ import (
 )
 
 // EnvVarWarningsAsErrors is the environment variable name used to enable warnings as errors
-// this meachinsm will be removed once structured errors are supported https://github.com/elastic/package-spec/v2/issues/342
+// this meachinsm will be removed once structured errors are supported https://github.com/elastic/package-spec/issues/342
 const EnvVarWarningsAsErrors = "PACKAGE_SPEC_WARNINGS_AS_ERRORS"
 
 // IsDefinedWarningsAsErrors checks whether or not warnings should be considered as errors,

--- a/code/go/internal/validator/common/helpers.go
+++ b/code/go/internal/validator/common/helpers.go
@@ -10,7 +10,7 @@ import (
 )
 
 // EnvVarWarningsAsErrors is the environment variable name used to enable warnings as errors
-// this meachinsm will be removed once structured errors are supported https://github.com/elastic/package-spec/issues/342
+// this meachinsm will be removed once structured errors are supported https://github.com/elastic/package-spec/v2/issues/342
 const EnvVarWarningsAsErrors = "PACKAGE_SPEC_WARNINGS_AS_ERRORS"
 
 // IsDefinedWarningsAsErrors checks whether or not warnings should be considered as errors,

--- a/code/go/internal/validator/content.go
+++ b/code/go/internal/validator/content.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
 )
 
 func validateContentType(fsys fs.FS, path string, contentType spectypes.ContentType) error {

--- a/code/go/internal/validator/folder_item_spec.go
+++ b/code/go/internal/validator/folder_item_spec.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
 )
 
 func matchingFileExists(spec spectypes.ItemSpec, files []fs.DirEntry) (bool, error) {

--- a/code/go/internal/validator/folder_spec.go
+++ b/code/go/internal/validator/folder_spec.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
-	"github.com/elastic/package-spec/code/go/internal/validator/common"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
+	"github.com/elastic/package-spec/v2/code/go/internal/validator/common"
 )
 
 type validator struct {

--- a/code/go/internal/validator/semantic/types.go
+++ b/code/go/internal/validator/semantic/types.go
@@ -13,8 +13,8 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 const dataStreamDir = "data_stream"

--- a/code/go/internal/validator/semantic/validate_changelog_links.go
+++ b/code/go/internal/validator/semantic/validate_changelog_links.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 var errGithubIssue = errors.New("issue number in changelog link should be a positive number")

--- a/code/go/internal/validator/semantic/validate_dimensions.go
+++ b/code/go/internal/validator/semantic/validate_dimensions.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 // ValidateDimensionFields verifies if dimension fields are of one of the expected types.

--- a/code/go/internal/validator/semantic/validate_field_groups.go
+++ b/code/go/internal/validator/semantic/validate_field_groups.go
@@ -7,8 +7,8 @@ package semantic
 import (
 	"fmt"
 
-	"github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 // ValidateFieldGroups verifies if field groups don't have units and metric types defined.

--- a/code/go/internal/validator/semantic/validate_field_groups_test.go
+++ b/code/go/internal/validator/semantic/validate_field_groups_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 func TestValidateFieldGroups_Good(t *testing.T) {

--- a/code/go/internal/validator/semantic/validate_fields_limits.go
+++ b/code/go/internal/validator/semantic/validate_fields_limits.go
@@ -7,8 +7,8 @@ package semantic
 import (
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 // ValidateFieldsLimits verifies limits on fields.

--- a/code/go/internal/validator/semantic/validate_ilmpolicypresent.go
+++ b/code/go/internal/validator/semantic/validate_ilmpolicypresent.go
@@ -12,8 +12,8 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 // ValidateILMPolicyPresent produces an error if the indicated ILM policy

--- a/code/go/internal/validator/semantic/validate_kibana_matching_object_ids.go
+++ b/code/go/internal/validator/semantic/validate_kibana_matching_object_ids.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
-	"github.com/elastic/package-spec/code/go/internal/pkgpath"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/pkgpath"
 )
 
 // ValidateKibanaObjectIDs returns validation errors if there are any Kibana

--- a/code/go/internal/validator/semantic/validate_kibana_no_dangling_object_ids.go
+++ b/code/go/internal/validator/semantic/validate_kibana_no_dangling_object_ids.go
@@ -4,7 +4,7 @@
 
 package semantic
 
-import "github.com/elastic/package-spec/code/go/internal/errors"
+import "github.com/elastic/package-spec/v2/code/go/internal/errors"
 
 // ValidateKibanaNoDanglingObjectIDs returns validation errors if there are any
 // dangling references to Kibana objects in any Kibana object files. That is, it

--- a/code/go/internal/validator/semantic/validate_prerelease.go
+++ b/code/go/internal/validator/semantic/validate_prerelease.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 var (

--- a/code/go/internal/validator/semantic/validate_required_fields.go
+++ b/code/go/internal/validator/semantic/validate_required_fields.go
@@ -7,8 +7,8 @@ package semantic
 import (
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 // ValidateRequiredFields validates that required fields are present and have the expected

--- a/code/go/internal/validator/semantic/validate_unique_fields.go
+++ b/code/go/internal/validator/semantic/validate_unique_fields.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 // ValidateUniqueFields verifies that any field is defined only once on each data stream.

--- a/code/go/internal/validator/semantic/validate_version_integrity.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
-	"github.com/elastic/package-spec/code/go/internal/pkgpath"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/pkgpath"
 )
 
 // ValidateVersionIntegrity returns validation errors if the version defined in manifest isn't referenced in the latest

--- a/code/go/internal/validator/semantic/validate_version_integrity_test.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 )
 
 func TestValidateGithubLink(t *testing.T) {

--- a/code/go/internal/validator/semantic/validate_visualizations_used_by_value.go
+++ b/code/go/internal/validator/semantic/validate_visualizations_used_by_value.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
-	"github.com/elastic/package-spec/code/go/internal/pkgpath"
-	"github.com/elastic/package-spec/code/go/internal/validator/common"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/pkgpath"
+	"github.com/elastic/package-spec/v2/code/go/internal/validator/common"
 )
 
 type reference struct {

--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -11,12 +11,12 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 
-	spec "github.com/elastic/package-spec"
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/fspath"
-	"github.com/elastic/package-spec/code/go/internal/loader"
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
-	"github.com/elastic/package-spec/code/go/internal/validator/semantic"
+	spec "github.com/elastic/package-spec/v2"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/loader"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
+	"github.com/elastic/package-spec/v2/code/go/internal/validator/semantic"
 )
 
 // Spec represents a package specification

--- a/code/go/internal/validator/spec_test.go
+++ b/code/go/internal/validator/spec_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/package-spec/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 )
 
 func TestNewSpec(t *testing.T) {

--- a/code/go/internal/yamlschema/formatcheckers.go
+++ b/code/go/internal/yamlschema/formatcheckers.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/elastic/gojsonschema"
 
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
 )
 
 const (

--- a/code/go/internal/yamlschema/loader.go
+++ b/code/go/internal/yamlschema/loader.go
@@ -15,8 +15,8 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
-	ve "github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
 )
 
 type FileSchemaLoader struct{}

--- a/code/go/pkg/validator/errors.go
+++ b/code/go/pkg/validator/errors.go
@@ -5,7 +5,7 @@
 package validator
 
 import (
-	"github.com/elastic/package-spec/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/errors"
 )
 
 // ValidationErrors is an Error that contains a iterable collection of validation error messages.

--- a/code/go/pkg/validator/limits_test.go
+++ b/code/go/pkg/validator/limits_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/package-spec/code/go/internal/spectypes"
+	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
 )
 
 func TestLimitsValidation(t *testing.T) {

--- a/code/go/pkg/validator/validator.go
+++ b/code/go/pkg/validator/validator.go
@@ -11,7 +11,7 @@ import (
 	"io/fs"
 	"os"
 
-	"github.com/elastic/package-spec/code/go/internal/validator"
+	"github.com/elastic/package-spec/v2/code/go/internal/validator"
 )
 
 // ValidateFromPath validates a package located at the given path against the

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/elastic/package-spec/code/go/internal/errors"
-	"github.com/elastic/package-spec/code/go/internal/validator/common"
+	"github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/validator/common"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elastic/package-spec
+module github.com/elastic/package-spec/v2
 
 go 1.19
 

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,6 +2,17 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
+- version: 2.0.0-rc2
+  changes:
+  - description: Add map as another reference type to check to show warnings
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/414
+  - description: Document and validate `object_type` and `object_type_mapping_type`.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/417
+  - description: Fix import paths for Go code
+    type: bugfix
+    link: https://github.com/elastic/package-spec/issues/423
 - version: 2.0.0-rc1
   changes:
   - description: Enable validation of duplicated fields.
@@ -19,14 +30,6 @@
   - description: Stricter validation of field definitions.
     type: breaking-change
     link: https://github.com/elastic/package-spec/pull/420
-- version: 1.18.1-next
-  changes:
-  - description: Add map as another reference type to check to show warnings
-    type: enhancement
-    link: https://github.com/elastic/package-spec/pull/414
-  - description: Document and validate `object_type` and `object_type_mapping_type`.
-    type: enhancement
-    link: https://github.com/elastic/package-spec/pull/417
 - version: 1.18.0
   changes:
   - description: Update Go runtime to 1.19.1.


### PR DESCRIPTION
## What does this PR do?

Updates go code to use `github.com/elastic/package-spec/v2` as import path, and releases `v2.0.0-rc2` including the changes that were planned for 1.18.1.

## Why is it important?

Package Spec is imported in several go projects, and go has strict rules for versioning and import paths.