### PR TITLE
Add index_template.data_stream.hidden flag

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -18,6 +18,9 @@
   - description: Add flag in _dev/build/build.yml to import ECS mappings.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/455
+  - description: Add index_pattern.data_stream.hidden flag to data stream manifest
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/465
 - version: 2.2.0
   changes:
   - description: Support definition of system tests for input packages

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,6 +7,9 @@
   - description: Allow security_rule objects to have rule IDs different from the object IDs.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/463
+  - description: Add index_pattern.data_stream.hidden flag to data stream manifest
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/465
 - version: 2.3.0
   changes:
   - description: Remove the release tag, semantic versioning should be used instead.
@@ -18,9 +21,6 @@
   - description: Add flag in _dev/build/build.yml to import ECS mappings.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/455
-  - description: Add index_pattern.data_stream.hidden flag to data stream manifest
-    type: enhancement
-    link: https://github.com/elastic/package-spec/pull/465
 - version: 2.2.0
   changes:
   - description: Support definition of system tests for input packages

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,7 +7,7 @@
   - description: Allow security_rule objects to have rule IDs different from the object IDs.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/463
-  - description: Add index_pattern.data_stream.hidden flag to data stream manifest
+  - description: Add index_template.data_stream.hidden flag to data stream manifest
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/465
 - version: 2.3.0

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -126,6 +126,14 @@ spec:
               type: string
           required:
           - name
+        data_stream:
+          description: Data stream section of index template
+          type: object
+          additionalProperties: false
+          properties:
+            hidden:
+              description: Makes the data stream hidden
+              type: boolean
   properties:
     dataset:
       description: Name of data set.

--- a/test/packages/good/data_stream/foo/manifest.yml
+++ b/test/packages/good/data_stream/foo/manifest.yml
@@ -32,6 +32,7 @@ elasticsearch.index_template.mappings:
   a:
     b: 1
 elasticsearch.index_template.ingest_pipeline.name: foobar
+elasticsearch.index_template.data_stream.hidden: true
 elasticsearch.privileges.indices: [auto_configure, create_doc, monitor]
 elasticsearch.dynamic_dataset: true
 elasticsearch.dynamic_namespace: true


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here WHAT changes you made in the PR.
-->

Adds `index_template.data_stream.hidden` flag to data stream manifest

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

We need this urgently in APM as we want to release an important performance improvement in Kibana that makes use of continuously rolled up metrics for 1m, 10m, and 60m granularities. We need to hide the data streams with the non-default 10m and 60m buckets so that the OOTB ML jobs and existing custom dashboards don't break.

Sorry for having identified this blocker so late but we'd really hope to be able to get this in 8.7. This feels like a rather trivial and non-controversial change. Hopefully this turns out to be true.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

Closes https://github.com/elastic/package-spec/issues/464
