### PR TITLE
Fix go mod version for dependabot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/package-spec/v2
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
Dependabot is failing to parse go.mod files starting on 1.21, it requires a whole version.