### PR TITLE
depracting csp_template fields

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,6 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
+- version: 1.5.0
+  changes:
+  - description: Deprecate the `muted` and `enabled` properties of the `csp-rule-template` asset.
+    type: breaking-change
+    link: TODO - fill in
 - version: 2.3.0-next
   changes:
   - description: Remove the release tag, semantic versioning should be used instead.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,11 +2,6 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
-- version: 1.5.0
-  changes:
-  - description: Deprecate the `muted` and `enabled` properties of the `csp-rule-template` asset.
-    type: breaking-change
-    link: TODO - fill in
 - version: 2.3.0-next
   changes:
   - description: Remove the release tag, semantic versioning should be used instead.

--- a/test/packages/good/kibana/csp_rule_template/good-csp-rule-template-abc-1.json
+++ b/test/packages/good/kibana/csp_rule_template/good-csp-rule-template-abc-1.json
@@ -30,9 +30,7 @@
   "id": "good-csp-rule-template-abc-1",
   "type": "csp-rule-template",
   "migrationVersion": {
-    // TODO - Should we add 8.4.0 as well?
     "csp-rule-template": "8.7.0"
   },
-  //  TODO - is this the right core migration version?
-  "coreMigrationVersion": "8.4.0"
+  "coreMigrationVersion": "8.7.0"
 }

--- a/test/packages/good/kibana/csp_rule_template/good-csp-rule-template-abc-1.json
+++ b/test/packages/good/kibana/csp_rule_template/good-csp-rule-template-abc-1.json
@@ -1,7 +1,5 @@
 {
   "attributes": {
-    "enabled": true,
-    "muted": false,
     "metadata": {
       "id": "6664c1b8-05f2-5872-a516-4b2c3c36d2d7",
       "name": "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)",
@@ -23,7 +21,8 @@
       ],
       "benchmark": {
         "name": "CIS Kubernetes V1.23",
-        "version": "v1.0.0"
+        "version": "v1.0.0",
+        "id": "cis_k8s"
       },
       "rego_rule_id": "cis_1_1_1"
     }
@@ -31,7 +30,9 @@
   "id": "good-csp-rule-template-abc-1",
   "type": "csp-rule-template",
   "migrationVersion": {
-    "csp-rule-template": "8.4.0"
+    // TODO - Should we add 8.4.0 as well?
+    "csp-rule-template": "8.7.0"
   },
+  //  TODO - is this the right core migration version?
   "coreMigrationVersion": "8.4.0"
 }

--- a/test/packages/good_v2/kibana/csp_rule_template/good_v2-csp-rule-template-abc-1.json
+++ b/test/packages/good_v2/kibana/csp_rule_template/good_v2-csp-rule-template-abc-1.json
@@ -1,3 +1,4 @@
+// TODO - What is this file ? Do I need to update it as well?
 {
   "attributes": {
     "benchmark_rule_id": "1.1.1",

--- a/test/packages/good_v2/kibana/csp_rule_template/good_v2-csp-rule-template-abc-1.json
+++ b/test/packages/good_v2/kibana/csp_rule_template/good_v2-csp-rule-template-abc-1.json
@@ -27,7 +27,7 @@
       "rego_rule_id": "cis_1_1_1"
     }
   },
-  "id": "good-csp-rule-template-abc-1",
+  "id": "good_v2-csp-rule-template-abc-1",
   "type": "csp-rule-template",
   "migrationVersion": {
     "csp-rule-template": "8.7.0"

--- a/test/packages/good_v2/kibana/csp_rule_template/good_v2-csp-rule-template-abc-1.json
+++ b/test/packages/good_v2/kibana/csp_rule_template/good_v2-csp-rule-template-abc-1.json
@@ -1,23 +1,36 @@
-// TODO - What is this file ? Do I need to update it as well?
 {
   "attributes": {
-    "benchmark_rule_id": "1.1.1",
-    "rego_rule_id": "cis_k8s.cis_1_1_1",
-    "name": "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)",
-    "description": "'Disable anonymous requests to the API server",
-    "rationale": "When enabled, requests that are not rejected by other configured authentication methods\nare treated as anonymous requests. These requests are then served by the API server. You\nshould rely on authentication to authorize access and disallow anonymous requests.\nIf you are using RBAC authorization, it is generally considered reasonable to allow\nanonymous access to the API Server for health checks and discovery purposes, and hence\nthis recommendation is not scored. However, you should consider whether anonymous\ndiscovery is an acceptable risk for your purposes.",
-    "impact": "Anonymous requests will be rejected.",
-    "default_value": "By default, anonymous access is enabled.",
-    "remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kubeapiserver.yaml on the master node and set the below parameter.\n--anonymous-auth=false",
-    "enabled": true,
-    "muted": false,
-    "tags": [
-      "Kubernetes",
-      "Containers"
-    ],
-    "benchmark": { "name": "CIS Kubernetes", "version": "1.4.1" },
-    "severity": "low"
+    "metadata": {
+      "id": "6664c1b8-05f2-5872-a516-4b2c3c36d2d7",
+      "name": "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)",
+      "profile_applicability": "* Level 1 - Master Node\n",
+      "description": "Ensure that the API server pod specification file has permissions of `644` or more restrictive.\n",
+      "rationale": "The API server pod specification file controls various parameters that set the behavior of the API server. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system.\n",
+      "audit": "Run the below command (based on the file location on your system) on the\ncontrol plane node.\nFor example,\n```\nstat -c %a /etc/kubernetes/manifests/kube-apiserver.yaml\n```\nVerify that the permissions are `644` or more restrictive.\n",
+      "remediation": "Run the below command (based on the file location on your system) on the\ncontrol plane node.\nFor example,\n```\nchmod 644 /etc/kubernetes/manifests/kube-apiserver.yaml\n```\n",
+      "impact": "None\n",
+      "default_value": "By default, the `kube-apiserver.yaml` file has permissions of `640`.\n",
+      "references": "1. [https://kubernetes.io/docs/admin/kube-apiserver/](https://kubernetes.io/docs/admin/kube-apiserver/)\n",
+      "section": "Control Plane Node Configuration Files",
+      "version": "1.0",
+      "tags": [
+        "CIS",
+        "Kubernetes",
+        "CIS 1.1.1",
+        "Control Plane Node Configuration Files"
+      ],
+      "benchmark": {
+        "name": "CIS Kubernetes V1.23",
+        "version": "v1.0.0",
+        "id": "cis_k8s"
+      },
+      "rego_rule_id": "cis_1_1_1"
+    }
   },
-  "id": "good_v2-csp-rule-template-abc-1",
-  "type": "csp-rule-template"
+  "id": "good-csp-rule-template-abc-1",
+  "type": "csp-rule-template",
+  "migrationVersion": {
+    "csp-rule-template": "8.7.0"
+  },
+  "coreMigrationVersion": "8.7.0"
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here WHAT changes you made in the PR.
-->
We are deprecating two fields from our CSP template object.

## Why is it important?
During the development of 8.7.0 we've refactored the schema of the rule templates and it is important to keep the examples in the spec updated as well
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues
- https://github.com/elastic/kibana/issues/143524