### PR TITLE
[CI] Avoid setting username and token for git push

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -11,8 +11,10 @@ export GO_VERSION
 # https://buildkite.com/docs/pipelines/managing-log-output#redacted-environment-variables
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "package-spec-test-with-integrations" && "$BUILDKITE_STEP_KEY" == "pr-integrations" ]]; then
+    # required to set the git commit information
     GITHUB_USERNAME_SECRET="elasticmachine"
     export GITHUB_USERNAME_SECRET=$GITHUB_USERNAME_SECRET
     export GITHUB_EMAIL_SECRET="elasticmachine@elastic.co"
+    # required by `gh` commands
     export GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
 fi

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -58,12 +58,10 @@ set_git_config() {
     git config user.email "${GITHUB_EMAIL_SECRET}"
 }
 
-git_push_with_auth() {
-    local owner="$1"
-    local repository="$2"
-    local branch="$3"
+git_push() {
+    local branch="$1"
 
-    retry 3 git push https://${GITHUB_TOKEN}@github.com/${owner}/${repository}.git "${branch}"
+    retry 3 git push origin "${branch}"
 }
 
 clone_repository() {
@@ -156,7 +154,7 @@ create_or_update_pull_request() {
     update_dependency
 
     echo "--- Pushing branch ${INTEGRATIONS_PR_BRANCH} to integrations repository..."
-    git_push_with_auth "${INTEGRATIONS_GITHUB_OWNER}" "${INTEGRATIONS_GITHUB_REPO_NAME}" "${INTEGRATIONS_PR_BRANCH}"
+    git_push "${INTEGRATIONS_PR_BRANCH}"
 
     if [ -z "${integrations_pr_number}" ]; then
         echo "--- Creating pull request :github:"


### PR DESCRIPTION
## What does this PR do?

Update script to test with integrations repository to not use token for git push commands.

PR created in integrations: https://github.com/elastic/integrations/pull/10651
Buildkite Job triggered to create this PR: https://buildkite.com/elastic/package-spec-test-with-integrations/builds/44

## Related issues

- Follows #773 
