### PR TITLE
Add support for system tests in input packages

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-//go:embed spec spec/integration/_dev spec/integration/data_stream/_dev spec/input
+//go:embed spec spec/integration/_dev spec/integration/data_stream/_dev spec/input/_dev
 var content embed.FS
 
 // FS returns an io/fs.FS for accessing the "package-spec/spec" contents.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,6 +7,9 @@
   - description: Prepare for next version
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/442
+  - description: Add definition of system tests for input packages
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/443
 - version: 2.1.0
   changes:
   - description: Allowing multiple services included as part of custom-agent-deployer

--- a/spec/input/_dev/spec.yml
+++ b/spec/input/_dev/spec.yml
@@ -7,12 +7,12 @@ spec:
       name: build
       required: false
       $ref: "../../integration/_dev/build/spec.yml"
-    - description: Folder containing configuration related to deploying the package's integration service(s)
+    - description: Folder containing configuration related to deploying the package's service(s) required for testing scenarios.
       type: folder
       name: deploy
       required: false
       $ref: "../../integration/_dev/deploy/spec.yml"
-    - description: Folder containing test resources
+    - description: Folder containing test resources.
       type: folder
       name: test
       required: false

--- a/spec/input/_dev/spec.yml
+++ b/spec/input/_dev/spec.yml
@@ -1,0 +1,19 @@
+spec:
+  additionalContents: false
+  developmentFolder: true
+  contents:
+    - description: Folder containing resources related to building the package.
+      type: folder
+      name: build
+      required: false
+      $ref: "../../integration/_dev/build/spec.yml"
+    - description: Folder containing configuration related to deploying the package's integration service(s)
+      type: folder
+      name: deploy
+      required: false
+      $ref: "../../integration/_dev/deploy/spec.yml"
+    - description: Folder containing test resources
+      type: folder
+      name: test
+      required: false
+      $ref: "./test/spec.yml"

--- a/spec/input/_dev/test/spec.yml
+++ b/spec/input/_dev/test/spec.yml
@@ -1,0 +1,8 @@
+spec:
+  additionalContents: false
+  contents:
+    - description: Folder containing system tests
+      type: folder
+      name: system
+      required: false
+      $ref: "../../../integration/data_stream/_dev/test/system/spec.yml"

--- a/spec/input/spec.yml
+++ b/spec/input/spec.yml
@@ -51,4 +51,4 @@ spec:
     name: _dev
     required: false
     visibility: private
-    $ref: "../integration/_dev/spec.yml"
+    $ref: "./_dev/spec.yml"

--- a/spec/integration/_dev/spec.yml
+++ b/spec/integration/_dev/spec.yml
@@ -7,7 +7,7 @@ spec:
       name: build
       required: false
       $ref: "./build/spec.yml"
-    - description: Folder containing configuration related to deploying the package's integration service(s)
+    - description: Folder containing configuration related to deploying the package's service(s) required for testing scenarios.
       type: folder
       name: deploy
       required: false

--- a/test/packages/sql_input/_dev/test/system/test-default-config.yml
+++ b/test/packages/sql_input/_dev/test/system/test-default-config.yml
@@ -1,0 +1,2 @@
+wait_for_data_timeout: 10m
+vars: ~

--- a/test/packages/sql_input/manifest.yml
+++ b/test/packages/sql_input/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 1.0.0
+format_version: 2.0.0
 name: sql_input
 title: SQL Input
 description: >-


### PR DESCRIPTION
## What does this PR do?

Allow to define system tests in input packages.

## Why is it important?

Package developers are starting to implement input packages and there is no supported way to automate tests for them.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Part of https://github.com/elastic/package-spec/issues/361.
