### PR TITLE
Allow to define number of shards in data stream settings

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,12 +7,17 @@
   - description: Using non-GA versions of the spec in GA packages produces a filterable validation error instead of a warning.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/627
-  - description: Remove deprecated `corpora.generator.size` in favour of `corpora.generator.total_events`
-    type: breaking-change
-    link: https://github.com/elastic/package-spec/pull/639
+- version: 3.0.0-rc2
+  changes:
   - description: Allow to define limits of nested and total number of fields.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/641
+  - description: Remove deprecated `corpora.generator.size` in favour of `corpora.generator.total_events`
+    type: breaking-change
+    link: https://github.com/elastic/package-spec/pull/639
+  - description: Allow to define number of shards in data stream settings.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/645
 - version: 3.0.0-rc1
   changes:
   - description: Validate processors used in ingest pipelines

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -226,6 +226,11 @@ spec:
                             enum:
                               - asc
                               - desc
+            number_of_shards:
+              description: Number of primary shards that the data stream should have.
+              type: integer
+              minimum: 1
+              default: 1
         mappings:
           description: Mappings section of index template
           type: object

--- a/test/packages/good_v3/data_stream/foo/manifest.yml
+++ b/test/packages/good_v3/data_stream/foo/manifest.yml
@@ -55,6 +55,7 @@ elasticsearch:
             limit: 5000
           dimension_fields:
             limit: 32
+      number_of_shards: 1
     mappings:
       dynamic: strict
     ingest_pipeline:


### PR DESCRIPTION
## What does this PR do?

Allow to define number of shards in data stream settings.

## Why is it important?

APM package needs to make explicit that some of its data streams require a single shard.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #644