### PR TITLE
Prepare next version after 2.6.0

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,6 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
+- version: 2.6.1-next
+  changes:
+  - description: Prepare for next version
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/494
 - version: 2.6.0
   changes:
   - description: Remove monitoring_infrastructure category


### PR DESCRIPTION
## What does this PR do?

Add entry in `spec/changelog.yml` to prepare for next version after 2.6.0.
