### PR TITLE
fix go version

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -32,6 +32,7 @@ checkout_merge() {
     }
 }
 
+export GO_VERSION="$(< .go-version)"
 pull_request="${BUILDKITE_PULL_REQUEST:-false}"
 
 if [[ "${pull_request}" == "false" ]]; then
@@ -48,8 +49,6 @@ checkout_merge "${TARGET_BRANCH}" "${PR_COMMIT}" "${MERGE_BRANCH}"
 
 echo "Commit information"
 git log --format=%B -n 1
-
-export GO_VERSION="$(< .go-version)"
 
 # Ensure buildkite groups are rendered
 echo ""


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Error getting the GO version
https://buildkite.com/elastic/package-spec/builds/15#018907c7-f525-4bd0-a626-82bc76360fcf

## How does this PR solve the problem?

Moved the exportin of the variable in the post-checkout script

## How to test this PR locally

It worked in the previous PR because it was PR

## Checklist

The Buildkite pipeline will be triggered by this PR and we will see the result

## Related issues

-
