### PR TITLE
Use core-windows-2022 instead of unmaintained ci-windows-2022

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ env:
   SETUP_MAGE_VERSION: "latest"
   DOCKER_COMPOSE_VERSION: "v2.17.2"
   GO_LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
-  GO_WINDOWS_AGENT_IMAGE: "family/ci-windows-2022"
+  GO_WINDOWS_AGENT_IMAGE: "family/core-windows-2022"
 
 steps:
   - label: ":go: Run check-static"


### PR DESCRIPTION
The image family `ci-windows-2022` has been unmaintained for a while and has been replaced by `core-windows-2022`. This PR updates them to this instead.

Related to and mitigates issues from [incident 505.](https://elastic.slack.com/archives/C078RND5G5C)