### PR TITLE
Prepare release 3.1.0

### DIFF
--- a/compliance/testdata/packages/counted_keyword/validation.yml
+++ b/compliance/testdata/packages/counted_keyword/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - "PSR00001" # GA package using non-GA features

--- a/compliance/testdata/packages/subobjects_false/validation.yml
+++ b/compliance/testdata/packages/subobjects_false/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - "PSR00001" # GA package using non-GA features

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,7 +2,7 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
-- version: 3.1.0-next
+- version: 3.1.0
   changes:
   - description: Add support for subobjects in fields
     type: enhancement
@@ -10,8 +10,6 @@
   - description: Add support for counted_keyword field type in data streams
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/707
-- version: 3.0.5-next
-  changes:
   - description: Disallow to use 'integration' as data stream name
     type: breaking-change
     link: https://github.com/elastic/package-spec/pull/704

--- a/spec/integration/elasticsearch/pipeline.spec.yml
+++ b/spec/integration/elasticsearch/pipeline.spec.yml
@@ -108,7 +108,7 @@ spec:
       description: List of processors to apply in case of failure.
       $ref: "#/definitions/processors"
 
-  versions:
+versions:
   - before: 3.1.0
     patch:
       - op: remove

--- a/spec/integration/elasticsearch/pipeline.spec.yml
+++ b/spec/integration/elasticsearch/pipeline.spec.yml
@@ -109,7 +109,7 @@ spec:
       $ref: "#/definitions/processors"
 
   versions:
-  - before: 3.0.5
+  - before: 3.1.0
     patch:
       - op: remove
         path: /definitions/processors/if # remove rename processor validation

--- a/test/packages/bad_ingest_pipeline/manifest.yml
+++ b/test/packages/bad_ingest_pipeline/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.0.5
+format_version: 3.1.0
 name: bad_ingest_pipeline
 title: "Package with bad ingest pipelines"
 version: 1.0.0

--- a/test/packages/skip_pipeline_rename_validation/manifest.yml
+++ b/test/packages/skip_pipeline_rename_validation/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.0.5
+format_version: 3.1.0
 name: skip_pipeline_rename_validation
 title: "Skip Ingest Pipeline Message Rename Validation"
 version: 1.0.0


### PR DESCRIPTION
Prepares release 3.1.0 by merging the changes we had for both 3.0.5 and 3.1.0.

Compliance testing for features required for 3.1.0 added in https://github.com/elastic/package-spec/pull/709. 