### PR TITLE
Require filters in dashboards

### DIFF
--- a/code/go/internal/validator/semantic/testdata/dashboards/apache-no-filter.json
+++ b/code/go/internal/validator/semantic/testdata/dashboards/apache-no-filter.json
@@ -1,0 +1,1529 @@
+{
+    "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"8310f315-329a-45aa-90c2-925c542a3f1a\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"host.hostname\",\"title\":\"Hostname\",\"singleSelect\":true,\"id\":\"8310f315-329a-45aa-90c2-925c542a3f1a\",\"enhancements\":{}}}}"
+        },
+        "description": "Overview of Apache server status",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "highlightAll": true,
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                },
+                "version": true
+            }
+        },
+        "optionsJSON": {
+            "darkTheme": false,
+            "syncColors": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 7,
+                    "i": "7b7a1f18-e274-4f4e-a3b3-3760e7896897",
+                    "w": 16,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "7b7a1f18-e274-4f4e-a3b3-3760e7896897",
+                "panelRefName": "panel_7b7a1f18-e274-4f4e-a3b3-3760e7896897",
+                "type": "visualization",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-f7f31753-87a3-44c8-8be7-d11de2e96e18",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "f7f31753-87a3-44c8-8be7-d11de2e96e18": {
+                                            "columnOrder": [
+                                                "6a937091-e344-4d7e-a268-643b26c4ce73"
+                                            ],
+                                            "columns": {
+                                                "6a937091-e344-4d7e-a268-643b26c4ce73": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": " Total accesses",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.total_accesses"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "6a937091-e344-4d7e-a268-643b26c4ce73",
+                                "layerId": "f7f31753-87a3-44c8-8be7-d11de2e96e18",
+                                "layerType": "data",
+                                "size": "xxl",
+                                "textAlign": "center",
+                                "titlePosition": "top"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 7,
+                    "i": "bcaad3c3-d62c-44bd-8e76-f00cb8a7f0eb",
+                    "w": 16,
+                    "x": 16,
+                    "y": 0
+                },
+                "panelIndex": "bcaad3c3-d62c-44bd-8e76-f00cb8a7f0eb",
+                "title": "Total accesses [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-5db9209c-0470-4d6c-9099-6a61d16182e5",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "5db9209c-0470-4d6c-9099-6a61d16182e5": {
+                                            "columnOrder": [
+                                                "a3cfe7a5-b154-4d79-809d-da58fb456d09"
+                                            ],
+                                            "columns": {
+                                                "a3cfe7a5-b154-4d79-809d-da58fb456d09": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Total egress",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.total_bytes"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "accessor": "a3cfe7a5-b154-4d79-809d-da58fb456d09",
+                                "layerId": "5db9209c-0470-4d6c-9099-6a61d16182e5",
+                                "layerType": "data",
+                                "size": "xxl",
+                                "textAlign": "center",
+                                "titlePosition": "top"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 7,
+                    "i": "ea52006e-efe5-499a-88e7-2843258d6905",
+                    "w": 16,
+                    "x": 32,
+                    "y": 0
+                },
+                "panelIndex": "ea52006e-efe5-499a-88e7-2843258d6905",
+                "title": "Total egress [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-5ad06229-ad00-4090-a067-bfd4982a8e5d",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "5ad06229-ad00-4090-a067-bfd4982a8e5d": {
+                                            "columnOrder": [
+                                                "b6dc771b-b22b-49fd-a9f9-d03cdabc5ff9",
+                                                "cdd8ddfe-34a0-429c-86ec-b701e037a3da"
+                                            ],
+                                            "columns": {
+                                                "b6dc771b-b22b-49fd-a9f9-d03cdabc5ff9": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cdd8ddfe-34a0-429c-86ec-b701e037a3da": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Requests per sec",
+                                                    "operationType": "average",
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.requests_per_sec"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "(data_stream.dataset:apache.status)"
+                            },
+                            "visualization": {
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "cdd8ddfe-34a0-429c-86ec-b701e037a3da"
+                                        ],
+                                        "layerId": "5ad06229-ad00-4090-a067-bfd4982a8e5d",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "b6dc771b-b22b-49fd-a9f9-d03cdabc5ff9",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#da8b45",
+                                                "forAccessor": "cdd8ddfe-34a0-429c-86ec-b701e037a3da"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "auto",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yTitle": "Requests per sec"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "9386f867-d876-448b-b5fb-cc39eefb09cd",
+                    "w": 24,
+                    "x": 0,
+                    "y": 22
+                },
+                "panelIndex": "9386f867-d876-448b-b5fb-cc39eefb09cd",
+                "title": "Requests per sec [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-0154148b-c83a-4999-aacf-d096779b4a2d",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "0154148b-c83a-4999-aacf-d096779b4a2d": {
+                                            "columnOrder": [
+                                                "b54b81e7-a8c0-43b5-abb8-a7d85b5a1c0d",
+                                                "d2ce4a56-768f-4230-a097-cdc1ef6c145e",
+                                                "fcb57958-5c2b-42d6-8e82-026c11b9c4a6",
+                                                "a09e8787-5f02-4926-8b9b-8749c05bff51",
+                                                "3e8f02ab-d9aa-4bf8-a239-e262d79677ba",
+                                                "3c22b5cd-1236-4715-a141-83551cb1d69b",
+                                                "281445b6-8289-43bf-8fe4-91ec2aef2e39",
+                                                "ff3584e3-3bb2-4947-9f28-9bf7213395f1",
+                                                "25d0fc98-7b2c-4c11-b041-39cce4f45136",
+                                                "ece2abfc-43c6-4417-a51e-59531e471b11",
+                                                "46f38a6b-f372-4e43-9c85-e6f119845d5d",
+                                                "9375f15a-941e-4918-ad1e-b0aa66a76a78",
+                                                "cf3ca3dd-07cf-4baa-93da-e2504a608f56",
+                                                "dcc29ae9-4560-48b6-894a-8ada91a345ff"
+                                            ],
+                                            "columns": {
+                                                "25d0fc98-7b2c-4c11-b041-39cce4f45136": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Open slot",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.open_slot"
+                                                },
+                                                "281445b6-8289-43bf-8fe4-91ec2aef2e39": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Keepalive",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.keepalive"
+                                                },
+                                                "3c22b5cd-1236-4715-a141-83551cb1d69b": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Idle cleanup",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.idle_cleanup"
+                                                },
+                                                "3e8f02ab-d9aa-4bf8-a239-e262d79677ba": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Gracefully finishing",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.gracefully_finishing"
+                                                },
+                                                "46f38a6b-f372-4e43-9c85-e6f119845d5d": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Sending reply",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.sending_reply"
+                                                },
+                                                "9375f15a-941e-4918-ad1e-b0aa66a76a78": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Starting up",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.starting_up"
+                                                },
+                                                "a09e8787-5f02-4926-8b9b-8749c05bff51": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "DNS lookup",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.dns_lookup"
+                                                },
+                                                "b54b81e7-a8c0-43b5-abb8-a7d85b5a1c0d": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 5 values of host.hostname",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "fcb57958-5c2b-42d6-8e82-026c11b9c4a6",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "host.hostname"
+                                                },
+                                                "cf3ca3dd-07cf-4baa-93da-e2504a608f56": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Total",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.total"
+                                                },
+                                                "d2ce4a56-768f-4230-a097-cdc1ef6c145e": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "dcc29ae9-4560-48b6-894a-8ada91a345ff": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Waiting for connection",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.waiting_for_connection"
+                                                },
+                                                "ece2abfc-43c6-4417-a51e-59531e471b11": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Reading request",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.reading_request"
+                                                },
+                                                "fcb57958-5c2b-42d6-8e82-026c11b9c4a6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Closing connection",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.closing_connection"
+                                                },
+                                                "ff3584e3-3bb2-4947-9f28-9bf7213395f1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Logging",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.scoreboard.logging"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "(data_stream.dataset:apache.status)"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "emphasizeFitting": true,
+                                "fittingFunction": "Linear",
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "fcb57958-5c2b-42d6-8e82-026c11b9c4a6",
+                                            "a09e8787-5f02-4926-8b9b-8749c05bff51",
+                                            "3e8f02ab-d9aa-4bf8-a239-e262d79677ba",
+                                            "3c22b5cd-1236-4715-a141-83551cb1d69b",
+                                            "281445b6-8289-43bf-8fe4-91ec2aef2e39",
+                                            "ff3584e3-3bb2-4947-9f28-9bf7213395f1",
+                                            "25d0fc98-7b2c-4c11-b041-39cce4f45136",
+                                            "ece2abfc-43c6-4417-a51e-59531e471b11",
+                                            "46f38a6b-f372-4e43-9c85-e6f119845d5d",
+                                            "9375f15a-941e-4918-ad1e-b0aa66a76a78",
+                                            "cf3ca3dd-07cf-4baa-93da-e2504a608f56",
+                                            "dcc29ae9-4560-48b6-894a-8ada91a345ff"
+                                        ],
+                                        "layerId": "0154148b-c83a-4999-aacf-d096779b4a2d",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "b54b81e7-a8c0-43b5-abb8-a7d85b5a1c0d",
+                                        "xAccessor": "d2ce4a56-768f-4230-a097-cdc1ef6c145e"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "xlarge",
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": false,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yTitle": "Count"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "fb9f73a9-022d-4f08-a176-a4af0618cfc6",
+                    "w": 24,
+                    "x": 24,
+                    "y": 7
+                },
+                "panelIndex": "fb9f73a9-022d-4f08-a176-a4af0618cfc6",
+                "title": "Scoreboard [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-9c48411c-649e-4e2c-976e-15a98bd84b1e",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "9c48411c-649e-4e2c-976e-15a98bd84b1e": {
+                                            "columnOrder": [
+                                                "d268948d-fb3a-42f3-be99-e35966b7aa71",
+                                                "bcf5e58f-9ca6-4c82-a90d-3e4e12b3da34"
+                                            ],
+                                            "columns": {
+                                                "bcf5e58f-9ca6-4c82-a90d-3e4e12b3da34": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Total",
+                                                    "operationType": "max",
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.connections.total"
+                                                },
+                                                "d268948d-fb3a-42f3-be99-e35966b7aa71": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "bcf5e58f-9ca6-4c82-a90d-3e4e12b3da34"
+                                        ],
+                                        "layerId": "9c48411c-649e-4e2c-976e-15a98bd84b1e",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "d268948d-fb3a-42f3-be99-e35966b7aa71",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#00a69b",
+                                                "forAccessor": "bcf5e58f-9ca6-4c82-a90d-3e4e12b3da34"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "auto",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yTitle": "Connections"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "44d1c271-bc9a-41a8-b30c-ca8b04f04277",
+                    "w": 24,
+                    "x": 0,
+                    "y": 37
+                },
+                "panelIndex": "44d1c271-bc9a-41a8-b30c-ca8b04f04277",
+                "title": "Total connections [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-a7789028-079f-49ac-be7a-01cb273d989b",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "a7789028-079f-49ac-be7a-01cb273d989b": {
+                                            "columnOrder": [
+                                                "b84b73f9-e817-4b80-b610-1a4b153f5ad0",
+                                                "fac61003-2fc4-449d-9eed-43fa6dda8a10"
+                                            ],
+                                            "columns": {
+                                                "b84b73f9-e817-4b80-b610-1a4b153f5ad0": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "fac61003-2fc4-449d-9eed-43fa6dda8a10": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Bytes per sec",
+                                                    "operationType": "average",
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.bytes_per_sec"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "(data_stream.dataset:apache.status)"
+                            },
+                            "visualization": {
+                                "curveType": "LINEAR",
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "hideEndzones": false,
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "fac61003-2fc4-449d-9eed-43fa6dda8a10"
+                                        ],
+                                        "layerId": "a7789028-079f-49ac-be7a-01cb273d989b",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "b84b73f9-e817-4b80-b610-1a4b153f5ad0",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#6545da",
+                                                "forAccessor": "fac61003-2fc4-449d-9eed-43fa6dda8a10"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "auto",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yTitle": "Bytes per sec"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "7f45f1dc-cc1c-42a6-a691-a1a602ace63c",
+                    "w": 24,
+                    "x": 24,
+                    "y": 22
+                },
+                "panelIndex": "7f45f1dc-cc1c-42a6-a691-a1a602ace63c",
+                "title": "Bytes per sec [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-d2035e51-9934-4e76-a23e-4b039a3c6298",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "d2035e51-9934-4e76-a23e-4b039a3c6298": {
+                                            "columnOrder": [
+                                                "575f1bf5-96cb-40f7-a6a2-67aa25d60560",
+                                                "4962f547-53e0-49b5-9291-db9a6221e818",
+                                                "fb5a53c5-6b6c-4e86-86cf-5d59ef4e4d18"
+                                            ],
+                                            "columns": {
+                                                "4962f547-53e0-49b5-9291-db9a6221e818": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Busy workers",
+                                                    "operationType": "average",
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.workers.busy"
+                                                },
+                                                "575f1bf5-96cb-40f7-a6a2-67aa25d60560": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "fb5a53c5-6b6c-4e86-86cf-5d59ef4e4d18": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Idle workers",
+                                                    "operationType": "average",
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.workers.idle"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "(data_stream.dataset:apache.status)"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "4962f547-53e0-49b5-9291-db9a6221e818",
+                                            "fb5a53c5-6b6c-4e86-86cf-5d59ef4e4d18"
+                                        ],
+                                        "layerId": "d2035e51-9934-4e76-a23e-4b039a3c6298",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "575f1bf5-96cb-40f7-a6a2-67aa25d60560",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#00a69b",
+                                                "forAccessor": "4962f547-53e0-49b5-9291-db9a6221e818"
+                                            },
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#57c17b",
+                                                "forAccessor": "fb5a53c5-6b6c-4e86-86cf-5d59ef4e4d18"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "auto",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yTitle": "Workers"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "58f100e1-c5f9-4843-9bdf-a7ae9061ca20",
+                    "w": 24,
+                    "x": 0,
+                    "y": 7
+                },
+                "panelIndex": "58f100e1-c5f9-4843-9bdf-a7ae9061ca20",
+                "title": "Workers [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-bf531136-eb47-4c6f-bdbe-4cd280e9a4e6",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "bf531136-eb47-4c6f-bdbe-4cd280e9a4e6": {
+                                            "columnOrder": [
+                                                "61bb1fe9-8b02-467e-8626-e4b63233bed1",
+                                                "0a6b3d02-bfe8-4b42-a6f4-6ee2668f0d98",
+                                                "7f452acc-e255-4e23-b7e0-51cf55f30dc6",
+                                                "21bea96c-19a6-4108-bff2-0874c8af6bea"
+                                            ],
+                                            "columns": {
+                                                "0a6b3d02-bfe8-4b42-a6f4-6ee2668f0d98": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Writing",
+                                                    "operationType": "max",
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.connections.async.writing"
+                                                },
+                                                "21bea96c-19a6-4108-bff2-0874c8af6bea": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Closing",
+                                                    "operationType": "max",
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.connections.async.closing"
+                                                },
+                                                "61bb1fe9-8b02-467e-8626-e4b63233bed1": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "7f452acc-e255-4e23-b7e0-51cf55f30dc6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Keep alive",
+                                                    "operationType": "max",
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.connections.async.keep_alive"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "0a6b3d02-bfe8-4b42-a6f4-6ee2668f0d98",
+                                            "7f452acc-e255-4e23-b7e0-51cf55f30dc6",
+                                            "21bea96c-19a6-4108-bff2-0874c8af6bea"
+                                        ],
+                                        "layerId": "bf531136-eb47-4c6f-bdbe-4cd280e9a4e6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "61bb1fe9-8b02-467e-8626-e4b63233bed1",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#00a69b",
+                                                "forAccessor": "0a6b3d02-bfe8-4b42-a6f4-6ee2668f0d98"
+                                            },
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#57c17b",
+                                                "forAccessor": "7f452acc-e255-4e23-b7e0-51cf55f30dc6"
+                                            },
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#6f87d8",
+                                                "forAccessor": "21bea96c-19a6-4108-bff2-0874c8af6bea"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "auto",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yTitle": "Connections"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "de79f71b-cc47-40e7-b958-63d87a14fa97",
+                    "w": 24,
+                    "x": 24,
+                    "y": 37
+                },
+                "panelIndex": "de79f71b-cc47-40e7-b958-63d87a14fa97",
+                "title": "Connections [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-93d4224a-162f-4c5a-8eab-b51b2ae338d2",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "93d4224a-162f-4c5a-8eab-b51b2ae338d2": {
+                                            "columnOrder": [
+                                                "ecc24945-a05d-46a9-aea7-7751b36ac15b",
+                                                "95a58c50-fd7f-4d13-a24f-bca8ff8a8d06",
+                                                "55c21dee-0c99-4b2a-ab4a-9274cd0e5e57",
+                                                "f7e29362-28fa-4d7f-bd57-3f648ac095cd",
+                                                "486c191d-d979-418a-b78a-08f526b324ef"
+                                            ],
+                                            "columns": {
+                                                "486c191d-d979-418a-b78a-08f526b324ef": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Load per 15 min",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.load.15"
+                                                },
+                                                "55c21dee-0c99-4b2a-ab4a-9274cd0e5e57": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Load per 1 min",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.load.1"
+                                                },
+                                                "95a58c50-fd7f-4d13-a24f-bca8ff8a8d06": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "ecc24945-a05d-46a9-aea7-7751b36ac15b": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 5 values of host.hostname",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f7e29362-28fa-4d7f-bd57-3f648ac095cd",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "host.hostname"
+                                                },
+                                                "f7e29362-28fa-4d7f-bd57-3f648ac095cd": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Load per 5 min",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.load.5"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "(data_stream.dataset:apache.status)"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "emphasizeFitting": true,
+                                "fittingFunction": "Linear",
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "55c21dee-0c99-4b2a-ab4a-9274cd0e5e57",
+                                            "f7e29362-28fa-4d7f-bd57-3f648ac095cd",
+                                            "486c191d-d979-418a-b78a-08f526b324ef"
+                                        ],
+                                        "layerId": "93d4224a-162f-4c5a-8eab-b51b2ae338d2",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "ecc24945-a05d-46a9-aea7-7751b36ac15b",
+                                        "xAccessor": "95a58c50-fd7f-4d13-a24f-bca8ff8a8d06"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "xlarge",
+                                    "position": "right",
+                                    "shouldTruncate": false
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yTitle": "Count"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "a855f0c8-cac9-4ebe-bce1-91fff3c18668",
+                    "w": 24,
+                    "x": 0,
+                    "y": 52
+                },
+                "panelIndex": "a855f0c8-cac9-4ebe-bce1-91fff3c18668",
+                "title": "Average server load [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-6327731b-2cb9-4f8c-bc07-c8e799b56d37",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "indexpattern": {
+                                    "layers": {
+                                        "6327731b-2cb9-4f8c-bc07-c8e799b56d37": {
+                                            "columnOrder": [
+                                                "c3c68993-b7ea-43ec-99ff-57e89e39555b",
+                                                "5a671590-a106-4438-a96f-9f2f7164bffd",
+                                                "f136087d-75f7-40fe-842f-daa64ae7d1c7",
+                                                "491e0e96-f1b0-42a9-baf1-bdc77efb782a",
+                                                "fe117f49-f67f-45da-8a40-6fc6369a4afc",
+                                                "a8748731-8651-4274-a524-9bcdbb7ce526",
+                                                "76ce0b8c-4cb2-4d26-93bc-20c1a6274b09"
+                                            ],
+                                            "columns": {
+                                                "491e0e96-f1b0-42a9-baf1-bdc77efb782a": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "CPU user",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.cpu.user"
+                                                },
+                                                "5a671590-a106-4438-a96f-9f2f7164bffd": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "76ce0b8c-4cb2-4d26-93bc-20c1a6274b09": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "CPU children system",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.cpu.children_system"
+                                                },
+                                                "a8748731-8651-4274-a524-9bcdbb7ce526": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "CPU children user",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.cpu.children_user"
+                                                },
+                                                "c3c68993-b7ea-43ec-99ff-57e89e39555b": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 5 values of host.hostname",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "f136087d-75f7-40fe-842f-daa64ae7d1c7",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "host.hostname"
+                                                },
+                                                "f136087d-75f7-40fe-842f-daa64ae7d1c7": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "CPU load",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.cpu.load"
+                                                },
+                                                "fe117f49-f67f-45da-8a40-6fc6369a4afc": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "CPU system",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache.status.cpu.system"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": "(data_stream.dataset:apache.status)"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "emphasizeFitting": true,
+                                "fittingFunction": "Linear",
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "f136087d-75f7-40fe-842f-daa64ae7d1c7",
+                                            "491e0e96-f1b0-42a9-baf1-bdc77efb782a",
+                                            "fe117f49-f67f-45da-8a40-6fc6369a4afc",
+                                            "a8748731-8651-4274-a524-9bcdbb7ce526",
+                                            "76ce0b8c-4cb2-4d26-93bc-20c1a6274b09"
+                                        ],
+                                        "layerId": "6327731b-2cb9-4f8c-bc07-c8e799b56d37",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "c3c68993-b7ea-43ec-99ff-57e89e39555b",
+                                        "xAccessor": "5a671590-a106-4438-a96f-9f2f7164bffd"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "xlarge",
+                                    "position": "right",
+                                    "shouldTruncate": false
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yTitle": "Count"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "908bb0f9-4d98-469d-9351-424a5196803f",
+                    "w": 24,
+                    "x": 24,
+                    "y": 52
+                },
+                "panelIndex": "908bb0f9-4d98-469d-9351-424a5196803f",
+                "title": "CPU usage [Metrics Apache]",
+                "type": "lens",
+                "version": "8.3.0"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Metrics Apache] Overview",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.3.0",
+    "id": "apache-Metrics-Apache-HTTPD-server-status",
+    "migrationVersion": {
+        "dashboard": "8.3.0"
+    },
+    "references": [
+        {
+            "id": "apache-22057f20-3a12-11eb-8946-296aab7b13db",
+            "name": "7b7a1f18-e274-4f4e-a3b3-3760e7896897:panel_7b7a1f18-e274-4f4e-a3b3-3760e7896897",
+            "type": "visualization"
+        },
+        {
+            "id": "metrics-*",
+            "name": "bcaad3c3-d62c-44bd-8e76-f00cb8a7f0eb:indexpattern-datasource-layer-f7f31753-87a3-44c8-8be7-d11de2e96e18",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "ea52006e-efe5-499a-88e7-2843258d6905:indexpattern-datasource-layer-5db9209c-0470-4d6c-9099-6a61d16182e5",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "9386f867-d876-448b-b5fb-cc39eefb09cd:indexpattern-datasource-layer-5ad06229-ad00-4090-a067-bfd4982a8e5d",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "fb9f73a9-022d-4f08-a176-a4af0618cfc6:indexpattern-datasource-layer-0154148b-c83a-4999-aacf-d096779b4a2d",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "44d1c271-bc9a-41a8-b30c-ca8b04f04277:indexpattern-datasource-layer-9c48411c-649e-4e2c-976e-15a98bd84b1e",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "7f45f1dc-cc1c-42a6-a691-a1a602ace63c:indexpattern-datasource-layer-a7789028-079f-49ac-be7a-01cb273d989b",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "58f100e1-c5f9-4843-9bdf-a7ae9061ca20:indexpattern-datasource-layer-d2035e51-9934-4e76-a23e-4b039a3c6298",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "de79f71b-cc47-40e7-b958-63d87a14fa97:indexpattern-datasource-layer-bf531136-eb47-4c6f-bdbe-4cd280e9a4e6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a855f0c8-cac9-4ebe-bce1-91fff3c18668:indexpattern-datasource-layer-93d4224a-162f-4c5a-8eab-b51b2ae338d2",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "908bb0f9-4d98-469d-9351-424a5196803f:indexpattern-datasource-layer-6327731b-2cb9-4f8c-bc07-c8e799b56d37",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_8310f315-329a-45aa-90c2-925c542a3f1a:optionsListDataView",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "dashboard"
+}

--- a/code/go/internal/validator/semantic/testdata/dashboards/nats-with-query.json
+++ b/code/go/internal/validator/semantic/testdata/dashboards/nats-with-query.json
@@ -1,0 +1,245 @@
+{
+    "attributes": {
+        "description": "Overview of NATS server statistics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset: nats.log"
+                }
+            }
+        },
+        "optionsJSON": {
+            "darkTheme": false,
+            "hidePanelTitles": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "hidePanelTitles": false,
+                    "title": "Message Types Timeline"
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "1",
+                    "w": 17,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "1",
+                "panelRefName": "panel_0",
+                "title": "Message Types Timeline",
+                "version": "7.10.0"
+            },
+            {
+                "embeddableConfig": {
+                    "hidePanelTitles": false,
+                    "title": "Communication Directions"
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "2",
+                    "w": 17,
+                    "x": 31,
+                    "y": 0
+                },
+                "panelIndex": "2",
+                "panelRefName": "panel_1",
+                "title": "Communication Directions",
+                "version": "7.10.0"
+            },
+            {
+                "embeddableConfig": {
+                    "hidePanelTitles": false,
+                    "title": "Topics Timeline"
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "3",
+                    "w": 25,
+                    "x": 0,
+                    "y": 20
+                },
+                "panelIndex": "3",
+                "panelRefName": "panel_2",
+                "title": "Topics Timeline",
+                "version": "7.10.0"
+            },
+            {
+                "embeddableConfig": {
+                    "hidePanelTitles": false,
+                    "title": " Bytes Timeline",
+                    "vis": {
+                        "legendOpen": false
+                    }
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "4",
+                    "w": 12,
+                    "x": 11,
+                    "y": 11
+                },
+                "panelIndex": "4",
+                "panelRefName": "panel_3",
+                "title": " Bytes Timeline",
+                "version": "7.10.0"
+            },
+            {
+                "embeddableConfig": {
+                    "hidePanelTitles": false,
+                    "title": "Communication Directions Distribution",
+                    "vis": {
+                        "legendOpen": false
+                    }
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "5",
+                    "w": 11,
+                    "x": 0,
+                    "y": 11
+                },
+                "panelIndex": "5",
+                "panelRefName": "panel_4",
+                "title": "Communication Directions Distribution",
+                "version": "7.10.0"
+            },
+            {
+                "embeddableConfig": {
+                    "hidePanelTitles": false,
+                    "title": "Log Level Distribution",
+                    "vis": {
+                        "legendOpen": false
+                    }
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "6",
+                    "w": 11,
+                    "x": 37,
+                    "y": 11
+                },
+                "panelIndex": "6",
+                "panelRefName": "panel_5",
+                "title": "Log Level Distribution",
+                "version": "7.10.0"
+            },
+            {
+                "embeddableConfig": {
+                    "hidePanelTitles": false,
+                    "title": "Message Type Distribution",
+                    "vis": {
+                        "legendOpen": false
+                    }
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "7",
+                    "w": 14,
+                    "x": 17,
+                    "y": 0
+                },
+                "panelIndex": "7",
+                "panelRefName": "panel_6",
+                "title": "Message Type Distribution",
+                "version": "7.10.0"
+            },
+            {
+                "embeddableConfig": {
+                    "hidePanelTitles": false,
+                    "title": "Log Level Timeline"
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "8",
+                    "w": 14,
+                    "x": 23,
+                    "y": 11
+                },
+                "panelIndex": "8",
+                "panelRefName": "panel_7",
+                "title": "Log Level Timeline",
+                "version": "7.10.0"
+            },
+            {
+                "embeddableConfig": {
+                    "hidePanelTitles": false,
+                    "title": "Client IP Count Timeline"
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "9",
+                    "w": 22,
+                    "x": 25,
+                    "y": 20
+                },
+                "panelIndex": "9",
+                "panelRefName": "panel_8",
+                "title": "Client IP Count Timeline",
+                "version": "7.10.0"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Logs NATS] Overview",
+        "version": 1
+    },
+    "id": "nats-Logs-nats-overview",
+    "migrationVersion": {
+        "dashboard": "7.9.3"
+    },
+    "namespaces": [
+        "default"
+    ],
+    "references": [
+        {
+            "id": "nats-6987a800-41a8-11e9-a4da-b1df688edbcd",
+            "name": "panel_0",
+            "type": "visualization"
+        },
+        {
+            "id": "nats-0b2061d0-41ad-11e9-a4da-b1df688edbcd",
+            "name": "panel_1",
+            "type": "visualization"
+        },
+        {
+            "id": "nats-4a6d9ec0-41a8-11e9-a4da-b1df688edbcd",
+            "name": "panel_2",
+            "type": "visualization"
+        },
+        {
+            "id": "nats-c3d1ab80-41a8-11e9-a4da-b1df688edbcd",
+            "name": "panel_3",
+            "type": "visualization"
+        },
+        {
+            "id": "nats-7716c780-41ad-11e9-a4da-b1df688edbcd",
+            "name": "panel_4",
+            "type": "visualization"
+        },
+        {
+            "id": "nats-3f6cca40-41ae-11e9-a4da-b1df688edbcd",
+            "name": "panel_5",
+            "type": "visualization"
+        },
+        {
+            "id": "nats-7ed62870-41ae-11e9-a4da-b1df688edbcd",
+            "name": "panel_6",
+            "type": "visualization"
+        },
+        {
+            "id": "nats-04083600-41af-11e9-a4da-b1df688edbcd",
+            "name": "panel_7",
+            "type": "visualization"
+        },
+        {
+            "id": "nats-c669ae20-41ed-11e9-ac5c-71ffa38a62e3",
+            "name": "panel_8",
+            "type": "visualization"
+        }
+    ],
+    "type": "dashboard"
+}

