### PR TITLE
Add support for policy test definitions

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -24,6 +24,9 @@
   - description: Fix filter detection in dashboards with map visualizations.
     type: bugfix
     link: https://github.com/elastic/package-spec/pull/750
+  - description: Add support for policy tests.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/issues/751
 - version: 3.1.4
   changes:
   - description: Add definitions for different deployment modes.

--- a/spec/input/_dev/test/spec.yml
+++ b/spec/input/_dev/test/spec.yml
@@ -6,3 +6,8 @@ spec:
       name: system
       required: false
       $ref: "../../../integration/data_stream/_dev/test/system/spec.yml"
+    - description: Folder containing policy tests
+      type: folder
+      name: policy
+      required: false
+      $ref: "../../../integration/data_stream/_dev/test/policy/spec.yml"

--- a/spec/integration/data_stream/_dev/test/policy/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/policy/config.spec.yml
@@ -1,0 +1,33 @@
+##
+## Describes the specification for a policy test configuration file
+##
+spec:
+  # Everything under here follows JSON schema (https://json-schema.org/), written as YAML for readability
+  type: object
+  additionalProperties: false
+  definitions:
+    vars:
+      description: Variables defined for the test case.
+      type:
+        - object
+        - "null"
+      additionalProperties: true
+      default: ~
+  properties:
+    skip:
+      $ref: "./../skip.spec.yml#/definitions/skip"
+    data_stream:
+      description: Configuration for the data stream.
+      type: object
+      additionalProperties: false
+      properties:
+        vars:
+          description: Variables used to configure settings defined in the data stream manifest.
+          $ref: "#/definitions/vars"
+    input:
+      description: The input of the package to test.
+      type: string
+    vars:
+      description: Variables used to configure settings defined in the package manifest.
+      $ref: "#/definitions/vars"
+

--- a/spec/integration/data_stream/_dev/test/policy/spec.yml
+++ b/spec/integration/data_stream/_dev/test/policy/spec.yml
@@ -1,0 +1,14 @@
+spec:
+  additionalContents: false
+  contents:
+    - description: Configuration of test case in yaml format.
+      type: file
+      pattern: '^test-[a-z0-9_.-]+.yml$'
+      contentMediaType: "application/x-yaml"
+      required: false
+      $ref: "./config.spec.yml"
+    - description: Expected policy for a test case.
+      type: file
+      pattern: '^test-[a-z0-9_.-]+.expected$'
+      contentMediaType: "application/x-yaml"
+      required: false

--- a/spec/integration/data_stream/_dev/test/spec.yml
+++ b/spec/integration/data_stream/_dev/test/spec.yml
@@ -16,3 +16,8 @@ spec:
       name: system
       required: false
       $ref: "./system/spec.yml"
+    - description: Folder containing policy tests
+      type: folder
+      name: policy
+      required: false
+      $ref: "./policy/spec.yml"

--- a/test/packages/good_input/_dev/test/policy/test-mysql.expected
+++ b/test/packages/good_input/_dev/test/policy/test-mysql.expected
@@ -1,0 +1,39 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: sql_input
+      name: test-mysql-sql_input
+      streams:
+        - data_stream:
+            dataset: sql_input.sql_query
+            elasticsearch:
+                dynamic_dataset: true
+                dynamic_namespace: true
+            type: metrics
+          driver: mysql
+          hosts:
+            - root:test@tcp(localhost:3306)/
+          metricsets:
+            - query
+          period: 10s
+          sql_query: SHOW GLOBAL STATUS LIKE 'Innodb_%';
+          sql_response_format: variables
+      type: sql/metrics
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - metrics-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/test/packages/good_input/_dev/test/policy/test-mysql.yml
+++ b/test/packages/good_input/_dev/test/policy/test-mysql.yml
@@ -1,0 +1,4 @@
+vars:
+  hosts:
+    - root:test@tcp(localhost:3306)/
+  sql_query: "SHOW GLOBAL STATUS LIKE 'Innodb_%';"

--- a/test/packages/good_input/_dev/test/policy/test-oracle.expected
+++ b/test/packages/good_input/_dev/test/policy/test-oracle.expected
@@ -1,0 +1,39 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: sql_input
+      name: test-oracle-sql_input
+      streams:
+        - data_stream:
+            dataset: sql_input.sql_query
+            elasticsearch:
+                dynamic_dataset: true
+                dynamic_namespace: true
+            type: metrics
+          driver: oracle
+          hosts:
+            - root:test@tcp(localhost)/
+          metricsets:
+            - query
+          period: 10s
+          sql_query: SELECT file_name, file_id, tablespace_name, bytes, status, maxbytes, user_bytes, online_status FROM sys.dba_data_files
+          sql_response_format: variables
+      type: sql/metrics
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - metrics-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/test/packages/good_input/_dev/test/policy/test-oracle.yml
+++ b/test/packages/good_input/_dev/test/policy/test-oracle.yml
@@ -1,0 +1,6 @@
+vars:
+  driver: "oracle"
+  hosts:
+    - root:test@tcp(localhost)/
+  # FIXME: This doesn't work as a multiline block.
+  sql_query: SELECT file_name, file_id, tablespace_name, bytes, status, maxbytes, user_bytes, online_status FROM sys.dba_data_files

--- a/test/packages/good_v3/data_stream/foo/_dev/test/policy/test-default.expected
+++ b/test/packages/good_v3/data_stream/foo/_dev/test/policy/test-default.expected
@@ -1,0 +1,34 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: apache
+      name: test-default-apache
+      streams:
+        - data_stream:
+            dataset: apache.access
+            type: logs
+          exclude_files:
+            - .gz$
+          paths:
+            - /var/logs/apache/access.log*
+          tags:
+            - apache-access
+      type: logfile
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-apache.access-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references: []

--- a/test/packages/good_v3/data_stream/foo/_dev/test/policy/test-default.yml
+++ b/test/packages/good_v3/data_stream/foo/_dev/test/policy/test-default.yml
@@ -1,0 +1,4 @@
+data_stream:
+  vars:
+    paths:
+      - "/var/logs/apache/access.log*"


### PR DESCRIPTION
## What does this PR do?

Add definitions for policy tests. These tests can be used to check that for a given user configuration the expected policies are generated.

## Why is it important?

Cover the gap of testing the package policies generated for a given configuration. This is kind of tested in system tests, but these new tests will allow to check the expected policies and more easily add more test cases, without needing a fully running system.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Part of https://github.com/elastic/elastic-package/issues/947
- Required for https://github.com/elastic/elastic-package/pull/1847