### PR TITLE
Re-wrap errors using standard libraries

### DIFF
--- a/code/go/internal/pkgpath/files.go
+++ b/code/go/internal/pkgpath/files.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
@@ -63,17 +63,17 @@ func (f File) Values(path string) (interface{}, error) {
 
 	contents, err := fs.ReadFile(f.fsys, f.path)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading file content failed")
+		return nil, fmt.Errorf("reading file content failed: %w", err)
 	}
 
 	var v interface{}
 	if fileExt == "yaml" || fileExt == "yml" {
 		if err := yaml.Unmarshal(contents, &v); err != nil {
-			return nil, errors.Wrapf(err, "unmarshalling YAML file failed (path: %s)", f.fsys.Path(fileName))
+			return nil, fmt.Errorf("unmarshalling YAML file failed (path: %s): %w", f.fsys.Path(fileName), err)
 		}
 	} else if fileExt == "json" {
 		if err := json.Unmarshal(contents, &v); err != nil {
-			return nil, errors.Wrapf(err, "unmarshalling JSON file failed (path: %s)", f.fsys.Path(fileName))
+			return nil, fmt.Errorf("unmarshalling JSON file failed (path: %s): %w", f.fsys.Path(fileName), err)
 		}
 	}
 

--- a/code/go/internal/validator/content.go
+++ b/code/go/internal/validator/content.go
@@ -6,10 +6,9 @@ package validator
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io/fs"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
 )
@@ -72,7 +71,7 @@ func validateContentTypeSize(fsys fs.FS, path string, contentType spectypes.Cont
 		sizeLimit = limits.MaxConfigurationSize()
 	}
 	if sizeLimit > 0 && size > sizeLimit {
-		return errors.Errorf("file size (%s) is bigger than expected (%s)", size, sizeLimit)
+		return fmt.Errorf("file size (%s) is bigger than expected (%s)", size, sizeLimit)
 	}
 	return nil
 }
@@ -88,7 +87,7 @@ func validateMaxSize(fsys fs.FS, path string, limits spectypes.LimitsSpec) error
 	}
 	size := spectypes.FileSize(info.Size())
 	if size > limits.MaxFileSize() {
-		return errors.Errorf("file size (%s) is bigger than expected (%s)", size, limits.MaxFileSize())
+		return fmt.Errorf("file size (%s) is bigger than expected (%s)", size, limits.MaxFileSize())
 	}
 	return nil
 }