--- a/code/go/internal/validator/semantic/testdata/dashboards/tomcat-with-filter.json
+++ b/code/go/internal/validator/semantic/testdata/dashboards/tomcat-with-filter.json
@@ -1,0 +1,1070 @@
+{
+    "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"48036e6b-bb5f-4779-8ff2-a0affc20a119\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"service.address\",\"title\":\"Host Name\",\"id\":\"48036e6b-bb5f-4779-8ff2-a0affc20a119\",\"existsSelected\":false,\"selectedOptions\":[],\"enhancements\":{}}},\"b59436ce-764c-468d-ab13-0eb522f11c5c\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"apache_tomcat.session.application_name\",\"title\":\"Application Name\",\"id\":\"b59436ce-764c-468d-ab13-0eb522f11c5c\",\"selectedOptions\":[],\"enhancements\":{},\"exclude\":true}}}"
+        },
+        "description": "This Apache Tomcat dashboard visualizes session data stream metrics.",
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "field": "event.dataset",
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "event.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "apache_tomcat.session"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "event.dataset": "apache_tomcat.session"
+                            }
+                        }
+                    }
+                ],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-0175242f-2671-474a-a828-deff61e43fb6",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "34b8c32b-1aaf-45de-bdb4-09081617f0c8",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "0175242f-2671-474a-a828-deff61e43fb6": {
+                                            "columnOrder": [
+                                                "83b48f4e-37fd-4965-a277-7fbc36cd10c4",
+                                                "227ea4ce-b872-4b6d-a4d6-b010fd3b7525",
+                                                "ebf4eedd-4933-4ed5-b63c-251ad89ce456"
+                                            ],
+                                            "columns": {
+                                                "227ea4ce-b872-4b6d-a4d6-b010fd3b7525": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "83b48f4e-37fd-4965-a277-7fbc36cd10c4": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Application name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "ebf4eedd-4933-4ed5-b63c-251ad89ce456",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "apache_tomcat.session.application_name"
+                                                },
+                                                "ebf4eedd-4933-4ed5-b63c-251ad89ce456": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "apache_tomcat.session.create.total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Created",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache_tomcat.session.create.total"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "34b8c32b-1aaf-45de-bdb4-09081617f0c8",
+                                        "key": "event.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "apache_tomcat.session"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "event.dataset": "apache_tomcat.session"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "ebf4eedd-4933-4ed5-b63c-251ad89ce456"
+                                        ],
+                                        "layerId": "0175242f-2671-474a-a828-deff61e43fb6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "83b48f4e-37fd-4965-a277-7fbc36cd10c4",
+                                        "xAccessor": "227ea4ce-b872-4b6d-a4d6-b010fd3b7525"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yTitle": "Sessions"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "a39adf70-8e40-4d80-a127-a1747a75be1f",
+                    "w": 24,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "a39adf70-8e40-4d80-a127-a1747a75be1f",
+                "title": "Created sessions over time [Metrics Apache Tomcat]",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-85bb5555-4581-4120-ab66-6ce66aeb4066",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "fa5f9b9a-65b0-452a-bcd0-1df3a33b1b3e",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "85bb5555-4581-4120-ab66-6ce66aeb4066": {
+                                            "columnOrder": [
+                                                "a97f3cfc-2145-4883-9f87-11126379918d",
+                                                "763d5a9f-ee92-4166-806c-8b25ee913968",
+                                                "1eebd32f-91cc-4ea3-83d7-4802a2b9d79c"
+                                            ],
+                                            "columns": {
+                                                "1eebd32f-91cc-4ea3-83d7-4802a2b9d79c": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "apache_tomcat.session.expire.total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Expired",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache_tomcat.session.expire.total"
+                                                },
+                                                "763d5a9f-ee92-4166-806c-8b25ee913968": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "a97f3cfc-2145-4883-9f87-11126379918d": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Application name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "1eebd32f-91cc-4ea3-83d7-4802a2b9d79c",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "apache_tomcat.session.application_name"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "fa5f9b9a-65b0-452a-bcd0-1df3a33b1b3e",
+                                        "key": "event.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "apache_tomcat.session"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "event.dataset": "apache_tomcat.session"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "1eebd32f-91cc-4ea3-83d7-4802a2b9d79c"
+                                        ],
+                                        "layerId": "85bb5555-4581-4120-ab66-6ce66aeb4066",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "a97f3cfc-2145-4883-9f87-11126379918d",
+                                        "xAccessor": "763d5a9f-ee92-4166-806c-8b25ee913968",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "auto",
+                                                "color": "#54b399",
+                                                "forAccessor": "1eebd32f-91cc-4ea3-83d7-4802a2b9d79c"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "show",
+                                "valuesInLegend": true,
+                                "yTitle": "Sessions"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "91d26f64-351f-420e-a37b-88a882ecba0e",
+                    "w": 24,
+                    "x": 24,
+                    "y": 0
+                },
+                "panelIndex": "91d26f64-351f-420e-a37b-88a882ecba0e",
+                "title": "Expired sessions per application [Metrics Apache Tomcat]",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-57b12f03-6995-4072-8994-d512e5700ee4",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "de6b5c32-5630-4877-8b24-be30c47ee9c1",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "57b12f03-6995-4072-8994-d512e5700ee4": {
+                                            "columnOrder": [
+                                                "7d7e1358-c253-4d02-bb79-fff128597de4",
+                                                "d2e27628-e345-4f9e-b06e-2543268355c1",
+                                                "0d2a1caf-d316-462a-b8bd-a05a6d058d77"
+                                            ],
+                                            "columns": {
+                                                "0d2a1caf-d316-462a-b8bd-a05a6d058d77": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "apache_tomcat.session.active.total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Current active",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache_tomcat.session.active.total"
+                                                },
+                                                "7d7e1358-c253-4d02-bb79-fff128597de4": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Application name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "0d2a1caf-d316-462a-b8bd-a05a6d058d77",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "apache_tomcat.session.application_name"
+                                                },
+                                                "d2e27628-e345-4f9e-b06e-2543268355c1": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "de6b5c32-5630-4877-8b24-be30c47ee9c1",
+                                        "key": "event.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "apache_tomcat.session"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "event.dataset": "apache_tomcat.session"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "0d2a1caf-d316-462a-b8bd-a05a6d058d77"
+                                        ],
+                                        "layerId": "57b12f03-6995-4072-8994-d512e5700ee4",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "7d7e1358-c253-4d02-bb79-fff128597de4",
+                                        "xAccessor": "d2e27628-e345-4f9e-b06e-2543268355c1"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yTitle": "Sessions"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "5922510e-e6a2-4f9c-aceb-83715cc3b539",
+                    "w": 24,
+                    "x": 0,
+                    "y": 14
+                },
+                "panelIndex": "5922510e-e6a2-4f9c-aceb-83715cc3b539",
+                "title": "Current active sessions over time [Metrics Apache Tomcat]",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "Time spent doing housekeeping and expiration for sessions",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-9b0dd57c-eb2b-434c-a7d6-21a8e5e83e8b",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "efe32f1b-651c-4ce4-a1e9-06cb0cf2d5af",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "9b0dd57c-eb2b-434c-a7d6-21a8e5e83e8b": {
+                                            "columnOrder": [
+                                                "110a6317-3f6c-4522-9c5a-f66baf19cd30",
+                                                "5b3ec5bb-5905-4cac-bb0e-5f830e4d63cd"
+                                            ],
+                                            "columns": {
+                                                "110a6317-3f6c-4522-9c5a-f66baf19cd30": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Application name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "5b3ec5bb-5905-4cac-bb0e-5f830e4d63cd",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "apache_tomcat.session.application_name"
+                                                },
+                                                "5b3ec5bb-5905-4cac-bb0e-5f830e4d63cd": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "apache_tomcat.session.processing_time: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Processing time(ms)",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache_tomcat.session.processing_time"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "efe32f1b-651c-4ce4-a1e9-06cb0cf2d5af",
+                                        "key": "event.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "apache_tomcat.session"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "event.dataset": "apache_tomcat.session"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "5b3ec5bb-5905-4cac-bb0e-5f830e4d63cd"
+                                        ],
+                                        "layerId": "9b0dd57c-eb2b-434c-a7d6-21a8e5e83e8b",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "xAccessor": "110a6317-3f6c-4522-9c5a-f66baf19cd30"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "show"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "2d408e1c-da52-4aed-b760-812f89f48184",
+                    "w": 24,
+                    "x": 24,
+                    "y": 14
+                },
+                "panelIndex": "2d408e1c-da52-4aed-b760-812f89f48184",
+                "title": "Session expiration processing time [Metric Apache Tomcat]",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-8533f30a-f59a-4f19-8a60-2231660778cf",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "1df29502-1178-4b06-b0c8-3009d0c3271b",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "8533f30a-f59a-4f19-8a60-2231660778cf": {
+                                            "columnOrder": [
+                                                "da9f5c00-8752-45b3-8ecc-d8260b2f9522",
+                                                "ede9710d-b7f7-40ca-91ac-4532bf0f9c26",
+                                                "e5699bbc-30d5-4eca-a198-bc9e0d08819b",
+                                                "8622a6d6-5901-49e2-a998-285029bdc82b",
+                                                "b90571b5-4b61-4a20-996a-f27afcf022e2"
+                                            ],
+                                            "columns": {
+                                                "8622a6d6-5901-49e2-a998-285029bdc82b": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "apache_tomcat.session.expire.total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Expired",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache_tomcat.session.expire.total"
+                                                },
+                                                "b90571b5-4b61-4a20-996a-f27afcf022e2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "apache_tomcat.session.rejected.count: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Rejected",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache_tomcat.session.rejected.count"
+                                                },
+                                                "da9f5c00-8752-45b3-8ecc-d8260b2f9522": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Application name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "ede9710d-b7f7-40ca-91ac-4532bf0f9c26",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "apache_tomcat.session.application_name"
+                                                },
+                                                "e5699bbc-30d5-4eca-a198-bc9e0d08819b": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "apache_tomcat.session.active.total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Current active",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache_tomcat.session.active.total"
+                                                },
+                                                "ede9710d-b7f7-40ca-91ac-4532bf0f9c26": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "apache_tomcat.session.create.total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Created",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "apache_tomcat.session.create.total"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "1df29502-1178-4b06-b0c8-3009d0c3271b",
+                                        "key": "event.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "apache_tomcat.session"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "event.dataset": "apache_tomcat.session"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "da9f5c00-8752-45b3-8ecc-d8260b2f9522",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "e5699bbc-30d5-4eca-a198-bc9e0d08819b",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "ede9710d-b7f7-40ca-91ac-4532bf0f9c26",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "8622a6d6-5901-49e2-a998-285029bdc82b",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "b90571b5-4b61-4a20-996a-f27afcf022e2",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "headerRowHeight": "auto",
+                                "layerId": "8533f30a-f59a-4f19-8a60-2231660778cf",
+                                "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
+                                "rowHeight": "auto"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "8ce83532-0623-4974-9280-b6c56c6b0c27",
+                    "w": 48,
+                    "x": 0,
+                    "y": 28
+                },
+                "panelIndex": "8ce83532-0623-4974-9280-b6c56c6b0c27",
+                "title": "Sessions overview [Metrics Apache Tomcat]",
+                "type": "lens",
+                "version": "8.7.0"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Metrics Apache Tomcat] Session",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-06-09T11:27:22.150Z",
+    "id": "apache_tomcat-2a331270-b8cd-11ed-a099-3791d000f969",
+    "migrationVersion": {
+        "dashboard": "8.7.0"
+    },
+    "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a39adf70-8e40-4d80-a127-a1747a75be1f:indexpattern-datasource-layer-0175242f-2671-474a-a828-deff61e43fb6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "a39adf70-8e40-4d80-a127-a1747a75be1f:34b8c32b-1aaf-45de-bdb4-09081617f0c8",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "91d26f64-351f-420e-a37b-88a882ecba0e:indexpattern-datasource-layer-85bb5555-4581-4120-ab66-6ce66aeb4066",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "91d26f64-351f-420e-a37b-88a882ecba0e:fa5f9b9a-65b0-452a-bcd0-1df3a33b1b3e",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "5922510e-e6a2-4f9c-aceb-83715cc3b539:indexpattern-datasource-layer-57b12f03-6995-4072-8994-d512e5700ee4",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "5922510e-e6a2-4f9c-aceb-83715cc3b539:de6b5c32-5630-4877-8b24-be30c47ee9c1",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "2d408e1c-da52-4aed-b760-812f89f48184:indexpattern-datasource-layer-9b0dd57c-eb2b-434c-a7d6-21a8e5e83e8b",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "2d408e1c-da52-4aed-b760-812f89f48184:efe32f1b-651c-4ce4-a1e9-06cb0cf2d5af",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "8ce83532-0623-4974-9280-b6c56c6b0c27:indexpattern-datasource-layer-8533f30a-f59a-4f19-8a60-2231660778cf",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "8ce83532-0623-4974-9280-b6c56c6b0c27:1df29502-1178-4b06-b0c8-3009d0c3271b",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_48036e6b-bb5f-4779-8ff2-a0affc20a119:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_b59436ce-764c-468d-ab13-0eb522f11c5c:optionsListDataView",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "dashboard"
+}

