### PR TITLE
Prepare version 2.8.1

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,11 +2,8 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
-- version: 2.8.1-next
+- version: 2.8.1
   changes:
-  - description: Prepare for next version
-    type: enhancement
-    link: https://github.com/elastic/package-spec/pull/522
   - description: Add validation for data types of metrics
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/525


### PR DESCRIPTION
## What does this PR do?

Release new patch version including the following changes:
* [Add validation for data types of metrics](https://github.com/elastic/package-spec/pull/525)
* [Extend benchmarks spec to add rally scenario](https://github.com/elastic/package-spec/pull/524)

## Why is it important?

To prepare version 2.9.0 for https://github.com/elastic/package-spec/pull/339.
