### PR TITLE
Add main configuration file for tests

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -13,6 +13,9 @@
   - description: Support store mapping option.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/748
+  - description: Add configuration folder _dev/test for global test settings
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/759
 - version: 3.1.5
   changes:
   - description: Add property to not fail system tests on ignored values in fields

--- a/spec/input/_dev/test/config.spec.yml
+++ b/spec/input/_dev/test/config.spec.yml
@@ -1,0 +1,22 @@
+##
+## Describes the specification for a system test configuration file
+##
+spec:
+  # Everything under here follows JSON schema (https://json-schema.org/), written as YAML for readability
+  type: object
+  additionalProperties: false
+  properties:
+    system:
+      description: Configuration for system tests
+      type: object
+      additionalProperties: false
+      properties:
+        parallel:
+          $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/parallel"
+    policy:
+      description: Configuration for policy tests
+      type: object
+      additionalProperties: false
+      properties:
+        parallel:
+           $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/parallel"

--- a/spec/input/_dev/test/config.spec.yml
+++ b/spec/input/_dev/test/config.spec.yml
@@ -13,6 +13,8 @@ spec:
       properties:
         parallel:
           $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/parallel"
+        skip:
+          $ref: "../../../integration/data_stream/_dev/test/config.spec.yml#/definitions/skip"
     policy:
       description: Configuration for policy tests
       type: object
@@ -20,3 +22,5 @@ spec:
       properties:
         parallel:
            $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/parallel"
+        skip:
+          $ref: "../../../integration/data_stream/_dev/test/config.spec.yml#/definitions/skip"

--- a/spec/input/_dev/test/config.spec.yml
+++ b/spec/input/_dev/test/config.spec.yml
@@ -8,19 +8,7 @@ spec:
   properties:
     system:
       description: Configuration for system tests
-      type: object
-      additionalProperties: false
-      properties:
-        parallel:
-          $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/parallel"
-        skip:
-          $ref: "../../../integration/data_stream/_dev/test/config.spec.yml#/definitions/skip"
+      $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/config_tests"
     policy:
       description: Configuration for policy tests
-      type: object
-      additionalProperties: false
-      properties:
-        parallel:
-           $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/parallel"
-        skip:
-          $ref: "../../../integration/data_stream/_dev/test/config.spec.yml#/definitions/skip"
+      $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/config_tests"

--- a/spec/input/_dev/test/spec.yml
+++ b/spec/input/_dev/test/spec.yml
@@ -11,3 +11,9 @@ spec:
       name: policy
       required: false
       $ref: "../../../integration/data_stream/_dev/test/policy/spec.yml"
+    - description: Common Configuration of tests.
+      type: file
+      pattern: '^config.yml$'
+      contentMediaType: "application/x-yaml"
+      required: false
+      $ref: "./config.spec.yml"

--- a/spec/integration/_dev/spec.yml
+++ b/spec/integration/_dev/spec.yml
@@ -17,3 +17,8 @@ spec:
       name: deploy
       required: false
       $ref: "./deploy/spec.yml"
+    - description: Folder containing configuration related test configuration.
+      type: folder
+      name: test
+      required: false
+      $ref: "./test/spec.yml"

--- a/spec/integration/_dev/test/config.spec.yml
+++ b/spec/integration/_dev/test/config.spec.yml
@@ -6,53 +6,29 @@ spec:
   type: object
   additionalProperties: false
   definitions:
-    parallel:
-      description: Tests defined can be run in parallel (default true).
-      type: boolean
-      default: true
+    config_tests:
+      type: object
+      additionalProperties: false
+      properties:
+        parallel:
+          description: Tests defined can be run in parallel (default true).
+          type: boolean
+          default: true
+        skip:
+          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
   properties:
     system:
       description: Configuration for system tests
-      type: object
-      additionalProperties: false
-      properties:
-        parallel:
-          $ref: "#/definitions/parallel"
-        skip:
-          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
+      $ref: "#/definitions/config_tests"
     pipeline:
       description: Configuration for pipeline tests
-      type: object
-      additionalProperties: false
-      properties:
-        parallel:
-          $ref: "#/definitions/parallel"
-        skip:
-          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
+      $ref: "#/definitions/config_tests"
     policy:
       description: Configuration for policy tests
