### PR TITLE
Fix error transformations loop and use error filters from test packages

### DIFF
--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -118,18 +118,15 @@ func processErrors(errs specerrors.ValidationErrors) specerrors.ValidationErrors
 	for _, e := range errs {
 		for _, msg := range msgTransforms {
 			if strings.Contains(e.Error(), msg.original) {
-				processedErrs = append(processedErrs,
-					specerrors.NewStructuredError(
-						errors.New(strings.Replace(e.Error(), msg.original, msg.new, 1)),
-						specerrors.UnassignedCode),
-				)
-				continue
+				e = specerrors.NewStructuredError(
+					errors.New(strings.Replace(e.Error(), msg.original, msg.new, 1)),
+					specerrors.UnassignedCode)
 			}
-			if substringInSlice(e.Error(), redundant) {
-				continue
-			}
-			processedErrs = append(processedErrs, e)
 		}
+		if substringInSlice(e.Error(), redundant) {
+			continue
+		}
+		processedErrs = append(processedErrs, e)
 	}
 
 	return processedErrs

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -5,6 +5,7 @@
 package validator
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -248,13 +249,6 @@ func TestValidateFile(t *testing.T) {
 		},
 	}
 
-	filter := specerrors.NewFilter(&specerrors.ConfigFilter{
-		Errors: specerrors.Processors{
-			// TODO: Actually fix the references instead of ignoring the error.
-			ExcludeChecks: []string{"SVR00004"},
-		},
-	})
-
 	for pkgName, test := range tests {
 		t.Run(pkgName, func(t *testing.T) {
 			pkgRootPath := filepath.Join("..", "..", "..", "..", "test", "packages", pkgName)
@@ -262,9 +256,13 @@ func TestValidateFile(t *testing.T) {
 
 			errs := ValidateFromPath(pkgRootPath)
 			if verrs, ok := errs.(specerrors.ValidationErrors); ok {
-				result, err := filter.Run(verrs)
-				require.NoError(t, err)
-				errs = result.Processed
+				filterConfig, err := specerrors.LoadConfigFilter(os.DirFS(pkgRootPath))
+				if !errors.Is(err, os.ErrNotExist) {
+					filter := specerrors.NewFilter(filterConfig)
+					result, err := filter.Run(verrs)
+					require.NoError(t, err)
+					errs = result.Processed
+				}
 			}
 
 			if test.expectedErrContains == nil {

--- a/test/packages/bad_dangling_object_ids/validation.yml
+++ b/test/packages/bad_dangling_object_ids/validation.yml
@@ -1,0 +1,3 @@
+errors:
+  exclude_checks:
+    - SVR00004  # References in dashboards.

--- a/test/packages/good_v3/validation.yml
+++ b/test/packages/good_v3/validation.yml
@@ -1,0 +1,3 @@
+errors:
+  exclude_checks:
+    - "PSR00001"

--- a/test/packages/kibana_legacy_visualizations/validation.yml
+++ b/test/packages/kibana_legacy_visualizations/validation.yml
@@ -1,0 +1,3 @@
+errors:
+  exclude_checks:
+    - SVR00004  # References in dashboards.


### PR DESCRIPTION
## What does this PR do?

A couple of fixes/enhancements in how we handle and test spec errors:
* Fix in error transformations that was preventing to add more of them.
* Validation test loads error filters from each test package instead of having a hard-coded configuration.

## Why is it important?

This allows to add more error message transformations, and more fine-grained error filtering on tests.

These issues were part of previous PRs, one of them was closed, so creating a separate PR to ensure that we merge these enhancements.

These are the PRs where these changes were leveraged:
* https://github.com/elastic/package-spec/pull/654
* https://github.com/elastic/package-spec/pull/665

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] ~~I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).~~ Not relevant.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
Previously part of:
* https://github.com/elastic/package-spec/pull/654
* https://github.com/elastic/package-spec/pull/665