### PR TITLE
Fix conversion to JSON of empty YAML arrays

### DIFF
--- a/code/go/internal/yamlschema/loader.go
+++ b/code/go/internal/yamlschema/loader.go
@@ -113,7 +113,7 @@ func expandItemKey(c interface{}) interface{} {
 
 	// c is an array
 	if cArr, isArray := c.([]interface{}); isArray {
-		var arr []interface{}
+		arr := []interface{}{}
 		for _, ca := range cArr {
 			arr = append(arr, expandItemKey(ca))
 		}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -172,7 +172,6 @@ func TestValidateFile(t *testing.T) {
 			"data_stream/foo_stream/manifest.yml",
 			[]string{
 				"field streams.0.vars.1: options is required",
-				"field streams.0.vars.2.options: Invalid type. Expected: array, given: null",
 				"field streams.0.vars.3: Must not be present",
 			},
 		},

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -12,6 +12,9 @@
   - description: Prepare for next version
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/681
+  - description: Fix validation of empty arrays in YAML files
+    type: bugfix
+    link: https://github.com/elastic/package-spec/issues/683
 - version: 3.0.3
   changes:
   - description: Do not require an object_type on objects with `enabled` set to `false`

--- a/test/packages/good_v2/data_stream/foo/fields/some_fields.yml
+++ b/test/packages/good_v2/data_stream/foo/fields/some_fields.yml
@@ -91,3 +91,6 @@
   expected_values:
     - artifact
     - directory
+- name: empty_expected_values
+  type: keyword
+  expected_values: []

--- a/test/packages/good_v3/data_stream/foo/fields/some_fields.yml
+++ b/test/packages/good_v3/data_stream/foo/fields/some_fields.yml
@@ -86,3 +86,6 @@
   metrics:
     - min
     - max
+- name: empty_expected_values
+  type: keyword
+  expected_values: []


### PR DESCRIPTION
## What does this PR do?

Initialize arrays when converting them from YAML to JSON.

## Why is it important?

We were not initializing arrays when converting from YAML to JSON, so the ones that don't have elements were kept as null values. This lead to unexpected error messages about unexpected null values.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes https://github.com/elastic/package-spec/issues/630