-      type: object
-      additionalProperties: false
-      properties:
-        parallel:
-          $ref: "#/definitions/parallel"
-        skip:
-          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
+      $ref: "#/definitions/config_tests"
     static:
       description: Configuration for static tests
-      type: object
-      additionalProperties: false
-      properties:
-        parallel:
-          $ref: "#/definitions/parallel"
-        skip:
-          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
+      $ref: "#/definitions/config_tests"
     asset:
       description: Configuration for asset tests
-      type: object
-      additionalProperties: false
-      properties:
-        parallel:
-          $ref: "#/definitions/parallel"
-        skip:
-          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
+      $ref: "#/definitions/config_tests"

--- a/spec/integration/_dev/test/config.spec.yml
+++ b/spec/integration/_dev/test/config.spec.yml
@@ -10,10 +10,10 @@ spec:
       type: object
       additionalProperties: false
       properties:
-        parallel:
-          description: Tests defined can be run in parallel (default true).
+        sequential:
+          description: Tests defined should be run sequentially (default false).
           type: boolean
-          default: true
+          default: false
         skip:
           $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
   properties:

--- a/spec/integration/_dev/test/config.spec.yml
+++ b/spec/integration/_dev/test/config.spec.yml
@@ -1,0 +1,48 @@
+##
+## Describes the specification for a system test configuration file
+##
+spec:
+  # Everything under here follows JSON schema (https://json-schema.org/), written as YAML for readability
+  type: object
+  additionalProperties: false
+  definitions:
+    parallel:
+      description: Tests defined can be run in parallel (default true).
+      type: boolean
+      default: true
+  properties:
+    system:
+      description: Configuration for system tests
+      type: object
+      additionalProperties: false
+      properties:
+        parallel:
+          $ref: "#/definitions/parallel"
+    pipeline:
+      description: Configuration for pipeline tests
+      type: object
+      additionalProperties: false
+      properties:
+        parallel:
+          $ref: "#/definitions/parallel"
+    policy:
+      description: Configuration for policy tests
+      type: object
+      additionalProperties: false
+      properties:
+        parallel:
+          $ref: "#/definitions/parallel"
+    static:
+      description: Configuration for static tests
+      type: object
+      additionalProperties: false
+      properties:
+        parallel:
+          $ref: "#/definitions/parallel"
+    asset:
+      description: Configuration for asset tests
+      type: object
+      additionalProperties: false
+      properties:
+        parallel:
+          $ref: "#/definitions/parallel"

--- a/spec/integration/_dev/test/config.spec.yml
+++ b/spec/integration/_dev/test/config.spec.yml
@@ -18,6 +18,8 @@ spec:
       properties:
         parallel:
           $ref: "#/definitions/parallel"
+        skip:
+          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
     pipeline:
       description: Configuration for pipeline tests
       type: object
@@ -25,6 +27,8 @@ spec:
       properties:
         parallel:
           $ref: "#/definitions/parallel"
+        skip:
+          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
     policy:
       description: Configuration for policy tests
       type: object
@@ -32,6 +36,8 @@ spec:
       properties:
         parallel:
           $ref: "#/definitions/parallel"
+        skip:
+          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
     static:
       description: Configuration for static tests
       type: object
@@ -39,6 +45,8 @@ spec:
       properties:
         parallel:
           $ref: "#/definitions/parallel"
+        skip:
+          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
     asset:
       description: Configuration for asset tests
       type: object
@@ -46,3 +54,5 @@ spec:
       properties:
         parallel:
           $ref: "#/definitions/parallel"
+        skip:
+          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"

--- a/spec/integration/_dev/test/config.spec.yml
+++ b/spec/integration/_dev/test/config.spec.yml
@@ -10,8 +10,8 @@ spec:
       type: object
       additionalProperties: false
       properties:
-        sequential:
-          description: Tests defined should be run sequentially (default false).
+        parallel:
+          description: Tests defined can be run in parallel (default true).
           type: boolean
           default: false
         skip:

--- a/spec/integration/_dev/test/spec.yml
+++ b/spec/integration/_dev/test/spec.yml
@@ -7,3 +7,5 @@ spec:
       contentMediaType: "application/x-yaml"
       required: false
       $ref: "./config.spec.yml"
+
+

