### PR TITLE
Remove `monitoring_infrastructure` category from package spec

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,11 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
-- version: 2.5.2-next
+- version: 2.5.2
   changes:
-  - description: Prepare for next version
+  - description: Remove monitoring_infrastructure category
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/479
+    link: https://github.com/elastic/package-spec/pull/490
 - version: 2.5.1
   changes:
   - description: Add category for vulnerability_management

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,10 +2,10 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
-- version: 2.5.2
+- version: 2.6.0-next
   changes:
   - description: Remove monitoring_infrastructure category
-    type: enhancement
+    type: breaking-change
     link: https://github.com/elastic/package-spec/pull/490
 - version: 2.5.1
   changes:

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -53,7 +53,6 @@ spec:
           - load_balancer
           - message_queue
           - monitoring
-          - monitoring_infrastructure
           - native_search
           - network
           - network_security


### PR DESCRIPTION
## What does this PR do?

Related to https://github.com/elastic/package-registry/pull/970. With the deprecation of parent `Infrastructure` category, remove `monitoring_infrastructure` category as no integrations are currently using it.