### PR TITLE
Replace helper function by slices.Contains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@
 
 # Updates the spec in language libraries
 update: code/* compliance
-	@$(foreach lang,$^,make -C $(lang) update;)
+	@$(foreach lang,$^,set -e ; make -C $(lang) update;)
 
 # Checks that language libraries have latest specs
 check: code/* compliance
-	@$(foreach lang,$^,make -C $(lang) check;)
+	@$(foreach lang,$^,set -e ; make -C $(lang) check;)
 
 # Tests the language libraries' code
 test: code/*
-	@$(foreach lang,$^,make -C $(lang) test;)
+	@$(foreach lang,$^,set -e ; make -C $(lang) test;)
 
 # Tests the language libraries' code to produce the required test files for the CI
 test-ci: code/*
-	@$(foreach lang,$^,make -C $(lang) test-ci;)
+	@$(foreach lang,$^,set -e ; make -C $(lang) test-ci;)

--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -37,7 +37,7 @@ type validationRule func(pkg fspath.FS) specerrors.ValidationErrors
 
 type validationRules []validationRule
 
-// GASpecCheckVersion represents minimum version to start checking for unreleased versions of specs
+// GASpecCheckVersion represents minimum version to start checking for unreleased version of the spec
 var GASpecCheckVersion = semver.MustParse("3.0.1")
 
 // NewSpec creates a new Spec for the given version

--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -180,7 +181,7 @@ func (s Spec) rules(pkgType string, rootSpec spectypes.ItemSpec) validationRules
 			continue
 		}
 
-		if rule.types != nil && !stringSliceContains(rule.types, pkgType) {
+		if rule.types != nil && !slices.Contains(rule.types, pkgType) {
 			continue
 		}
 
@@ -188,15 +189,6 @@ func (s Spec) rules(pkgType string, rootSpec spectypes.ItemSpec) validationRules
 	}
 
 	return validationRules
-}
-
-func stringSliceContains(elems []string, v string) bool {
-	for _, a := range elems {
-		if a == v {
-			return true
-		}
-	}
-	return false
 }
 
 func (vr validationRules) validate(fsys fspath.FS) specerrors.ValidationErrors {

--- a/code/go/internal/validator/spec.go
+++ b/code/go/internal/validator/spec.go
@@ -36,6 +36,7 @@ type validationRule func(pkg fspath.FS) specerrors.ValidationErrors
 
 type validationRules []validationRule
 
+// GASpecCheckVersion represents minimum version to start checking for unreleased versions of specs
 var GASpecCheckVersion = semver.MustParse("3.0.1")
 
 // NewSpec creates a new Spec for the given version


### PR DESCRIPTION
## What does this PR do?

Fix Makefile to fail if some loop iteration fails.
Replace function for `slices.Contains` taking advantage of Go 1.21


## Why is it important?

Be sure that errors are detected. Currently, there is an error in `check-static` step:
https://buildkite.com/elastic/package-spec/builds/460#018c866f-fd28-4156-978c-8d2dd5d382e6/53-72

Ensure that `check-static` step fails: 
https://buildkite.com/elastic/package-spec/builds/463#018cca36-2d19-4011-bb9f-39d89d715edd


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~[ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~
- ~[ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
