### PR TITLE
Fail validation when using non-GA spec in GA package

### DIFF
--- a/code/go/internal/packages/package.go
+++ b/code/go/internal/packages/package.go
@@ -37,6 +37,17 @@ func (p *Package) Path(names ...string) string {
 	return path.Join(append([]string{p.location}, names...)...)
 }
 
+// IsGA returns true if the package is GA.
+func (p *Package) IsGA() bool {
+	if p.Version.Prerelease() != "" {
+		return false
+	}
+	if p.Version.LessThan(semver.MustParse("1.0.0")) {
+		return false
+	}
+	return true
+}
+
 // NewPackage creates a new Package from a path to the package's root folder
 func NewPackage(pkgRootPath string) (*Package, error) {
 	info, err := os.Stat(pkgRootPath)

--- a/code/go/internal/validator/spec_test.go
+++ b/code/go/internal/validator/spec_test.go
@@ -42,6 +42,7 @@ func TestNoBetaFeatures_Package_GA(t *testing.T) {
 	// given
 	s := Spec{
 		*semver.MustParse("1.0.0"),
+		*semver.MustParse("1.0.0"),
 		fspath.DirFS("testdata/fakespec"),
 	}
 	pkg, err := packages.NewPackage("testdata/packages/features_ga")
@@ -54,6 +55,7 @@ func TestNoBetaFeatures_Package_GA(t *testing.T) {
 func TestBetaFeatures_Package_GA(t *testing.T) {
 	// given
 	s := Spec{
+		*semver.MustParse("1.0.0"),
 		*semver.MustParse("1.0.0"),
 		fspath.DirFS("testdata/fakespec"),
 	}
@@ -129,6 +131,7 @@ func TestFolderSpecInvalid(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
 			s := Spec{
+				c.version,
 				c.version,
 				c.spec,
 			}

--- a/code/go/pkg/specerrors/constants.go
+++ b/code/go/pkg/specerrors/constants.go
@@ -6,7 +6,12 @@ package specerrors
 
 // Constants to be used for the structured errors
 const (
-	UnassignedCode                          = ""
+	UnassignedCode = ""
+
+	// PSR - Package Spec [General] Rule
+	CodeNonGASpecOnGAPackage = "PSR00001"
+
+	// SVR - Semantic Validation Rules
 	CodeKibanaDashboardWithQueryButNoFilter = "SVR00001"
 	CodeKibanaDashboardWithoutFilter        = "SVR00002"
 	CodeKibanaDanglingObjectsIDs            = "SVR00003"

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,6 +2,11 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
+- version: 3.0.1-next
+  changes:
+  - description: Using non-GA versions of the spec in GA packages produces a filterable validation error instead of a warning.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/627
 - version: 3.0.0-next
   changes:
   - description: Validate processors used in ingest pipelines


### PR DESCRIPTION
## What does this PR do?

It produces an error instead of a warning when a GA package uses an unreleased Package Spec version. This error can be filtered out.

## Why is it important?

It makes more explicit that package developers should be careful about using unreleased Package Spec versions.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~ Manually tested, adding a test package would also require to add a mocked spec with fixed unreleased versions.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Related to https://github.com/elastic/package-spec/issues/539
