### PR TITLE
Discard variables ending with _file or _url as secret candidates

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,7 +7,7 @@
   - description: Prepare for next version
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/711
-  - description: Discard variables ending with _file as secret candidates
+  - description: Discard variables ending with _file or _url as secret candidates
     type: enhancement
     link: https://github.com/elastic/package-spec/issues/712
 - version: 3.1.0

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,6 +7,9 @@
   - description: Prepare for next version
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/711
+  - description: Discard variables ending with _file as secret candidates
+    type: enhancement
+    link: https://github.com/elastic/package-spec/issues/712
 - version: 3.1.0
   changes:
   - description: Add support for subobjects in fields

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -158,7 +158,7 @@ spec:
                  - not:
                      properties:
                        name:
-                         pattern: "_file$"
+                         pattern: "(_file|_url)$"
                - properties:
                    type:
                      const: password

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -151,9 +151,14 @@ spec:
                  - options
          - if:
              anyOf:
-               - properties:
-                   name:
-                     pattern: "(access_key|api_key|passphrase|password|secret|token)"
+               - allOf:
+                 - properties:
+                     name:
+                       pattern: "(access_key|api_key|passphrase|password|secret|token)"
+                 - not:
+                     properties:
+                       name:
+                         pattern: "_file$"
                - properties:
                    type:
                      const: password

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -19,6 +19,10 @@ vars:
     title: Package Level Secret
     show_user: true
     secret: true
+  - name: bearer_token_file
+    title: A file to a secret, but not a secret itself.
+    type: text
+    show_user: true
 policy_templates:
   - name: apache
     title: Apache logs and metrics

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -23,6 +23,10 @@ vars:
     title: A file to a secret, but not a secret itself.
     type: text
     show_user: true
+  - name: token_url
+    title: A URL to get secrets, but not a secret itself.
+    type: url
+    show_user: true
 policy_templates:
   - name: apache
     title: Apache logs and metrics


### PR DESCRIPTION
## What does this PR do?

Disable variables ending with `_file` or `_url` as secret candidates.

## Why is it important?

Reduce the number of false positives. Variables with potential secrets with these names use to refer to files that contain secrets, and not to secrets themselves.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Proposed by @tetianakravchenko in https://github.com/elastic/integrations/issues/8610#issuecomment-1931620943
