### PR TITLE
Add agent.base_image setting in system configuration file

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -20,7 +20,7 @@
   - description: Improved error message for unsupported package types.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/777
-  - description: Add new agent.type setting for system tests configuration files.
+  - description: Add new agent.base_image setting for system tests configuration files.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/788
 - version: 3.2.1

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -20,6 +20,9 @@
   - description: Improved error message for unsupported package types.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/777
+  - description: Add new agent.type setting for system tests configuration files.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/788
 - version: 3.2.1
   changes:
   - description: Improve error information for missing dataset field in manifest.

--- a/spec/integration/data_stream/_dev/test/system/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/system/config.spec.yml
@@ -42,7 +42,6 @@ spec:
           enum:
             - default
             - complete
-            - minimal
           default: "default"
         user:
           description: "User that runs the Elastic Agent process"

--- a/spec/integration/data_stream/_dev/test/system/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/system/config.spec.yml
@@ -36,8 +36,10 @@ spec:
           default: docker
         type:
           description: >
-            "Elastic Agent image to be used for testing. Setting default will be used the
-            same Elastic Agent image as the stack."
+            Elastic Agent image to be used for testing. Setting `default` will be used the
+            same Elastic Agent image as the stack. Setting `complete` will use the "complete"
+            image, that includes all supported collectors, a web browser and the required runtime
+            for synthetic testing.
           type: string
           enum:
             - default

--- a/spec/integration/data_stream/_dev/test/system/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/system/config.spec.yml
@@ -34,7 +34,7 @@ spec:
           enum:
             - docker
           default: docker
-        type:
+        base_image:
           description: >
             Elastic Agent image to be used for testing. Setting `default` will be used the
             same Elastic Agent image as the stack. Setting `complete` will use the "complete"

--- a/spec/integration/data_stream/_dev/test/system/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/system/config.spec.yml
@@ -34,6 +34,16 @@ spec:
           enum:
             - docker
           default: docker
+        type:
+          description: >
+            "Elastic Agent image to be used for testing. Setting default will be used the
+            same Elastic Agent image as the stack."
+          type: string
+          enum:
+            - default
+            - complete
+            - minimal
+          default: "default"
         user:
           description: "User that runs the Elastic Agent process"
           type: string

--- a/test/packages/good_v3/data_stream/agent_settings/_dev/test/system/test-default-config.yml
+++ b/test/packages/good_v3/data_stream/agent_settings/_dev/test/system/test-default-config.yml
@@ -2,6 +2,7 @@ wait_for_data_timeout: 10m
 vars: ~
 agent:
   runtime: docker
+  type: complete
   user: root
   pid_mode: host
   linux_capabilities:

--- a/test/packages/good_v3/data_stream/agent_settings/_dev/test/system/test-default-config.yml
+++ b/test/packages/good_v3/data_stream/agent_settings/_dev/test/system/test-default-config.yml
@@ -2,7 +2,7 @@ wait_for_data_timeout: 10m
 vars: ~
 agent:
   runtime: docker
-  type: complete
+  base_image: complete
   user: root
   pid_mode: host
   linux_capabilities:


### PR DESCRIPTION
## What does this PR do?

Add a new setting into the system test configuration file to indicate the Elastic Agent base image to be used for testing.

## Why is it important?

This new setting allows developers to set the required Elastic Agent base image for their packages.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Relates https://github.com/elastic/elastic-package/issues/2037