--- a/spec/integration/_dev/test/spec.yml
+++ b/spec/integration/_dev/test/spec.yml
@@ -1,0 +1,11 @@
+spec:
+  additionalContents: false
+  contents:
+    - description: Common Configuration of tests.
+      type: file
+      pattern: '^config.yml$'
+      contentMediaType: "application/x-yaml"
+      required: false
+      $ref: "./config.spec.yml"
+
+

--- a/spec/integration/_dev/test/spec.yml
+++ b/spec/integration/_dev/test/spec.yml
@@ -7,5 +7,3 @@ spec:
       contentMediaType: "application/x-yaml"
       required: false
       $ref: "./config.spec.yml"
-
-

--- a/test/packages/good_input/_dev/test/config.yml
+++ b/test/packages/good_input/_dev/test/config.yml
@@ -2,3 +2,6 @@ system:
   parallel: true
 policy:
   parallel: false
+  skip:
+    reason: ignoring all system tests
+    link: https://github.com/elastic/package-spec/issues/1

--- a/test/packages/good_input/_dev/test/config.yml
+++ b/test/packages/good_input/_dev/test/config.yml
@@ -1,7 +1,7 @@
 system:
-  sequential: true
+  parallel: true
 policy:
-  sequential: false
+  parallel: false
   skip:
-    reason: ignoring all policy tests
+    reason: ignoring all system tests
     link: https://github.com/elastic/package-spec/issues/1

--- a/test/packages/good_input/_dev/test/config.yml
+++ b/test/packages/good_input/_dev/test/config.yml
@@ -1,0 +1,4 @@
+system:
+  parallel: true
+policy:
+  parallel: false

--- a/test/packages/good_input/_dev/test/config.yml
+++ b/test/packages/good_input/_dev/test/config.yml
@@ -1,7 +1,7 @@
 system:
-  parallel: true
+  sequential: true
 policy:
-  parallel: false
+  sequential: false
   skip:
-    reason: ignoring all system tests
+    reason: ignoring all policy tests
     link: https://github.com/elastic/package-spec/issues/1

--- a/test/packages/good_v3/_dev/test/config.yml
+++ b/test/packages/good_v3/_dev/test/config.yml
@@ -1,0 +1,10 @@
+system:
+  parallel: true
+pipeline:
+  parallel: false
+asset:
+  parallel: false
+policy:
+  parallel: false
+static:
+  parallel: false

--- a/test/packages/good_v3/_dev/test/config.yml
+++ b/test/packages/good_v3/_dev/test/config.yml
@@ -1,13 +1,13 @@
 system:
-  parallel: true
+  sequential: true
   skip:
     reason: ignoring all system tests
     link: https://github.com/elastic/package-spec/issues/1
 pipeline:
-  parallel: false
+  sequential: false
 asset:
-  parallel: false
+  sequential: false
 policy:
-  parallel: false
+  sequential: false
 static:
-  parallel: false
+  sequential: false

--- a/test/packages/good_v3/_dev/test/config.yml
+++ b/test/packages/good_v3/_dev/test/config.yml
@@ -1,5 +1,8 @@
 system:
   parallel: true
+  skip:
+    reason: ignoring all system tests
+    link: https://github.com/elastic/package-spec/issues/1
 pipeline:
   parallel: false
 asset:

--- a/test/packages/good_v3/_dev/test/config.yml
+++ b/test/packages/good_v3/_dev/test/config.yml
@@ -1,13 +1,13 @@
 system:
-  sequential: true
+  parallel: true
   skip:
     reason: ignoring all system tests
     link: https://github.com/elastic/package-spec/issues/1
 pipeline:
-  sequential: false
+  parallel: false
 asset:
-  sequential: false
+  parallel: false
 policy:
-  sequential: false
+  parallel: false
 static:
-  sequential: false
+  parallel: false


### PR DESCRIPTION
## What does this PR do?

Adds a new configuration file to define global settings for tests: `_dev/test/config.yml`

## Why is it important?

This configuration file is going to be used to define if tests of specific runners could be run in parallel or they should be run sequentially.

Example of the contents of this configuration file:
```
system:
  parallel: true
policy:
  parallel: false
  skip:
    reason: flaky tests
    link: https://github.com/elastic/package-spec/issues/1
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Part of https://github.com/elastic/elastic-package/issues/787
