### PR TITLE
Add string_number_fields for tests

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -23,6 +23,9 @@
   - description: Add new agent.base_image setting for system tests configuration files.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/788
+  - description: Add new string_number_fields option for tests.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/791
 - version: 3.2.1
   changes:
   - description: Improve error information for missing dataset field in manifest.

--- a/spec/integration/data_stream/_dev/test/pipeline/common_config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/pipeline/common_config.spec.yml
@@ -18,3 +18,6 @@ spec:
     numeric_keyword_fields:
       description: List of keyword type fields allowed to have a numeric value.
       type: array
+    string_number_fields:
+      description: List of numeric type fields allowed to have a string value if it can be parsed as a number.
+      type: array

--- a/spec/integration/data_stream/_dev/test/pipeline/config_json.spec.yml
+++ b/spec/integration/data_stream/_dev/test/pipeline/config_json.spec.yml
@@ -14,3 +14,6 @@ spec:
     numeric_keyword_fields:
       description: List of keyword type fields allowed to have a numeric value.
       type: array
+    string_number_fields:
+      description: List of numeric type fields allowed to have a string value if it can be parsed as a number.
+      type: array

--- a/spec/integration/data_stream/_dev/test/pipeline/config_raw.spec.yml
+++ b/spec/integration/data_stream/_dev/test/pipeline/config_raw.spec.yml
@@ -18,3 +18,6 @@ spec:
     numeric_keyword_fields:
       description: List of keyword type fields allowed to have a numeric value.
       type: array
+    string_number_fields:
+      description: List of numeric type fields allowed to have a string value if it can be parsed as a number.
+      type: array

--- a/test/packages/good_v3/data_stream/foo/_dev/test/pipeline/test-common-config.yml
+++ b/test/packages/good_v3/data_stream/foo/_dev/test/pipeline/test-common-config.yml
@@ -1,2 +1,6 @@
 multiline:
   first_line_pattern: "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}"
+numeric_keyword_fields:
+  - "foo.code"
+string_number_fields:
+  - "foo.count"


### PR DESCRIPTION
## What does this PR do?

Add a new option similar to `numeric_keyword_fields`, that allows to indicate fields with numeric types that can accept string values if they can be parsed as numbers.

Find implementation in https://github.com/elastic/elastic-package/pull/2065.

## Why is it important?

This is needed to introduce validation on fields that were not being tested, without needing to modify the existing functionality (https://github.com/elastic/elastic-package/pull/2054).

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates to https://github.com/elastic/elastic-package/pull/2065.
- Relates to https://github.com/elastic/elastic-package/pull/2054.