--- a/code/go/internal/validator/semantic/validate_kibana_filter_present.go
+++ b/code/go/internal/validator/semantic/validate_kibana_filter_present.go
@@ -1,0 +1,62 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package semantic
+
+import (
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/mitchellh/mapstructure"
+
+	ve "github.com/elastic/package-spec/v2/code/go/internal/errors"
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/pkgpath"
+)
+
+// ValidateKibanaFilterPresent checks that all the dashboards included in a package
+// contain a filter, so only data related to its datasets is queried.
+func ValidateKibanaFilterPresent(fsys fspath.FS) ve.ValidationErrors {
+	var errs ve.ValidationErrors
+
+	filePaths := path.Join("kibana", "dashboard", "*.json")
+	dashboardFiles, err := pkgpath.Files(fsys, filePaths)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("error finding Kibana dashboard files: %w", err))
+		return errs
+	}
+	for _, file := range dashboardFiles {
+		err = checkDashboardHasFilter(file)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("file \"%s\" is invalid: expected filter in dashboard: %w", fsys.Path(file.Path()), err))
+		}
+	}
+
+	return errs
+}
+
+func checkDashboardHasFilter(file pkgpath.File) error {
+	searchJSON, err := file.Values("$.attributes.kibanaSavedObjectMeta.searchSourceJSON")
+	if err != nil {
+		return fmt.Errorf("unable to find search definition: %w", err)
+	}
+
+	var search struct {
+		Filter []interface{} `mapstructure:"filter"`
+		Query  struct {
+			Query string `mapstructure:"query"`
+		} `mapstructure:"query"`
+	}
+	err = mapstructure.Decode(searchJSON, &search)
+	if err != nil {
+		return fmt.Errorf("unable to decode search definition: %w", err)
+	}
+
+	if len(search.Filter) == 0 && len(search.Query.Query) == 0 {
+		return errors.New("no filter found")
+	}
+
+	return nil
+}

