### PR TITLE
Allow to define limits of nested and total number of fields per data stream

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,6 +7,9 @@
   - description: Using non-GA versions of the spec in GA packages produces a filterable validation error instead of a warning.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/627
+  - description: Allow to define limits of nested and total number of fields.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/641
 - version: 3.0.0-rc1
   changes:
   - description: Validate processors used in ingest pipelines

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -194,13 +194,13 @@ spec:
                 mapping:
                   type: object
                   additionalProperties: false
-                  properties:
-                    dimension_fields:
+                  patternProperties:
+                    "^(dimension|nested|total)_fields$":
                       type: object
                       additionalProperties: false
                       properties:
                         limit:
-                          description: Limit on the number of dimension fields on this data stream.
+                          description: Limit on the number of fields of this kind on this data stream.
                           type: integer
                 sort:
                   type: object

--- a/test/packages/good_v3/data_stream/foo/manifest.yml
+++ b/test/packages/good_v3/data_stream/foo/manifest.yml
@@ -46,6 +46,15 @@ streams:
 dataset_is_prefix: true
 elasticsearch:
   index_template:
+    settings:
+      index:
+        mapping:
+          nested_fields:
+            limit: 80
+          total_fields:
+            limit: 5000
+          dimension_fields:
+            limit: 32
     mappings:
       dynamic: strict
     ingest_pipeline:


### PR DESCRIPTION
## What does this PR do?

Allow to define limits of nested and total number of fields per data stream.

Fix https://github.com/elastic/package-spec/issues/640.

## Why is it important?

Keep supporting settings used by some packages before v3, see https://github.com/elastic/package-spec/issues/640.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes https://github.com/elastic/package-spec/issues/640.