### PR TITLE
Add support for transform destination aliases

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -19,6 +19,9 @@
   - description: Add support for log files in deploy terraform spec
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/571
+  - description: Add aliases to transform spec
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/1111 #TODO change PR number
 - version: 2.9.0
   changes:
   - description: Update minimum kibana version required for runtime fields

--- a/spec/integration/elasticsearch/transform/transform.spec.yml
+++ b/spec/integration/elasticsearch/transform/transform.spec.yml
@@ -111,6 +111,26 @@ spec:
           title: Pipeline
           type: string
           pattern: "^.*$"
+        aliases:
+          "$id": "#root/dest/aliases"
+          title: Aliases
+          type: array
+          items:
+            type: object
+            required:
+            - alias
+            additionalProperties: false
+            properties:
+              alias:
+                "$id": "#root/dest/aliases/alias"
+                title: Alias
+                type: string
+                examples:
+                  - mylogs
+              move_on_creation:
+                "$id": "#root/dest/aliases/move_on_creation"
+                title: Move on Creation
+                type: boolean
     frequency:
       "$id": "#root/frequency"
       title: Frequency

--- a/test/packages/good/elasticsearch/transform/good_example_abc_1/transform.yml
+++ b/test/packages/good/elasticsearch/transform/good_example_abc_1/transform.yml
@@ -17,6 +17,9 @@ description: Maximum priced ecommerce data by customer_id in Asia
 dest:
   index: kibana_sample_data_ecommerce_transform1
   pipeline: add_timestamp_pipeline
+  aliases:
+    - alias: kibana_sample_alias1
+      move_on_creation: false
 frequency: 5m
 sync:
   time:

--- a/test/packages/good/elasticsearch/transform/good_example_bdc_2/transform.yml
+++ b/test/packages/good/elasticsearch/transform/good_example_bdc_2/transform.yml
@@ -17,6 +17,11 @@ description: Maximum priced ecommerce data by customer_id in Asia
 dest:
   index: kibana_sample_data_ecommerce_transform1
   pipeline: add_timestamp_pipeline
+  aliases:
+    - alias: kibana_sample_alias1
+      move_on_creation: false
+    - alias: kibana_sample_alias2
+      move_on_creation: true
 frequency: 5m
 sync:
   time:

--- a/test/packages/good_v2/elasticsearch/transform/good_example_abc_1/transform.yml
+++ b/test/packages/good_v2/elasticsearch/transform/good_example_abc_1/transform.yml
@@ -17,6 +17,9 @@ description: Maximum priced ecommerce data by customer_id in Asia
 dest:
   index: kibana_sample_data_ecommerce_transform1
   pipeline: add_timestamp_pipeline
+  aliases:
+    - alias: kibana_sample_alias1
+      move_on_creation: false
 frequency: 5m
 sync:
   time:

--- a/test/packages/good_v2/elasticsearch/transform/good_example_bdc_2/transform.yml
+++ b/test/packages/good_v2/elasticsearch/transform/good_example_bdc_2/transform.yml
@@ -17,6 +17,11 @@ description: Maximum priced ecommerce data by customer_id in Asia
 dest:
   index: kibana_sample_data_ecommerce_transform1
   pipeline: add_timestamp_pipeline
+  aliases:
+    - alias: kibana_sample_alias1
+      move_on_creation: false
+    - alias: kibana_sample_alias2
+      move_on_creation: true
 frequency: 5m
 sync:
   time:


### PR DESCRIPTION
## What does this PR do?
Adds support for transform [destination aliases](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html).
<!-- Mandatory
Explain here WHAT changes you made in the PR.
--> 
   - Added `aliases` into transform `dest` as array of objects containing `alias` and `move_on_creation`
   - Updated tests with `aliases` for  both `good` and `good_v2` packages containing transform.

## Why is it important?

- Having `alias` along with `move_on_creation` will help delete existing destination indices for `ti_*` packages. This helps in avoiding duplicates during Indicator Match Rules.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
