### PR TITLE
Add validation for data types of metrics

### DIFF
--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -101,6 +101,7 @@ func TestValidateFile(t *testing.T) {
 		"bad_time_series": {
 			"data_stream/example/fields/fields.yml",
 			[]string{
+				`field 0.fields.4.type: 0.fields.4.type must be one of the following: "histogram", "aggregate_metric_double", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "unsigned_long"`,
 				"field \"example.agent.call_duration\" of type histogram can't be a dimension, allowed types for dimensions: constant_keyword, keyword, long, integer, short, byte, double, float, half_float, scaled_float, unsigned_long, ip",
 			},
 		},

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -102,6 +102,7 @@ func TestValidateFile(t *testing.T) {
 			"data_stream/example/fields/fields.yml",
 			[]string{
 				`field 0.fields.4.type: 0.fields.4.type must be one of the following: "histogram", "aggregate_metric_double", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "unsigned_long"`,
+				`field 0.fields.5: type is required`,
 				"field \"example.agent.call_duration\" of type histogram can't be a dimension, allowed types for dimensions: constant_keyword, keyword, long, integer, short, byte, double, float, half_float, scaled_float, unsigned_long, ip",
 			},
 		},

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,6 +7,9 @@
   - description: Prepare for next version
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/522
+  - description: Add validation for data types of metrics
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/525
 - version: 2.8.0
   changes:
   - description: Add new subcategory "advanced_analytics_ueba"

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -453,7 +453,6 @@ spec:
               - runtime
       - if:
           required:
-            - type
             - metric_type
         then:
           properties:
@@ -470,10 +469,8 @@ spec:
                 - half_float
                 - scaled_float
                 - unsigned_long
-        else:
-          not:
-            required:
-              - metric_type
+          required:
+            - type
     required:
     - name
 

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -144,15 +144,15 @@ spec:
 
       date_format:
         description: >
-          The date format(s) that can be parsed. 
+          The date format(s) that can be parsed.
           Type date format default to `strict_date_optional_time||epoch_millis`, see the [doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html#date-params).
-          
-          In JSON documents, dates are represented as strings. 
-          Elasticsearch uses a set of preconfigured formats to recognize 
-          and parse these strings into a long value representing 
+
+          In JSON documents, dates are represented as strings.
+          Elasticsearch uses a set of preconfigured formats to recognize
+          and parse these strings into a long value representing
           _milliseconds-since-the-epoch_ in UTC.
 
-          Besides the [built-in formats](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats), your own [custom 
+          Besides the [built-in formats](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats), your own [custom
           formats](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#custom-date-formats) can be specified using the familiar `yyyy/MM/dd` syntax.
         type: string
 
@@ -451,7 +451,29 @@ spec:
           not:
             required:
               - runtime
-
+      - if:
+          required:
+            - type
+            - metric_type
+        then:
+          properties:
+            type:
+              enum:
+                - histogram
+                - aggregate_metric_double
+                - long
+                - integer
+                - short
+                - byte
+                - double
+                - float
+                - half_float
+                - scaled_float
+                - unsigned_long
+        else:
+          not:
+            required:
+              - metric_type
     required:
     - name
 

--- a/test/packages/bad_time_series/data_stream/example/fields/fields.yml
+++ b/test/packages/bad_time_series/data_stream/example/fields/fields.yml
@@ -14,6 +14,8 @@
     type: histogram
     metric_type: gauge
     dimension: true # This should fail, a histogram cannot be a dimension.
-  - name: agent.no_valid
+  - name: no_valid_type
     type: boolean
+    metric_type: gauge
+  - name: no_type
     metric_type: gauge

--- a/test/packages/bad_time_series/data_stream/example/fields/fields.yml
+++ b/test/packages/bad_time_series/data_stream/example/fields/fields.yml
@@ -14,3 +14,6 @@
     type: histogram
     metric_type: gauge
     dimension: true # This should fail, a histogram cannot be a dimension.
+  - name: agent.no_valid
+    type: boolean
+    metric_type: gauge


### PR DESCRIPTION
## What does this PR do?

This PR adds validation to ensure that fields using `metric_type` use just the required types. 

Required types ([link](https://www.elastic.co/guide/en/elasticsearch/reference/8.8/tsds.html#time-series-metric)) to use `metric_types`:
- aggregate_metric_double
- histogram
- numerical field types ([link](https://www.elastic.co/guide/en/elasticsearch/reference/8.8/number.html)).

To ensure that the type is one of the above, this PR also sets `type`field as a required one when `metric_type` is used.

## Why is it important?

Ensure that field types are the correct ones to avoid errors when installing packages.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).
- [x] Test this branch with integrations repository.
    - No packages found with errors related to this new validation.

## Related issues

- Closes #520 
