### PR TITLE
Run sematic validation also when schema validation fails

### DIFF
--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -59,13 +59,12 @@ func (s Spec) ValidatePackage(pkg Package) ve.ValidationErrors {
 
 	// Syntactic validations
 	validator := newValidator(rootSpec, &pkg)
-	errs = validator.Validate()
-	if len(errs) != 0 {
-		return errs
-	}
+	errs = append(errs, validator.Validate()...)
 
 	// Semantic validations
-	return s.rules(rootSpec).validate(&pkg)
+	errs = append(errs, s.rules(rootSpec).validate(&pkg)...)
+
+	return errs
 }
 
 func (s Spec) rules(rootSpec spectypes.ItemSpec) validationRules {

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -4,9 +4,12 @@
 ##
 - version: 2.0.0-next
   changes:
-  - description: Add setting to configure the source mode of a data stream
+  - description: Add setting to configure the source mode of a data stream.
     type: enhancement
     link: https://github.com/elastic/package-spec/issues/340
+  - description: Semnatic validation is also executed when shema validation fails.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/428
 - version: 2.0.0-rc2
   changes:
   - description: Add map as another reference type to check to show warnings

--- a/test/packages/bad_additional_content/changelog.yml
+++ b/test/packages/bad_additional_content/changelog.yml
@@ -8,4 +8,4 @@
   changes:
     - description: Initial draft of the package
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/0 # FIXME Replace with the real PR link
+      link: https://github.com/elastic/integrations/pull/193

--- a/test/packages/bad_deploy_variants/data_stream/foo/fields/base_fields.yml
+++ b/test/packages/bad_deploy_variants/data_stream/foo/fields/base_fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: data_stream.type
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/test/packages/docs_extra_files/data_stream/pe/fields/base_fields.yml
+++ b/test/packages/docs_extra_files/data_stream/pe/fields/base_fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: data_stream.type
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/test/packages/input_groups_bad_data_stream/changelog.yml
+++ b/test/packages/input_groups_bad_data_stream/changelog.yml
@@ -2,4 +2,4 @@
   changes:
     - description: initial release
       type: enhancement
-      link: https://github.com/elastic/package-spec/pull/0
+      link: https://github.com/elastic/package-spec/pull/143

--- a/test/packages/input_groups_bad_data_stream/data_stream/dynamodb/fields/base_fields.yml
+++ b/test/packages/input_groups_bad_data_stream/data_stream/dynamodb/fields/base_fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: data_stream.type
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/test/packages/input_groups_bad_data_stream/data_stream/ec2_logs/fields/base_fields.yml
+++ b/test/packages/input_groups_bad_data_stream/data_stream/ec2_logs/fields/base_fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: data_stream.type
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/test/packages/input_groups_bad_data_stream/data_stream/ec2_metrics/fields/base_fields.yml
+++ b/test/packages/input_groups_bad_data_stream/data_stream/ec2_metrics/fields/base_fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: data_stream.type
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/test/packages/missing_image_files/data_stream/pe/fields/base_fields.yml
+++ b/test/packages/missing_image_files/data_stream/pe/fields/base_fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: data_stream.type
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/test/packages/missing_pipeline_dashes/data_stream/foo/fields/base_fields.yml
+++ b/test/packages/missing_pipeline_dashes/data_stream/foo/fields/base_fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: data_stream.type
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/test/packages/wrong_kibana_filename/data_stream/foo/fields/base_fields.yml
+++ b/test/packages/wrong_kibana_filename/data_stream/foo/fields/base_fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: data_stream.type
+  external: ecs
+- name: "@timestamp"
+  external: ecs


### PR DESCRIPTION
## What does this PR do?

It always run sematic validation, even when schema validation fails.

## Why is it important?

It gives earlier feedback to package developers, as they can see semantic validation failures also before solving other schema issues.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).
