### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,11 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/code/go"
+    directory: "/"
     schedule:
       interval: "daily"
     labels:
       - automation
     reviewers:
-      - "elastic/integrations-developer-experience"
+      - "elastic/ecosystem"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this PR do?

Update dependabot config after being moved `go.mod` from `/code/go` to the root of the repository. Since this pull request https://github.com/elastic/package-spec/pull/213 , that file changed its location.

Update reviewer to be ecosystem team.

## Why is it important?

Dependabot needs to have the location to the `go.mod` in order to create the corresponding Pull Requests.

