### PR TITLE
Prepare release 3.2.0

### DIFF
--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -12,6 +12,8 @@ cat <<EOF
         command: ".buildkite/scripts/run-installer-compliance.sh ${stack_version} ${spec_version}"
         artifact_paths:
           - compliance/report-*.xml
+        env:
+          ELASTIC_PACKAGE_CHECK_UPDATE_DISABLED: "true"
         agents:
           provider: "gcp"
 EOF
@@ -26,11 +28,8 @@ steps:
 EOF
 
 # Generate each test we want to do.
-## Requires changes in elastic-package to be able to test log_synthetic_mode test package
-# compliance_test 8.15.0-SNAPSHOT 3.2.0
-compliance_test 8.14.1-SNAPSHOT 3.1.5
+compliance_test 8.15.0-SNAPSHOT 3.2.0
 compliance_test 8.14.0 3.1.5
-compliance_test 8.13.4 3.1.5
 compliance_test 8.9.0 2.7.0
 
 # Annotate junit results.

--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -29,6 +29,7 @@ EOF
 compliance_test 8.15.0-SNAPSHOT 3.2.0
 compliance_test 8.14.1-SNAPSHOT 3.1.5
 compliance_test 8.14.0 3.1.5
+compliance_test 8.13.4 3.1.5
 compliance_test 8.9.0 2.7.0
 
 # Annotate junit results.

--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -27,8 +27,8 @@ EOF
 
 # Generate each test we want to do.
 compliance_test 8.15.0-SNAPSHOT 3.2.0
-compliance_test 8.14.1-SNAPSHOT 3.2.0
-compliance_test 8.14.0 3.2.0
+compliance_test 8.14.1-SNAPSHOT 3.1.5
+compliance_test 8.14.0 3.1.5
 compliance_test 8.9.0 2.7.0
 
 # Annotate junit results.

--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -26,8 +26,8 @@ steps:
 EOF
 
 # Generate each test we want to do.
-compliance_test 8.14.0-SNAPSHOT 3.1.5
-compliance_test 8.13.4 3.1.5
+compliance_test 8.14.1-SNAPSHOT 3.2.0
+compliance_test 8.14.0 3.2.0
 compliance_test 8.9.0 2.7.0
 
 # Annotate junit results.

--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -26,6 +26,7 @@ steps:
 EOF
 
 # Generate each test we want to do.
+compliance_test 8.15.0-SNAPSHOT 3.2.0
 compliance_test 8.14.1-SNAPSHOT 3.2.0
 compliance_test 8.14.0 3.2.0
 compliance_test 8.9.0 2.7.0

--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -26,7 +26,8 @@ steps:
 EOF
 
 # Generate each test we want to do.
-compliance_test 8.15.0-SNAPSHOT 3.2.0
+## Requires changes in elastic-package to be able to test log_synthetic_mode test package
+# compliance_test 8.15.0-SNAPSHOT 3.2.0
 compliance_test 8.14.1-SNAPSHOT 3.1.5
 compliance_test 8.14.0 3.1.5
 compliance_test 8.13.4 3.1.5

--- a/.buildkite/scripts/run-installer-compliance.sh
+++ b/.buildkite/scripts/run-installer-compliance.sh
@@ -4,14 +4,16 @@ set -euo pipefail
 
 WORKSPACE="$(pwd)"
 
-source .buildkite/scripts/install_deps.sh
-add_bin_path
+if [[ "${CI:-"false"}" == "true" ]]; then
+    source .buildkite/scripts/install_deps.sh
+    add_bin_path
 
-echo "--- Install Go :go:"
-with_go
+    echo "--- Install Go :go:"
+    with_go
 
-echo "--- Install docker-compose"
-with_docker_compose
+    echo "--- Install docker-compose"
+    with_docker_compose
+fi
 
 function usage() {
     echo "usage: $0 STACK_VERSION SPEC_VERSION"

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cucumber/godog"
+	messages "github.com/cucumber/messages/go/v21"
 	"golang.org/x/exp/slices"
 )
 
@@ -202,6 +203,15 @@ func thereIsATransformAlias(transformAliasName string) error {
 }
 
 func InitializeScenario(ctx *godog.ScenarioContext) {
+	ctx.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
+		skipped := slices.ContainsFunc(sc.Tags, func(elem *messages.PickleTag) bool {
+			return elem.Name == "@skip"
+		})
+		if skipped {
+			return ctx, godog.ErrSkip
+		}
+		return ctx, nil
+	})
 	ctx.Step(`^index template "([^"]*)" has a field "([^"]*)" with "([^"]*)"$`, indexTemplateHasAFieldWith)
 	ctx.Step(`^the "([^"]*)" package is installed$`, thePackageIsInstalled)
 	ctx.Step(`^a policy is created with "([^"]*)" package$`, aPolicyIsCreatedWithPackage)

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -78,7 +78,7 @@ func indexTemplateHasAFieldWith(indexTemplateName, fieldName, condition string) 
 	}
 	fmt.Printf("Found the following mapping for field %q:\n", fieldName)
 	fmt.Println(string(d))
