### PR TITLE
Allow to include non-indexing definitions in embedded ECS templates

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,6 +10,9 @@
   - description: Deprecate `dependencies.ecs.import_mappings` in favor of `ecs@mappings` from Elasticsearch
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/726
+  - description: Allow to include `index` and `doc_values` in embedded ECS templates
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/729
 - version: 3.1.2
   changes:
   - description: Introduce cloudsecurity_cdr category

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -338,17 +338,21 @@ spec:
                         type: object
                         additionalProperties: false
                         properties:
-                          type:
-                             $ref: "./fields/fields.spec.yml#/items/properties/type"
-                          scaling_factor:
-                            $ref: "./fields/fields.spec.yml#/items/properties/scaling_factor"
-                          ignore_malformed:
-                            $ref: "./fields/fields.spec.yml#/items/properties/ignore_malformed"
+                          doc_values:
+                            $ref: "./fields/fields.spec.yml#/items/properties/doc_values"
                           fields:
                             type: object
                             minProperties: 1
                             additionalProperties:
                               $ref: "#/definitions/elasticsearch_index_template/properties/mappings/properties/dynamic_templates/items/patternProperties/^_embedded_ecs/properties/mapping"
+                          ignore_malformed:
+                            $ref: "./fields/fields.spec.yml#/items/properties/ignore_malformed"
+                          index:
+                            $ref: "./fields/fields.spec.yml#/items/properties/index"
+                          scaling_factor:
+                            $ref: "./fields/fields.spec.yml#/items/properties/scaling_factor"
+                          type:
+                             $ref: "./fields/fields.spec.yml#/items/properties/type"
         ingest_pipeline:
           description: Elasticsearch ingest pipeline settings
           type: object

--- a/test/packages/good_v3/data_stream/ecs_import_mappings/manifest.yml
+++ b/test/packages/good_v3/data_stream/ecs_import_mappings/manifest.yml
@@ -217,6 +217,18 @@ elasticsearch:
             mapping:
               type: keyword
             path_match: agent.name
+        - _embedded_ecs-event_original_non_indexed_keyword:
+            mapping:
+              type: keyword
+              index: false
+              doc_values: false
+            path_match: 'event.original'
+        - _embedded_ecs-x509_public_key_exponent_non_indexed_keyword:
+            mapping:
+              type: keyword
+              index: false
+              doc_values: false
+            path_match: '*.x509.public_key_exponent'
         - _embedded_ecs-service_name_to_keyword:
             mapping:
               type: keyword


### PR DESCRIPTION
## What does this PR do?

Allow to include non-indexing definitions in embedded ECS templates.

## Why is it important?

To support ECS fields that use `index: false` and/or `doc_values: false`.

See https://github.com/elastic/elastic-package/pull/1733.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Required for https://github.com/elastic/elastic-package/pull/1733.
