### PR TITLE
Allow to use group-nested wherever nested can be used

### DIFF
--- a/code/go/pkg/validator/validator_fields_test.go
+++ b/code/go/pkg/validator/validator_fields_test.go
@@ -95,7 +95,7 @@ func TestValidateFields(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long"`,
+				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "group-nested", "flattened", "wildcard", "version", "unsigned_long"`,
 			},
 		},
 		{
@@ -108,7 +108,7 @@ func TestValidateFields(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "flattened", "wildcard", "version", "unsigned_long"`,
+				`field 0.type: 0.type must be one of the following: "aggregate_metric_double", "alias", "histogram", "constant_keyword", "text", "match_only_text", "keyword", "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float", "date", "date_nanos", "boolean", "binary", "integer_range", "float_range", "long_range", "double_range", "date_range", "ip_range", "group", "geo_point", "object", "ip", "nested", "group-nested", "flattened", "wildcard", "version", "unsigned_long"`,
 			},
 		},
 		{
@@ -155,7 +155,7 @@ func TestValidateFields(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				`field 0.type: 0.type must be one of the following: "group", "nested"`,
+				`field 0.type: 0.type must be one of the following: "group", "group-nested", "nested"`,
 			},
 		},
 		{

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -23,6 +23,9 @@
   - description: Add new agent.base_image setting for system tests configuration files.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/788
+  - description: Allow to use group-nested type wherever nested can be used.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/issues/789
 - version: 3.2.1
   changes:
   - description: Improve error information for missing dataset field in manifest.

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -86,6 +86,7 @@ spec:
         - object
         - ip
         - nested
+        - group-nested
         - flattened
         - wildcard
         - version
@@ -579,6 +580,7 @@ spec:
             type:
               enum:
                 - group
+                - group-nested
                 - nested
       - if:
           required:
@@ -603,7 +605,7 @@ versions:
   - before: 3.1.0
     patch:
       - op: remove
-        path: "/items/properties/type/enum/34" #remove counted_keyword type
+        path: "/items/properties/type/enum/35" #remove counted_keyword type
       - op: remove
         path: "/items/allOf/8" # removing subobjects when type is object
       - op: remove

--- a/test/packages/good_v3/data_stream/foo/fields/nested_fields.yml
+++ b/test/packages/good_v3/data_stream/foo/fields/nested_fields.yml
@@ -1,0 +1,22 @@
+- name: a
+  type: nested
+  include_in_parent: true
+- name: a.b
+  type: keyword
+- name: c
+  type: nested
+  include_in_root: true
+- name: nested
+  type: nested
+  fields:
+    - name: a
+      type: keyword
+    - name: b
+      type: long
+- name: groupnested
+  type: group-nested
+  fields:
+    - name: a
+      type: keyword
+    - name: b
+      type: long

--- a/test/packages/good_v3/data_stream/foo/fields/some_fields.yml
+++ b/test/packages/good_v3/data_stream/foo/fields/some_fields.yml
@@ -42,14 +42,6 @@
     - "panic now"
 - name: metric.*_bytes
   type: long
-- name: a
-  type: nested
-  include_in_parent: true
-- name: a.b
-  type: keyword
-- name: c
-  type: nested
-  include_in_root: true
 - name: c.d
   type: keyword
 - name: name-with-dash


### PR DESCRIPTION
nested and group-nested have different implementations in Fleet, for nested it doesn't generate any mapping for the subfields, but for group-nested it does. Integrations are using nested expecting that the subfields are going to have mappings.

Add group-nested to the spec, for all versions, as a synonymous of nested, so integrations can use it when supporting older versions of the stack. nested type should be fixed in Fleet to work also the same as group-nested.

Part of https://github.com/elastic/package-spec/issues/784