-	return fmt.Errorf("conditon %q not satisfied by field %q", condition, fieldName)
+	return fmt.Errorf("condition %q not satisfied by field %q", condition, fieldName)
 }
 
 func thePackageIsInstalled(packageName string) error {
@@ -126,7 +126,6 @@ func findTestPackage(packageName string) (string, error) {
 	}
 
 	return "", godog.ErrPending
-
 }
 
 func aPolicyIsCreatedWithPackage(packageName string) error {

--- a/compliance/features/synthetic-source.feature
+++ b/compliance/features/synthetic-source.feature
@@ -1,6 +1,9 @@
 Feature: Synthetic source
   Support synthetic source
 
+  # Requires a new elastic-package release to be able to use -C flag  to run tests
+  # of a package located in another directory (https://github.com/elastic/elastic-package/pull/1914)
+  @skip
   @3.2.0
   Scenario: Installer leverages source true
    Given the "logs_synthetic_mode" package is installed

--- a/compliance/version.go
+++ b/compliance/version.go
@@ -89,6 +89,9 @@ func checkFeaturesVersions(t *testing.T, fs fs.FS, paths []string) {
 			return fmt.Errorf("no version tags")
 		}
 		for _, tag := range tags {
+			if tag.Name == "@skip" {
+				return nil
+			}
 			if !slices.Contains(versions, strings.TrimLeft(tag.Name, "@")) {
 				return fmt.Errorf("tag indicates an unknown spec version %s", tag.Name)
 			}

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -2,9 +2,9 @@
 ## This file documents changes in the package specification. It is NOT a package specification file.
 ## Newer entries go at the bottom of each in-development version.
 ##
-- version: 3.2.0-next
+- version: 3.2.0
   changes:
-  - description: Add subobjects definition (at the data stream level)
+  - description: Add subobjects definition (at the data stream level).
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/727
   - description: Allow to disable policies and variables in default deployment mode.
@@ -13,7 +13,7 @@
   - description: Support store mapping option.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/748
-  - description: Add configuration folder _dev/test for global test settings
+  - description: Add configuration folder _dev/test for global test settings.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/759
 - version: 3.1.5

--- a/spec/integration/_dev/build/build.spec.yml
+++ b/spec/integration/_dev/build/build.spec.yml
@@ -32,7 +32,7 @@ spec:
     - dependencies
 # JSON patches for newer versions should be placed on top
 versions:
-  - before: 3.2.0
+  - before: 3.1.3
     patch:
       - op: remove
         path: "/properties/dependencies/properties/ecs/properties/import_mappings/deprecated"

--- a/test/packages/logs_synthetic_mode/changelog.yml
+++ b/test/packages/logs_synthetic_mode/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.0"
+- version: "1.0.0-beta1"
   changes:
     - description: Initial draft of the package
       type: enhancement

--- a/test/packages/logs_synthetic_mode/changelog.yml
+++ b/test/packages/logs_synthetic_mode/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.0-beta1"
+- version: "1.0.0"
   changes:
     - description: Initial draft of the package
       type: enhancement

--- a/test/packages/logs_synthetic_mode/manifest.yml
+++ b/test/packages/logs_synthetic_mode/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.0
 name: logs_synthetic_mode
 title: "Logs package with synthetic mode"
-version: 1.0.0
+version: 1.0.0-beta1
 source:
   license: "Apache-2.0"
 description: "This is a package with a logs data stream that uses synthetic mode"

--- a/test/packages/logs_synthetic_mode/manifest.yml
+++ b/test/packages/logs_synthetic_mode/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.0
 name: logs_synthetic_mode
 title: "Logs package with synthetic mode"
-version: 1.0.0-beta1
+version: 1.0.0
 source:
   license: "Apache-2.0"
 description: "This is a package with a logs data stream that uses synthetic mode"

--- a/test/packages/logs_synthetic_mode/manifest.yml
+++ b/test/packages/logs_synthetic_mode/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - custom
 conditions:
   kibana:
-    version: "^8.13.2"
+    version: "^8.15.0"
   elastic:
     subscription: "basic"
 screenshots:


### PR DESCRIPTION
This PR prepares the changelog for the release 3.2.0

Updated compliance tests to start testing spec version 3.2.0 too. Required to add support to skip tests using a new tag `@skip`.