### PR TITLE
Update top hidden field description in datastream manifest

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,6 +10,9 @@
   - description: Add index_template.data_stream.hidden flag to data stream manifest
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/465
+  - description: Update description of top level hidden field in data_streams and deprecate it.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/466
 - version: 2.3.0
   changes:
   - description: Remove the release tag, semantic versioning should be used instead.

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -176,8 +176,9 @@ spec:
       examples:
       - metrics
     hidden:
-      description: Specifies if a data stream is hidden
+      description: Specifies if a data stream is hidden, resulting in dot prefixed system indices
       type: boolean
+      deprecated: true # https://github.com/elastic/package-spec/issues/464
     streams:
       description: Streams offered by data stream.
       type: array

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -176,7 +176,9 @@ spec:
       examples:
       - metrics
     hidden:
-      description: Specifies if a data stream is hidden, resulting in dot prefixed system indices
+      description: >
+        Specifies if a data stream is hidden, resulting in dot prefixed system indices.
+        To set the data stream hidden without those dot prefixed indices, check `elasticsearch.index_template.data_stream.hidden` flag.
       type: boolean
       deprecated: true # https://github.com/elastic/package-spec/issues/464
     streams:


### PR DESCRIPTION
## What does this PR do?

Updates the description of the top level `hidden` field in the manifest datastream:
https://github.com/elastic/package-spec/blob/main/spec/integration/data_stream/manifest.spec.yml#L178-L180

This field is also set as "deprecated". It should be used the [new `hidden` field](https://github.com/elastic/package-spec/blob/main/spec/integration/data_stream/manifest.spec.yml#L134) that can be defined under `elsaticsearch`: `elasticsearch.index_template.data_stream.hidden`


## Why is it important?

Updating the description of the top level allows to differentiate from the `hidden` defined under the `elasticsearch` key, to be sure which one should used in each case.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #464
