### PR TITLE
Prepare release 2.11.0

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -16,11 +16,8 @@
   - description: Add validation rule to ensure there are no dangling object IDs
     type: breaking-change
     link: https://github.com/elastic/package-spec/pull/589
-- version: 2.10.1-next
+- version: 2.11.0
   changes:
-  - description: Prepare for next version
-    type: enhancement
-    link: https://github.com/elastic/package-spec/pull/576
   - description: Add owner.type field to indicate package support level
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/568


### PR DESCRIPTION
It includes some fixes, an update of the Go runtime and an initial preview of Package Spec v3.