### PR TITLE
Add settings for data retention (DLM)

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,11 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
-- version: 2.9.1-next
+- version: 2.10.0-next
   changes:
-  - description: Prepare for next version
+  - description: Add specific settings for data retention lifecycle configuration (for DLM).
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/547
+    link: https://github.com/elastic/package-spec/issues/556
 - version: 2.9.0
   changes:
   - description: Update minimum kibana version required for runtime fields

--- a/spec/input/spec.yml
+++ b/spec/input/spec.yml
@@ -57,3 +57,15 @@ spec:
     required: false
     visibility: private
     $ref: "./_dev/spec.yml"
+  - description: File containing lifecycle configuration (technical preview)
+    type: file
+    contentMediaType: "application/x-yaml"
+    name: "lifecycle.yml"
+    required: false
+    $ref: "../integration/data_stream/lifecycle.spec.yml"
+
+versions:
+  - before: 2.10.0
+    patch:
+      - op: remove
+        path: "/contents/8" # remove lifecycle definition

--- a/spec/integration/data_stream/lifecycle.spec.yml
+++ b/spec/integration/data_stream/lifecycle.spec.yml
@@ -1,0 +1,17 @@
+##
+## Describes the specification for the data lifecycle configuration.
+##
+spec:
+  # Everything under here follows JSON schema (https://json-schema.org/), written as YAML for readability
+  items:
+    data_retention:
+      description: |-
+        Every document collected will be stored at least during this time frame.
+        Any time after this duration the documents could be deleted.
+      type: string
+      examples:
+        - "7d"
+  required:
+    - data_retention
+
+

--- a/spec/integration/data_stream/spec.yml
+++ b/spec/integration/data_stream/spec.yml
@@ -84,9 +84,18 @@ spec:
       name: "routing_rules.yml"
       required: false
       $ref: "./routing_rules.spec.yml"
+    - description: File containing lifecycle configuration (technical preview)
+      type: file
+      contentMediaType: "application/x-yaml"
+      name: "lifecycle.yml"
+      required: false
+      $ref: "lifecycle.spec.yml"
 
-# TODO add JSON patch to remove routing_rules.yml entry
 versions:
+  - before: 2.10.0
+    patch:
+      - op: remove
+        path: "/contents/0/contents/8" # remove lifecycle definition
   - before: 2.9.0
     patch:
       - op: remove

--- a/test/packages/good_input/lifecycle.yml
+++ b/test/packages/good_input/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/test/packages/good_input/manifest.yml
+++ b/test/packages/good_input/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 2.9.0
+format_version: 2.10.0
 name: good_input
 title: good_input
 description: >-

--- a/test/packages/good_v2/data_stream/foo/lifecycle.yml
+++ b/test/packages/good_v2/data_stream/foo/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "7d"

--- a/test/packages/good_v2/manifest.yml
+++ b/test/packages/good_v2/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 2.9.0
+format_version: 2.10.0
 name: good_v2
 title: Good package
 description: This package is good for format version 2

--- a/test/packages/sql_input/lifecycle.yml
+++ b/test/packages/sql_input/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"


### PR DESCRIPTION
## What does this PR do?

Add a new configuration file for lifecycle configuration with a single setting for the data retention period.

This is intended to add support for DLM, but is agnostic of the lifecycle management used. More settings related to lifecycle management can be added to the same file in the future.

This is added to integration data streams and input packages.

## Why is it important?

To add support for DLM.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/package-spec/issues/536