--- a/code/go/internal/validator/semantic/validate_kibana_filter_present.go
+++ b/code/go/internal/validator/semantic/validate_kibana_filter_present.go
@@ -54,7 +54,10 @@ func checkDashboardHasFilter(file pkgpath.File) error {
 		return fmt.Errorf("unable to decode search definition: %w", err)
 	}
 
-	if len(search.Filter) == 0 && len(search.Query.Query) == 0 {
+	if len(search.Filter) == 0 {
+		if len(search.Query.Query) > 0 {
+			return errors.New("saved query found, but no filter")
+		}
 		return errors.New("no filter found")
 	}
 

--- a/code/go/internal/validator/semantic/validate_kibana_filter_present_test.go
+++ b/code/go/internal/validator/semantic/validate_kibana_filter_present_test.go
@@ -25,7 +25,7 @@ func TestCheckDashboardHasFilter(t *testing.T) {
 		},
 		{
 			dashboard: "testdata/dashboards/nats-with-query.json",
-			valid:     true,
+			valid:     false,
 		},
 		{
 			dashboard: "testdata/dashboards/tomcat-with-filter.json",

--- a/code/go/internal/validator/semantic/validate_kibana_filter_present_test.go
+++ b/code/go/internal/validator/semantic/validate_kibana_filter_present_test.go
@@ -7,10 +7,11 @@ package semantic
 import (
 	"testing"
 
-	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
-	"github.com/elastic/package-spec/v2/code/go/internal/pkgpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/pkgpath"
 )
 
 func TestCheckDashboardHasFilter(t *testing.T) {

--- a/code/go/internal/validator/semantic/validate_kibana_filter_present_test.go
+++ b/code/go/internal/validator/semantic/validate_kibana_filter_present_test.go
@@ -1,0 +1,49 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package semantic
+
+import (
+	"testing"
+
+	"github.com/elastic/package-spec/v2/code/go/internal/fspath"
+	"github.com/elastic/package-spec/v2/code/go/internal/pkgpath"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckDashboardHasFilter(t *testing.T) {
+	cases := []struct {
+		dashboard string
+		valid     bool
+	}{
+		{
+			dashboard: "testdata/dashboards/apache-no-filter.json",
+			valid:     false,
+		},
+		{
+			dashboard: "testdata/dashboards/nats-with-query.json",
+			valid:     true,
+		},
+		{
+			dashboard: "testdata/dashboards/tomcat-with-filter.json",
+			valid:     true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.dashboard, func(t *testing.T) {
+			files, err := pkgpath.Files(fspath.DirFS("."), c.dashboard)
+			require.NoError(t, err)
+			require.Len(t, files, 1)
+
+			err = checkDashboardHasFilter(files[0])
+			if c.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -135,6 +135,7 @@ func (s Spec) rules(pkgType string, rootSpec spectypes.ItemSpec) validationRules
 		{fn: semantic.ValidateKibanaObjectIDs, types: []string{"integration"}},
 		{fn: semantic.ValidateRoutingRulesAndDataset, types: []string{"integration"}, since: semver.MustParse("2.9.0")},
 		{fn: semantic.ValidateKibanaNoDanglingObjectIDs, since: semver.MustParse("3.0.0")},
+		{fn: semantic.ValidateKibanaFilterPresent, since: semver.MustParse("3.0.0")},
 	}
 
 	var validationRules validationRules

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/elastic/gojsonschema v1.2.1
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/otiai10/copy v1.12.0
 	github.com/stretchr/testify v1.8.4
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/otiai10/copy v1.12.0 h1:cLMgSQnXBs1eehF0Wy/FAGsgDTDmAqFR7rQylBb1nDY=
 github.com/otiai10/copy v1.12.0/go.mod h1:rSaLseMUsZFFbsFGc7wCJnnkTAvdc5L6VWxPE4308Ww=
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -19,6 +19,9 @@
   - description: Require owner.type field
     type: breaking-change
     link: https://github.com/elastic/package-spec/pull/604
+  - description: Require filter in dashboards to limit scope of queries
+    type: breaking-change
+    link: https://github.com/elastic/package-spec/pull/607
 - version: 2.12.0-next
   changes:
   - description: Add flag to manifests to indicate if a package or data stream requires root privileges

--- a/test/packages/bad_dangling_object_ids/kibana/dashboard/bad_dangling_object_ids-82273ffe-6acc-4f2f-bbee-c1004abba63d.json
+++ b/test/packages/bad_dangling_object_ids/kibana/dashboard/bad_dangling_object_ids-82273ffe-6acc-4f2f-bbee-c1004abba63d.json
@@ -33,6 +33,15 @@
                 "version": "7.5.2"
             }
         ],
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset: \"bad_dangling_object_ids.*\""
+                }
+            }
+        },
         "timeRestore": false,
         "title": "Dashboard  by References",
         "version": 1

--- a/test/packages/bad_dangling_object_ids/kibana/dashboard/bad_dangling_object_ids-82273ffe-6acc-4f2f-bbee-c1004abba63d.json
+++ b/test/packages/bad_dangling_object_ids/kibana/dashboard/bad_dangling_object_ids-82273ffe-6acc-4f2f-bbee-c1004abba63d.json
@@ -35,11 +35,35 @@
         ],
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "field": "event.dataset",
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "event.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "bad_dangling_object_ids.foo"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "event.dataset": "bad_dangling_object_ids.foo"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
-                    "query": "data_stream.dataset: \"bad_dangling_object_ids.*\""
+                    "query": ""
                 }
