### PR TITLE
Add `date_format` to field of type `date`

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -4,9 +4,9 @@
 ##
 - version: 2.5.2-next
   changes:
-  - description: Prepare for next version
+  - description: Add date_format to field of type date
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/479
+    link: https://github.com/elastic/package-spec/pull/123
 - version: 2.5.1
   changes:
   - description: Add category for vulnerability_management

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -117,6 +117,20 @@ spec:
         - micros
         - nanos
 
+      date_format:
+        description: >
+          The date format(s) that can be parsed. 
+          Type date format default to `strict_date_optional_time||epoch_millis`, see the (doc)[https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html#date-params].
+          
+          In JSON documents, dates are represented as strings. 
+          Elasticsearch uses a set of preconfigured formats to recognize 
+          and parse these strings into a long value representing 
+          _milliseconds-since-the-epoch_ in UTC.
+
+          Besides the [built-in formats](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats), your own [custom 
+          formats](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#custom-date-formats) can be specified using the familiar `yyyy/MM/dd` syntax.
+        type: string
+
       dimension:
         description: >
           Declare a field as dimension of time series. This is


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here WHAT changes you made in the PR.
-->
Allow to specify how date will be recognized and parsed. 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Currently the default in elasticsearch is `strict_date_optional_time||epoch_millis` (see [doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html#date-params))
However, integrations might send date values in different formatting than the default one.
This will allow their docs to be indexed and mapped properly

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/cloudbeat/issues/768
- Requires https://github.com/elastic/kibana/pull/151871
