### PR TITLE
Prepare release 3.1.3

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -7,11 +7,8 @@
   - description: Add subobjects definition (at the data stream level)
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/727
-- version: 3.1.3-next
+- version: 3.1.3
   changes:
-  - description: Prepare for next version
-    type: enhancement
-    link: https://github.com/elastic/package-spec/pull/720
   - description: Deprecate `dependencies.ecs.import_mappings` in favor of `ecs@mappings` from Elasticsearch
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/726


### PR DESCRIPTION
This release includes https://github.com/elastic/package-spec/pull/729, that is a blocker for https://github.com/elastic/elastic-package/pull/1733.