### PR TITLE
Add new code to be able to filter legacy visualizations validation rule

### DIFF
--- a/code/go/internal/validator/semantic/validate_kibana_no_legacy_visualizations.go
+++ b/code/go/internal/validator/semantic/validate_kibana_no_legacy_visualizations.go
@@ -5,6 +5,7 @@
 package semantic
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/elastic/kbncontent"
@@ -31,7 +32,6 @@ func ValidateKibanaNoLegacyVisualizations(fsys fspath.FS) specerrors.ValidationE
 			continue
 		}
 
-
 		visMap, ok := visJSON.(map[string]interface{})
 		if !ok {
 			errs = append(errs, specerrors.NewStructuredErrorf("file \"%s\" is invalid: JSON of unexpected type %T", filePath, visJSON))
@@ -49,7 +49,10 @@ func ValidateKibanaNoLegacyVisualizations(fsys fspath.FS) specerrors.ValidationE
 			if result, err := desc.Editor(); err == nil {
 				editor = result
 			}
-			errs = append(errs, specerrors.NewStructuredErrorf("file \"%s\" is invalid: found legacy visualization \"%s\" (%s, %s)", filePath, desc.Title(), desc.SemanticType(), editor))
+			errs = append(errs, specerrors.NewStructuredError(
+				fmt.Errorf("file \"%s\" is invalid: found legacy visualization \"%s\" (%s, %s)", filePath, desc.Title(), desc.SemanticType(), editor),
+				specerrors.CodeKibanaLegacyVisualizations),
+			)
 		}
 	}
 
@@ -87,7 +90,9 @@ func ValidateKibanaNoLegacyVisualizations(fsys fspath.FS) specerrors.ValidationE
 				if result, err := desc.Editor(); err == nil {
 					editor = result
 				}
-				err := specerrors.NewStructuredErrorf("file \"%s\" is invalid: \"%s\" contains legacy visualization: \"%s\" (%s, %s)", filePath, dashboardTitle, desc.Title(), desc.SemanticType(), editor)
+				err := specerrors.NewStructuredError(
+					fmt.Errorf("file \"%s\" is invalid: \"%s\" contains legacy visualization: \"%s\" (%s, %s)", filePath, dashboardTitle, desc.Title(), desc.SemanticType(), editor),
+					specerrors.CodeKibanaLegacyVisualizations)
 				errs = append(errs, err)
 			}
 		}

--- a/code/go/pkg/specerrors/constants.go
+++ b/code/go/pkg/specerrors/constants.go
@@ -10,4 +10,5 @@ const (
 	CodeKibanaDashboardWithQueryButNoFilter = "SVR00001"
 	CodeKibanaDashboardWithoutFilter        = "SVR00002"
 	CodeKibanaDanglingObjectsIDs            = "SVR00003"
+	CodeKibanaLegacyVisualizations          = "SVR00004"
 )

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -230,13 +230,13 @@ func TestValidateFile(t *testing.T) {
 		"kibana_legacy_visualizations": {
 			"kibana/dashboard/kibana_legacy_visualizations-c36e9b90-596c-11ee-adef-4fe896364076.json",
 			[]string{
-				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"Legacy input control vis\" (input_control_vis, Aggs-based)",
-				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"TSVB time series\" (timeseries, TSVB)",
-				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"TSVB gauge\" (gauge, TSVB)",
-				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"Aggs-based table\" (table, Aggs-based)",
-				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"Aggs-based tag cloud\" (tagcloud, Aggs-based)",
-				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"\" (heatmap, Aggs-based)",
-				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"Timelion time series\" (timelion, Timelion)",
+				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"Legacy input control vis\" (input_control_vis, Aggs-based) (SVR00004)",
+				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"TSVB time series\" (timeseries, TSVB) (SVR00004)",
+				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"TSVB gauge\" (gauge, TSVB) (SVR00004)",
+				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"Aggs-based table\" (table, Aggs-based) (SVR00004)",
+				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"Aggs-based tag cloud\" (tagcloud, Aggs-based) (SVR00004)",
+				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"\" (heatmap, Aggs-based) (SVR00004)",
+				"\"Dashboard with mixed by-value visualizations\" contains legacy visualization: \"Timelion time series\" (timelion, Timelion) (SVR00004)",
 			},
 		},
 	}

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -25,6 +25,9 @@
   - description: Disallow legacy visualizations
     type: breaking-change
     link: https://github.com/elastic/package-spec/pull/610
+  - description: Add code to filter legacy visualizations validation rule
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/618
 - version: 2.12.1-next
   changes:
   - description: Allow to define expected values in fields definitions.


### PR DESCRIPTION
## What does this PR do?

This PR adds a new code error for those structured errors related to legacy visualizations introduced in https://github.com/elastic/package-spec/pull/610
## Why is it important?

It adds a mechanism to filter these errors (legacy visualizations) in the packages.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/package-spec/pull/610
