### PR TITLE
Fix dataset in compliance test

### DIFF
--- a/compliance/features/basic.feature
+++ b/compliance/features/basic.feature
@@ -10,5 +10,5 @@ Feature: Basic package types support
   @2.6.0
   Scenario: Input package can be installed
    Given the "basic_input" package is installed
-     And a policy is created with "basic_input" package, "test" template, "test" input, "logfile" input type and dataset "spec.input-test"
-    Then there is an index template "logs-spec.input-test" with pattern "logs-spec.input-test-*"
+     And a policy is created with "basic_input" package, "test" template, "test" input, "logfile" input type and dataset "spec.input_test"
+    Then there is an index template "logs-spec.input_test" with pattern "logs-spec.input_test-*"

--- a/compliance/testdata/packages/basic_input/agent/input/input.yml.hbs
+++ b/compliance/testdata/packages/basic_input/agent/input/input.yml.hbs
@@ -1,1 +1,3 @@
 paths: []
+data_stream:
+  dataset: "{{data_stream.dataset}}"


### PR DESCRIPTION
`-` is not allowed in datasets since https://github.com/elastic/kibana/pull/182925

Fixes issue found in https://buildkite.com/elastic/package-spec/builds/664#018f9c74-ef57-4b56-b8ad-9b390d847bae:
```
Step a policy is created with "basic_input" package, "test" template, "test" input, "logfile" input type and dataset "spec.input-test": failed to create package policy: request failed with status 400, body: {"statusCode":400,"error":"Bad Request","message":"Package policy is invalid: inputs.logfile.streams.basic_input.test.vars.data_stream.dataset: Dataset contains invalid characters"}
```

We may consider adding validation for these fields in the test config files as a follow up.