### PR TITLE
Prepare version 2.5.0 with new subcategories

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,11 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
-- version: 2.4.1-next
+- version: 2.5.0
   changes:
-  - description: Prepare for next version
+  - description: Add new subcategories
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/468
+    link: https://github.com/elastic/package-spec/pull/469
 - version: 2.4.0
   changes:
   - description: Allow security_rule objects to have rule IDs different from the object IDs.

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -12,31 +12,71 @@ spec:
       items:
         type: string
         enum:
+          - analytics_engine
+          - application_observability
+          - app_search
+          - auditd
+          - authentication
           - aws
           - azure
+          - big_data
+          - cdn_security
           - cloud
           - config_management
+          - connector
+          - connector_client
+          - connector_package
           - containers
+          - content_source
+          - crawler
+          - credential_management
           - crm
           - custom
+          - custom_logs
+          - database_security
           - datastore
+          - dns_security
+          - edr_xdr
+          - elasticsearch_sdk
           - elastic_stack
+          - email_security
+          - enterprise_serch
+          - firewall_security
           - google_cloud
+          - iam
+          - ids_ips
           - infrastructure
+          - java_observability
           - kubernetes
+          - language_client
           - languages
+          - load_balancer
           - message_queue
           - monitoring
+          - monitoring_infrastructure
+          - native_search
           - network
+          - network_security
           - notification
+          - observability
           - os_system
+          - process_manager
           - productivity
+          - productivity_security
+          - proxy_security
+          - sdk_search
           - security
+          - stream_processing
           - support
           - threat_intel
           - ticketing
           - version_control
+          - virtualization
+          - vpn_security
           - web
+          - web_application_firewall
+          - websphere
+          - workplace_search
         examples:
           - web
     conditions:

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -40,7 +40,7 @@ spec:
           - elasticsearch_sdk
           - elastic_stack
           - email_security
-          - enterprise_serch
+          - enterprise_search
           - firewall_security
           - google_cloud
           - iam


### PR DESCRIPTION
Subcategories were added to the package registry in https://github.com/elastic/package-registry/pull/914, but we didn't add them to the spec, so they cannot be actually used in packages.