### PR TITLE
Deprecate dependencies.ecs.import_mappings

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,6 +7,9 @@
   - description: Prepare for next version
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/720
+  - description: Deprecate `dependencies.ecs.import_mappings` in favor of `ecs@mappings` from Elasticsearch
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/726
 - version: 3.1.2
   changes:
   - description: Introduce cloudsecurity_cdr category

--- a/spec/integration/_dev/build/build.spec.yml
+++ b/spec/integration/_dev/build/build.spec.yml
@@ -25,6 +25,7 @@ spec:
               description: >
                 Whether or not import common used dynamic templates and properties into the package
               default: false
+              deprecated: true
           required:
             - reference
   required:

--- a/spec/integration/_dev/build/build.spec.yml
+++ b/spec/integration/_dev/build/build.spec.yml
@@ -19,7 +19,7 @@ spec:
             reference:
               type: string
               description: Source reference
-              pattern: '^git@.+'
+              pattern: "^git@.+"
             import_mappings:
               type: boolean
               description: >
@@ -29,9 +29,13 @@ spec:
           required:
             - reference
   required:
-  - dependencies
+    - dependencies
 # JSON patches for newer versions should be placed on top
 versions:
+  - before: 3.1.3
+    patch:
+      - op: remove
+        path: "/properties/dependencies/properties/ecs/properties/import_mappings/deprecated"
   - before: 2.3.0
     patch:
       - op: remove

--- a/spec/integration/_dev/build/build.spec.yml
+++ b/spec/integration/_dev/build/build.spec.yml
@@ -25,7 +25,7 @@ spec:
               description: >
                 Whether or not import common used dynamic templates and properties into the package
               default: false
-              deprecated: true
+              deprecated: true # See: https://github.com/elastic/package-spec/pull/726
           required:
             - reference
   required:


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here WHAT changes you made in the PR.
-->

Deprecate `dependencies.ecs.import_mappings`

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Starting from stack version 8.13, Fleet adds the `ecs@mappings` component template to all index templates. With the `ecs@mappings`, integration no longer need to use the static legacy mappings embedded by elastic-package at build time.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/elastic-package/issues/1649
