### PR TITLE
Allow metric_type without type for external fields

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -45,6 +45,9 @@
   - description: Require group or nested types for fields with subobjects
     type: bugfix
     link: https://github.com/elastic/package-spec/pull/629
+  - description: Allow metric_type without type for external fields
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/637
 - version: 2.13.0
   changes:
   - description: Allow to define expected values in fields definitions.

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -471,22 +471,25 @@ spec:
             required:
               - object_type
         then:
-          properties:
-            type:
-              enum:
-                - histogram
-                - aggregate_metric_double
-                - long
-                - integer
-                - short
-                - byte
-                - double
-                - float
-                - half_float
-                - scaled_float
-                - unsigned_long
-          required:
-            - type
+          oneOf:
+            - properties:
+                type:
+                  enum:
+                    - histogram
+                    - aggregate_metric_double
+                    - long
+                    - integer
+                    - short
+                    - byte
+                    - double
+                    - float
+                    - half_float
+                    - scaled_float
+                    - unsigned_long
+              required:
+                - type
+            - required:
+                - external
       - if:
           required:
             - object_type

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -557,9 +557,9 @@ versions:
   - before: 3.0.0
     patch:
       - op: remove
-        path: "/items/allOf/7" # removing requirement of type group when element has subfields
+        path: "/items/allOf/7" # removing requirement of object_type and minimum fields when type is object
       - op: remove
-        path: "/items/allOf/6" # removing requirement of object_type and minimum fields when type is object
+        path: "/items/allOf/6" # removing requirement of type group when element has subfields
   - before: 2.10.0
     patch:
       - op: remove

--- a/test/packages/good_v3/data_stream/foo/fields/external-fields.yml
+++ b/test/packages/good_v3/data_stream/foo/fields/external-fields.yml
@@ -6,3 +6,6 @@
   fields:
     - name: category
       external: ecs
+- name: timeseries
+  external: ecs
+  metric_type: gauge


### PR DESCRIPTION
## What does this PR do?

Allow the use of metric_type without defining a type.

## Why is it important?

To be able to define TSDB related settings for external fields.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes https://github.com/elastic/package-spec/issues/634.
