### PR TITLE
Prepare version 2.6.0

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,11 +2,8 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
-- version: 2.6.0-next
+- version: 2.6.0
   changes:
-  - description: Release input packages spec as GA
-    type: enhancement
-    link: https://github.com/elastic/package-spec/pull/485
   - description: Remove monitoring_infrastructure category
     type: breaking-change
     link: https://github.com/elastic/package-spec/pull/490
@@ -19,6 +16,9 @@
   - description: Add transform settings.unattended option
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/491
+  - description: Release input packages spec as GA
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/485
 - version: 2.5.1
   changes:
   - description: Add category for vulnerability_management


### PR DESCRIPTION
## What does this PR do?

Release new minor version including the following changes:
* [Release input packages spec as GA](https://github.com/elastic/package-spec/pull/485)
* [Remove monitoring_infrastructure category](https://github.com/elastic/package-spec/pull/490)
* [Add date_format to field of type date](https://github.com/elastic/package-spec/pull/481)
* [Add select as a new field type](https://github.com/elastic/package-spec/pull/486)
* [Add transform settings.unattended option](https://github.com/elastic/package-spec/pull/491)

## Why is it important?

[Add select as a new field type](https://github.com/elastic/package-spec/pull/486) is needed to complete https://github.com/elastic/package-spec/issues/453.
