### PR TITLE
Prepare release 2.12.0

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -22,7 +22,7 @@
   - description: Require filter in dashboards to limit scope of queries
     type: breaking-change
     link: https://github.com/elastic/package-spec/pull/607
-- version: 2.12.0-next
+- version: 2.12.0
   changes:
   - description: Add flag to manifests to indicate if a package or data stream requires root privileges
     type: enhancement


### PR DESCRIPTION
It includes the new field to declare that an integration requires root in the agent. And additional checks for Package Spec v3.