### PR TITLE
Allow to set 'index: false'  in dynamic templates defined in data streams

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,6 +7,9 @@
   - description: Using non-GA versions of the spec in GA packages produces a filterable validation error instead of a warning
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/627
+  - description: 'Allow to set index: false in dynamic templates defined in data stream manifests'
+    type: enhancement
+    link: https://github.com/elastic/package-spec/issues/650
 - version: 3.0.0
   changes:
   - description: Validate processors used in ingest pipelines

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -300,6 +300,8 @@ spec:
                           $ref: "./fields/fields.spec.yml#/items/properties/default_metric"
                         ignore_above:
                           $ref: "./fields/fields.spec.yml#/items/properties/ignore_above"
+                        index:
+                          $ref: "./fields/fields.spec.yml#/items/properties/index"
                 patternProperties:
                   # Exception for fields imported by elastic-package when import_mappings is used.
                   # TODO: Allow this only on built packages.

--- a/test/packages/good_v3/data_stream/foo/manifest.yml
+++ b/test/packages/good_v3/data_stream/foo/manifest.yml
@@ -58,6 +58,21 @@ elasticsearch:
       number_of_shards: 1
     mappings:
       dynamic: strict
+      dynamic_templates:
+        - histogram:
+            mapping:
+              type: histogram
+        - summary:
+            mapping:
+              type: aggregate_metric_double
+              metrics:
+                - sum
+                - value_count
+              default_metric: value_count
+        - double:
+            mapping:
+              type: double
+              index: false
     ingest_pipeline:
       name: foobar
   privileges:


### PR DESCRIPTION
## What does this PR do?

Allow to set `index: false` in dynamic templates defined in data streams.

## Why is it important?

Package Spec v3 introduced validation for fields defined in manifests in data streams.  `index` was not added then, but this is [used by the APM package](https://github.com/elastic/apm-server/blob/5584a8aa2a999a3da3f656de66a15ace58f03665/apmpackage/apm/data_stream/app_metrics/manifest.yml#L33-L36).
In the case of the field in APM, it cannot be migrated to fields definitions because the definition is not based on the name of the field.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Needed for https://github.com/elastic/apm-server/pull/11822.