### PR TITLE
add support for transform `settings.unattended`

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -13,6 +13,9 @@
   - description: Add select as a new field type
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/486
+  - description: Add transform settings.unattended option
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/491
 - version: 2.5.1
   changes:
   - description: Add category for vulnerability_management

--- a/spec/integration/elasticsearch/transform/transform.spec.yml
+++ b/spec/integration/elasticsearch/transform/transform.spec.yml
@@ -67,7 +67,7 @@ spec:
           "$id": "#root/pivot/aggregations"
           title: Aggregations
           type: object
-        aggs: # This property was missing in the original schema and added manually. 
+        aggs: # This property was missing in the original schema and added manually.
           "$id": "#root/pivot/aggs"
           title: Aggregations
           type: object
@@ -159,6 +159,11 @@ spec:
           title: deduce mappings
           type: boolean
           default: true
+        unattended:
+          "$id": "#root/settings/unattended"
+          title: unattended
+          type: boolean
+          default: false
     _meta:
       "$id": "#root/_meta"
       title: Metadata

--- a/test/packages/good/elasticsearch/transform/metadata_current/transform.yml
+++ b/test/packages/good/elasticsearch/transform/metadata_current/transform.yml
@@ -18,3 +18,5 @@ sync:
   time:
     field: event.ingested
     delay: 1s
+settings:
+  unattended: true

--- a/test/packages/good/elasticsearch/transform/metadata_united/transform.yml
+++ b/test/packages/good/elasticsearch/transform/metadata_united/transform.yml
@@ -26,3 +26,5 @@ pivot:
 description: Merges latest Endpoint and Agent metadata documents
 _meta:
   managed: true
+settings:
+  unattended: true

--- a/test/packages/good_v2/elasticsearch/transform/metadata_current/transform.yml
+++ b/test/packages/good_v2/elasticsearch/transform/metadata_current/transform.yml
@@ -18,3 +18,5 @@ sync:
   time:
     field: event.ingested
     delay: 1s
+settings:
+  unattended: true

--- a/test/packages/good_v2/elasticsearch/transform/metadata_united/transform.yml
+++ b/test/packages/good_v2/elasticsearch/transform/metadata_united/transform.yml
@@ -26,3 +26,5 @@ pivot:
 description: Merges latest Endpoint and Agent metadata documents
 _meta:
   managed: true
+settings:
+  unattended: true


### PR DESCRIPTION
## What does this PR do?

This adds support for the transform `settings.unattended` option.

## Why is it important?

We [recently added unattended: true](https://github.com/elastic/endpoint-package/pull/353) into `endpoint-package`. We were previously managing the health of our transforms manually (kibana task for restarting / reinstalling our package transforms).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/security-team/issues/6165