### PR TITLE
Allow to include a sample event in input packages

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,6 +10,9 @@
   - description: Add definition of system tests for input packages
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/443
+  - description: Allow to include a sample event in input packages
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/444
 - version: 2.1.0
   changes:
   - description: Allowing multiple services included as part of custom-agent-deployer

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -12,7 +12,7 @@
     link: https://github.com/elastic/package-spec/pull/443
   - description: Allow to include a sample event in input packages
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/444
+    link: https://github.com/elastic/package-spec/pull/447
 - version: 2.1.0
   changes:
   - description: Allowing multiple services included as part of custom-agent-deployer

--- a/spec/input/spec.yml
+++ b/spec/input/spec.yml
@@ -46,6 +46,11 @@ spec:
     name: fields
     required: true
     $ref: "../integration/data_stream/fields/spec.yml"
+  - description: Sample event file
+    type: file
+    name: "sample_event.json"
+    contentMediaType: "application/json"
+    required: false
   - description: Folder containing development resources
     type: folder
     name: _dev

--- a/test/packages/sql_input/sample_event.json
+++ b/test/packages/sql_input/sample_event.json
@@ -1,0 +1,63 @@
+{
+    "@timestamp": "2022-11-16T19:00:58.919Z",
+    "agent": {
+        "ephemeral_id": "1f2789fe-4041-4b4d-aac2-076a34c5d24f",
+        "id": "47bdbac3-731d-4b11-9af6-06fba253dba8",
+        "name": "docker-fleet-agent",
+        "type": "metricbeat",
+        "version": "8.5.0"
+    },
+    "data_stream": {
+        "dataset": "sql_input.sql_query",
+        "namespace": "ep",
+        "type": "metrics"
+    },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "elastic_agent": {
+        "id": "47bdbac3-731d-4b11-9af6-06fba253dba8",
+        "snapshot": true,
+        "version": "8.5.0"
+    },
+    "event": {
+        "dataset": "sql_input.sql_query",
+        "duration": 1326395,
+        "module": "sql"
+    },
+    "host": {
+        "architecture": "x86_64",
+        "containerized": false,
+        "hostname": "docker-fleet-agent",
+        "id": "0addaca3101a43f4a52be882837fb33d",
+        "ip": [
+            "192.168.192.7"
+        ],
+        "mac": [
+            "02-42-C0-A8-C0-07"
+        ],
+        "name": "docker-fleet-agent",
+        "os": {
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.15.0-50-generic",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "20.04.5 LTS (Focal Fossa)"
+        }
+    },
+    "metricset": {
+        "name": "query",
+        "period": 10000
+    },
+    "service": {
+        "address": "elastic-package-service-sql_input-1:3306",
+        "type": "sql"
+    },
+    "sql": {
+        "driver": "mysql",
+        "metrics": {},
+        "query": "SHOW GLOBAL STATUS LIKE 'Innodb_system%'"
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Allow to include a sample event in input packages. Fixes https://github.com/elastic/package-spec/issues/445.

## Why is it important?

See https://github.com/elastic/package-spec/issues/445.

It will be possible to generate sample files for input packages once https://github.com/elastic/elastic-package/pull/1041 is merged.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes https://github.com/elastic/package-spec/issues/445.