### PR TITLE
Adds top level `volumes` property and `volume` definition

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -4,6 +4,9 @@
 ##
 - version: 3.1.0-next
   changes:
+  - description: Allowing volumes to be defined in custom-agent-deployer
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/689
   - description: Add support for subobjects in fields
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/573

--- a/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
+++ b/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
@@ -53,18 +53,18 @@ spec:
         "^[a-zA-Z0-9._-]+$":
           "$ref": "#/definitions/volume"
       additionalProperties: false
-  services:
-      description: Service list
-      type: object
-      additionalProperties:
-        description: Additional services
-        "$ref": "#/definitions/service"
-      properties:
-        docker-custom-agent:
-          description: Custom agent service definition
+    services:
+        description: Service list
+        type: object
+        additionalProperties:
+          description: Additional services
           "$ref": "#/definitions/service"
-      required:
-        - docker-custom-agent
+        properties:
+          docker-custom-agent:
+            description: Custom agent service definition
+            "$ref": "#/definitions/service"
+        required:
+          - docker-custom-agent
   required:
     - version
     - services

--- a/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
+++ b/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
@@ -14,33 +14,7 @@ spec:
           - required:
             - hostname
     volume:
-      type:
-        - object
-        - "null"
-      properties:
-        name:
-          type: string
-        driver:
-          type: string
-        driver_opts:
-          type: object
-          patternProperties:
-            "^.+$": 
-              type:
-                - string
-                - number
-        external:
-          type:
-            - boolean
-            - object
-          properties:
-            name:
-              deprecated: true
-              type: string
-          additionalProperties: false
-          patternProperties: { "^x-": {} }
-      additionalProperties: false
-      patternProperties: { "^x-": {} }
+      type: "null"
   properties:
     version:
       description: Docker Compose version

--- a/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
+++ b/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
@@ -54,17 +54,17 @@ spec:
           "$ref": "#/definitions/volume"
       additionalProperties: false
     services:
-        description: Service list
-        type: object
-        additionalProperties:
-          description: Additional services
+      description: Service list
+      type: object
+      additionalProperties:
+        description: Additional services
+        "$ref": "#/definitions/service"
+      properties:
+        docker-custom-agent:
+          description: Custom agent service definition
           "$ref": "#/definitions/service"
-        properties:
-          docker-custom-agent:
-            description: Custom agent service definition
-            "$ref": "#/definitions/service"
-        required:
-          - docker-custom-agent
+      required:
+        - docker-custom-agent
   required:
     - version
     - services

--- a/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
+++ b/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
@@ -13,12 +13,47 @@ spec:
         anyOf:
           - required:
             - hostname
+    volume:
+      type:
+        - object
+        - "null"
+      properties:
+        name:
+          type: string
+        driver:
+          type: string
+        driver_opts:
+          type: object
+          patternProperties:
+            "^.+$": 
+              type:
+                - string
+                - number
+        external:
+          type:
+            - boolean
+            - object
+          properties:
+            name:
+              deprecated: true
+              type: string
+          additionalProperties: false,
+          patternProperties: { "^x-": {} }
+      additionalProperties: false
+      patternProperties: { "^x-": {} }
   properties:
     version:
       description: Docker Compose version
       type: string
       pattern: '^2.3$'
-    services:
+    volumes:
+      description: Docker Compose volume declaration
+      type: object
+      patternProperties:
+        "^[a-zA-Z0-9._-]+$":
+          "$ref": "#/definitions/volume"
+      additionalProperties: false
+  services:
       description: Service list
       type: object
       additionalProperties:

--- a/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
+++ b/spec/integration/_dev/deploy/agent/custom-agent.spec.yml
@@ -37,7 +37,7 @@ spec:
             name:
               deprecated: true
               type: string
-          additionalProperties: false,
+          additionalProperties: false
           patternProperties: { "^x-": {} }
       additionalProperties: false
       patternProperties: { "^x-": {} }

--- a/test/packages/deploy_custom_agent/_dev/deploy/agent/custom-agent.yml
+++ b/test/packages/deploy_custom_agent/_dev/deploy/agent/custom-agent.yml
@@ -1,5 +1,9 @@
+volumes:
+  example_volume:
 version: "2.3"
 services:
   docker-custom-agent:
     host: pid
     user: root
+    volumes:
+      - example_volume:/volume_mount_point


### PR DESCRIPTION
## What does this PR do?

This adds the properties and definitions required to support validating docker compose 2.3 volumes in the custom-agent.yml of an elastic integration.


## Why is it important?

The cloud_defend integration requires mounting a volume for its system test. The current schema validation fails due to not having definitions for volumes in the custom-agent.yaml file.

## Checklist

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Relates https://github.com/elastic/integrations/pull/8567
