### PR TITLE
Add configuration to onboard repository into Buildkite and Backstage

### DIFF
--- a/.buildkite/pipeline.test-with-integrations-repo.yml
+++ b/.buildkite/pipeline.test-with-integrations-repo.yml
@@ -1,0 +1,15 @@
+env:
+  SETUP_GVM_VERSION: 'v0.5.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  GOLANG_VERSION: "1.20.3"
+  GH_CLI_VERSION: "2.29.0"
+  JQ_VERSION: "1.6"
+
+steps:
+  - label: ":go: Run check-static"
+    key: check
+    command: "make check"
+    agents:
+      image: "golang:${GOLANG_VERSION}"
+      cpu: "8"
+      memory: "4G"
+

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -1,0 +1,21 @@
+{
+   "jobs": [
+     {
+        "enabled": true,
+        "pipelineSlug": "package-spec-test-with-integrations",
+        "allow_org_users": true,
+        "allowed_repo_permissions": ["admin", "write"],
+        "allowed_list": [ ],
+        "set_commit_status": false,
+        "build_on_commit": false,
+        "build_on_comment": true,
+        "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:test)\\W+(?:integrations))$",
+        "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:test)\\W+(?:integrations))$",
+        "skip_ci_labels": [ ],
+        "skip_target_branches": [ ],
+        "skip_ci_on_only_changed": [ ],
+        "always_require_ci_on_changed": [ ]
+     }
+   ]
+}
+

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,65 @@
+# Declare a Backstage Component that represents your application.
+---
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: package-spec
+  description: EPR package specifications
+  links:
+    - title: Developer Documentation
+      icon: file-doc
+      url: https://www.elastic.co/guide/en/integrations-developer/current/package-spec.html
+
+spec:
+  type: tool
+  owner: group:ingest-fp
+  system: platform-ingest
+  lifecycle: production
+
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-package-spec-test-with-integrations
+  description: 'Buildkite pipeline to run specific package-spec version with all packages in integrations repository'
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/package-spec-test-with-integrations
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: package-spec-test-with-integrations
+      description: 'Buildkite pipeline to run specific package-spec version with all packages in integrations repository'
+    spec:
+      branch_configuration: main
+      pipeline_file: ".buildkite/pipeline.test-with-integrations-repo.yml"
+      provider_settings:
+        build_tags: false # just run on demand
+        build_branches: false # just run on demand
+        publish_commit_status: false # do not update status of commits for this pipeline
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        filter_enabled: true
+        filter_condition: |
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      repository: elastic/package-spec
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      teams:
+        ecosystem:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
## What does this PR do?

This PR adds the needed configuration to start using Buildkite as a CI framework for this repository.

## Why is it important?

At some point, all pipelines should be running in Buildkite.
