### PR TITLE
Added counted_keyword type

### DIFF
--- a/code/go/pkg/validator/validator_fields_test.go
+++ b/code/go/pkg/validator/validator_fields_test.go
@@ -95,7 +95,7 @@ func TestValidateFields(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long", "counted_keyword"`,
+				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long"`,
 			},
 		},
 		{
@@ -108,7 +108,7 @@ func TestValidateFields(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long", "counted_keyword"`,
+				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long"`,
 			},
 		},
 		{

--- a/code/go/pkg/validator/validator_fields_test.go
+++ b/code/go/pkg/validator/validator_fields_test.go
@@ -95,7 +95,7 @@ func TestValidateFields(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long"`,
+				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long", "counted_keyword"`,
 			},
 		},
 		{
@@ -108,7 +108,7 @@ func TestValidateFields(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long"`,
+				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long", "counted_keyword"`,
 			},
 		},
 		{

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,6 +7,9 @@
   - description: Add support for subobjects in fields
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/573
+  - description: Add support for counted_keyword field type in data streams
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/707
 - version: 3.0.5-next
   changes:
   - description: Disallow to use 'integration' as data stream name

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -17,7 +17,6 @@
     link: https://github.com/elastic/package-spec/pull/704
   - description: Add validation for ingest pipeline rename processor
     type: breaking-change
-    type: enhancement
     link: https://github.com/elastic/package-spec/pull/690
 - version: 3.0.4
   changes:

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -90,6 +90,7 @@ spec:
         - wildcard
         - version
         - unsigned_long
+        - counted_keyword
 
       description:
         description: Short description of field

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -592,6 +592,8 @@ versions:
         path: "/items/allOf/8" # removing subobjects when type is object
       - op: remove
         path: "/items/properties/subobjects"
+      - op: remove
+        path: "/items/properties/type/enum/35" #remove counted_keyword type
   - before: 3.0.3
     patch:
       - op: remove

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -589,11 +589,11 @@ versions:
   - before: 3.1.0
     patch:
       - op: remove
+        path: "/items/properties/type/enum/34" #remove counted_keyword type
+      - op: remove
         path: "/items/allOf/8" # removing subobjects when type is object
       - op: remove
         path: "/items/properties/subobjects"
-      - op: remove
-        path: "/items/properties/type/enum/35" #remove counted_keyword type
   - before: 3.0.3
     patch:
       - op: remove

--- a/test/packages/good_v3/data_stream/foo/fields/some_fields.yml
+++ b/test/packages/good_v3/data_stream/foo/fields/some_fields.yml
@@ -89,3 +89,8 @@
 - name: empty_expected_values
   type: keyword
   expected_values: []
+- name: some_counted_keyword
+  type: counted_keyword
+- name: counted_keyword_non_indexed
+  type: counted_keyword
+  index: false


### PR DESCRIPTION
## What does this PR do?

Adds `counted_keyword` as supported field type in data streams.

## Checklist


- [x] ~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~ I updated an existing test package instead
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

Part of #698 