+
             }
         },
         "timeRestore": false,

--- a/test/packages/good_v3/kibana/dashboard/good_v3-dashboard-abc-1.json
+++ b/test/packages/good_v3/kibana/dashboard/good_v3-dashboard-abc-1.json
@@ -1,4 +1,39 @@
 {
-    "id": "good_v3-dashboard-abc-1",
-    "type": "dashboard"
+   "id": "good_v3-dashboard-abc-1",
+   "type": "dashboard",
+   "attributes": {
+     "description": "",
+     "hits": 0,
+     "kibanaSavedObjectMeta": {
+         "searchSourceJSON": {
+             "filter": [
+                 {
+                     "$state": {
+                         "store": "appState"
+                     },
+                     "meta": {
+                         "alias": null,
+                         "disabled": false,
+                         "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                         "key": "data_stream.dataset",
+                         "negate": false,
+                         "params": {
+                             "query": "good_v3.foo"
+                         },
+                         "type": "phrase"
+                     },
+                     "query": {
+                         "match_phrase": {
+                             "data_stream.dataset": "good_v3.foo"
+                         }
+                     }
+                 }
+             ],
+             "query": {
+                 "language": "kuery",
+                 "query": ""
+             }
+         }
+     }
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Fails validation if a dashboard doesn't have a filter.

## Why is it important?

See https://github.com/elastic/package-spec/issues/596

Dashboards without filters may be doing queries on unnecessarily large sets of data. Requiring
filters in dashboards will produce dashboards that limit the queries to the data of the data sets
collected by the package where they are included.

We don't require an specific filter to still give some liberty on the kind of filter that better suite each
dashboard included in a package.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/package-spec/issues/596