--- a/code/go/internal/validator/folder_item_spec.go
+++ b/code/go/internal/validator/folder_item_spec.go
@@ -5,10 +5,9 @@
 package validator
 
 import (
+	"fmt"
 	"io/fs"
 	"regexp"
-
-	"github.com/pkg/errors"
 
 	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 	"github.com/elastic/package-spec/v2/code/go/internal/spectypes"
@@ -25,7 +24,7 @@ func matchingFileExists(spec spectypes.ItemSpec, files []fs.DirEntry) (bool, err
 		for _, file := range files {
 			isMatch, err := regexp.MatchString(spec.Pattern(), file.Name())
 			if err != nil {
-				return false, errors.Wrap(err, "invalid folder item spec pattern")
+				return false, fmt.Errorf("invalid folder item spec pattern: %w", err)
 			}
 			if isMatch {
 				return spec.IsDir() == file.IsDir(), nil

--- a/code/go/internal/validator/semantic/validate_changelog_links.go
+++ b/code/go/internal/validator/semantic/validate_changelog_links.go
@@ -5,13 +5,12 @@
 package semantic
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 	"github.com/elastic/package-spec/v2/code/go/internal/fspath"

--- a/code/go/internal/validator/semantic/validate_fields_limits.go
+++ b/code/go/internal/validator/semantic/validate_fields_limits.go
@@ -5,7 +5,7 @@
 package semantic
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
@@ -39,7 +39,7 @@ func validateFieldsLimits(fsys fspath.FS, limit int) ve.ValidationErrors {
 	var errs ve.ValidationErrors
 	for id, count := range counts {
 		if count > limit {
-			errs = append(errs, errors.Errorf("data stream %s has more than %d fields (%d)", id, limit, count))
+			errs = append(errs, fmt.Errorf("data stream %s has more than %d fields (%d)", id, limit, count))
 		}
 	}
 	return errs

--- a/code/go/internal/validator/semantic/validate_kibana_matching_object_ids.go
+++ b/code/go/internal/validator/semantic/validate_kibana_matching_object_ids.go
@@ -9,8 +9,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
 	"github.com/elastic/package-spec/v2/code/go/internal/pkgpath"
@@ -26,7 +24,7 @@ func ValidateKibanaObjectIDs(fsys fspath.FS) ve.ValidationErrors {
 	filePaths := path.Join("kibana", "*", "*.json")
 	objectFiles, err := pkgpath.Files(fsys, filePaths)
 	if err != nil {
-		errs = append(errs, errors.Wrap(err, "error finding Kibana object files"))
+		errs = append(errs, fmt.Errorf("error finding Kibana object files: %w", err))
 		return errs
 	}
 
@@ -35,7 +33,7 @@ func ValidateKibanaObjectIDs(fsys fspath.FS) ve.ValidationErrors {
 
 		objectID, err := objectFile.Values("$.id")
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "unable to get Kibana object ID in file [%s]", fsys.Path(filePath)))
+			errs = append(errs, fmt.Errorf("unable to get Kibana object ID in file [%s]: %w", fsys.Path(filePath), err))
 			continue
 		}
 
@@ -43,19 +41,19 @@ func ValidateKibanaObjectIDs(fsys fspath.FS) ve.ValidationErrors {
 		if path.Base(path.Dir(filePath)) == "security_rule" {
 			ruleID, err := objectFile.Values("$.attributes.rule_id")
 			if err != nil {
-				errs = append(errs, errors.Wrapf(err, "unable to get rule ID in file [%s]", fsys.Path(filePath)))
+				errs = append(errs, fmt.Errorf("unable to get rule ID in file [%s]: %w", fsys.Path(filePath), err))
 				continue
 			}
 
 			objectIDValue, ok := objectID.(string)
 			if !ok {
-				errs = append(errs, errors.Wrap(err, "expect object ID to be a string"))
+				errs = append(errs, fmt.Errorf("expect object ID to be a string: %w", err))
 				continue
 			}
 
 			ruleIDValue, ok := ruleID.(string)
 			if !ok {
-				errs = append(errs, errors.Wrap(err, "expect rule ID to be a string"))
+				errs = append(errs, fmt.Errorf("expect rule ID to be a string: %w", err))
 				continue
 			}
 

--- a/code/go/internal/validator/semantic/validate_unique_fields.go
+++ b/code/go/internal/validator/semantic/validate_unique_fields.go
@@ -5,10 +5,9 @@
 package semantic
 
 import (
+	"fmt"
 	"sort"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
@@ -45,7 +44,7 @@ func ValidateUniqueFields(fsys fspath.FS) ve.ValidationErrors {
 			if len(files) > 1 {
 				sort.Strings(files)
 				errs = append(errs,
-					errors.Errorf("field %q is defined multiple times for data stream %q, found in: %s",
+					fmt.Errorf("field %q is defined multiple times for data stream %q, found in: %s",
 						field, id, strings.Join(files, ", ")))
 			}
 		}

--- a/code/go/internal/validator/semantic/validate_version_integrity.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity.go
@@ -5,10 +5,9 @@
 package semantic
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
@@ -44,7 +43,7 @@ func readManifestVersion(fsys fspath.FS) (string, error) {
 	manifestPath := "manifest.yml"
 	f, err := pkgpath.Files(fsys, manifestPath)
 	if err != nil {
-		return "", errors.Wrap(err, "can't locate manifest file")
+		return "", fmt.Errorf("can't locate manifest file: %w", err)
 	}
 
 	if len(f) != 1 {
@@ -53,7 +52,7 @@ func readManifestVersion(fsys fspath.FS) (string, error) {
 
 	val, err := f[0].Values("$.version")
 	if err != nil {
-		return "", errors.Wrap(err, "can't read manifest version")
+		return "", fmt.Errorf("can't read manifest version: %w", err)
 	}
 
 	sVal, ok := val.(string)
@@ -71,7 +70,7 @@ func readChangelog(fsys fspath.FS, jsonpath string) ([]string, error) {
 	changelogPath := "changelog.yml"
 	f, err := pkgpath.Files(fsys, changelogPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't locate changelog file")
+		return nil, fmt.Errorf("can't locate changelog file: %w", err)
 	}
 
 	if len(f) != 1 {
@@ -80,12 +79,12 @@ func readChangelog(fsys fspath.FS, jsonpath string) ([]string, error) {
 
 	vals, err := f[0].Values(jsonpath)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't changelog entries")
+		return nil, fmt.Errorf("can't changelog entries: %w", err)
 	}
 
 	versions, err := toStringSlice(vals)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't convert slice entries")
+		return nil, fmt.Errorf("can't convert slice entries: %w", err)
 	}
 	return versions, nil
 }

--- a/code/go/internal/validator/semantic/validate_visualizations_used_by_value.go
+++ b/code/go/internal/validator/semantic/validate_visualizations_used_by_value.go
@@ -5,11 +5,10 @@
 package semantic
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"path"
-
-	"github.com/pkg/errors"
 
 	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
 	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
@@ -35,7 +34,7 @@ func ValidateVisualizationsUsedByValue(fsys fspath.FS) ve.ValidationErrors {
 	filePaths := path.Join("kibana", "dashboard", "*.json")
 	objectFiles, err := pkgpath.Files(fsys, filePaths)
 	if err != nil {
-		errs = append(errs, errors.Wrap(err, "error finding Kibana Dashboard files"))
+		errs = append(errs, fmt.Errorf("error finding Kibana Dashboard files: %w", err))
 		return errs
 	}
 
@@ -50,7 +49,7 @@ func ValidateVisualizationsUsedByValue(fsys fspath.FS) ve.ValidationErrors {
 
 		references, err := anyReference(objectReferences)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "error getting references in file: %s", fsys.Path(filePath)))
+			errs = append(errs, fmt.Errorf("error getting references in file: %s: %w", fsys.Path(filePath), err))
 		}
 		if len(references) > 0 {
 			s := fmt.Sprintf("%s (%s)", references[0].ID, references[0].Type)

--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -5,12 +5,13 @@
 package validator
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"log"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 
 	spec "github.com/elastic/package-spec/v2"
 	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
@@ -35,7 +36,7 @@ type validationRules []validationRule
 func NewSpec(version semver.Version) (*Spec, error) {
 	specVersion, err := spec.CheckVersion(version)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not load specification for version [%s]", version.String())
+		return nil, fmt.Errorf("could not load specification for version [%s]: %w", version.String(), err)
 	}
 	if specVersion.Prerelease() != "" {
 		log.Printf("Warning: package using an unreleased version of the spec (%s)", specVersion)
@@ -55,7 +56,7 @@ func (s Spec) ValidatePackage(pkg packages.Package) ve.ValidationErrors {
 
 	rootSpec, err := loader.LoadSpec(s.fs, s.version, pkg.Type)
 	if err != nil {
-		errs = append(errs, errors.Wrap(err, "could not read root folder spec file"))
+		errs = append(errs, fmt.Errorf("could not read root folder spec file: %w", err))
 		return errs
 	}
 

--- a/code/go/internal/yamlschema/loader.go
+++ b/code/go/internal/yamlschema/loader.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/elastic/gojsonschema"
-	"github.com/pkg/errors"
+
 	"gopkg.in/yaml.v3"
 
 	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
@@ -90,7 +90,7 @@ func convertYAMLToJSON(data []byte, expandKeys bool) ([]byte, error) {
 	var c interface{}
 	err := yaml.Unmarshal(data, &c)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unmarshalling YAML file failed")
+		return nil, fmt.Errorf("unmarshalling YAML file failed: %w", err)
 	}
 	if expandKeys {
 		c = expandItemKey(c)
@@ -98,7 +98,7 @@ func convertYAMLToJSON(data []byte, expandKeys bool) ([]byte, error) {
 
 	data, err = json.Marshal(&c)
 	if err != nil {
-		return nil, errors.Wrapf(err, "converting YAML to JSON failed")
+		return nil, fmt.Errorf("converting YAML to JSON failed: %w", err)
 	}
 	return data, nil
 }
@@ -124,7 +124,7 @@ func expandItemKey(c interface{}) interface{} {
 			ex := expandItemKey(v)
 			_, err := expanded.Put(k, ex)
 			if err != nil {
-				panic(errors.Wrapf(err, "unexpected error while setting key value (key: %s)", k))
+				panic(fmt.Errorf("unexpected error while setting key value (key: %s): %w", k, err))
 			}
 		}
 		return expanded

--- a/code/go/internal/yamlschema/mapstr.go
+++ b/code/go/internal/yamlschema/mapstr.go
@@ -10,10 +10,9 @@ package yamlschema
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -71,7 +70,7 @@ func (m MapStr) StringToPrint() string {
 func toMapStr(v interface{}) (MapStr, error) {
 	m, ok := tryToMapStr(v)
 	if !ok {
-		return nil, errors.Errorf("expected map but type is %T", v)
+		return nil, fmt.Errorf("expected map but type is %T", v)
 	}
 	return m, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
 	github.com/otiai10/copy v1.12.0
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
@@ -30,6 +29,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	golang.org/x/mod v0.12.0 // indirect


### PR DESCRIPTION
Use standard library for errors wrapping.

Most code changes done with `github.com/xdg-go/go-rewrap-errors` and `goimports`.

Steps followed to prepare this PR:
* `find . -name "*.go" -exec go run github.com/xdg-go/go-rewrap-errors@latest -w {} \;`
* `find . -name "*.go" -exec goimports -w {} \;`
* `go mod tidy`
* Manually replaced uses of `log.Fatal(fmt.Errorf` with `log.Fatalf(...` (not really related, but took the opportunity to fix this).
* `make check-static`, and fix linting issues related to error messages.


Based on the procedure followed in https://github.com/elastic/elastic-package/pull/1332