### PR TITLE
Add systemd value for agent.base_image setting (system tests configuration)

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -25,7 +25,7 @@
     link: https://github.com/elastic/package-spec/pull/788
   - description: Add new value systemd for agent.base_image setting in system tests configuration files.
     type: enhancement
-    link: https://github.com/elastic/package-spec/pull/789
+    link: https://github.com/elastic/package-spec/pull/792
 - version: 3.2.1
   changes:
   - description: Improve error information for missing dataset field in manifest.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -23,6 +23,9 @@
   - description: Add new agent.base_image setting for system tests configuration files.
     type: enhancement
     link: https://github.com/elastic/package-spec/pull/788
+  - description: Add new value systemd for agent.base_image setting in system tests configuration files.
+    type: enhancement
+    link: https://github.com/elastic/package-spec/pull/789
 - version: 3.2.1
   changes:
   - description: Improve error information for missing dataset field in manifest.

--- a/spec/integration/data_stream/_dev/test/system/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/system/config.spec.yml
@@ -37,13 +37,15 @@ spec:
         base_image:
           description: >
             Elastic Agent image to be used for testing. Setting `default` will be used the
-            same Elastic Agent image as the stack. Setting `complete` will use the "complete"
-            image, that includes all supported collectors, a web browser and the required runtime
-            for synthetic testing.
+            same Elastic Agent image as the stack. Setting `systemd` will use  the image containing
+            all the binaries for running Beats (collectors) in a systemd based OS. Setting `complete`
+            will use the "complete" image, that includes all supported collectors plus a web browser
+            and the required runtime for synthetic testing.
           type: string
           enum:
             - default
             - complete
+            - systemd
           default: "default"
         user:
           description: "User that runs the Elastic Agent process"


### PR DESCRIPTION
## What does this PR do?

Add a new option `systemd` to the `agent.base_image`

## Why is it important?

This new setting is intended to run the system tests using an Elastic Agent image without the synthetics capabilities. It would run with an Elastic Agent image "just" with all the binaries for running Beats.

`elastic-package` implementation https://github.com/elastic/elastic-package/pull/2066

Examples:

Elastic Agent images used while testing with two different values of `agent.base_image`:

- Setting `agent.base_image: systemd`:
  ```
   $ docker ps --format "{{.Names}} {{.Image}}" |grep elastic-agent
  elastic-package-agent-nginx-access-34488-elastic-agent-1 docker.elastic.co/elastic-agent/elastic-agent:8.15.0-SNAPSHOT
  elastic-package-stack-elastic-agent-1 docker.elastic.co/elastic-agent/elastic-agent-complete:8.15.0-SNAPSHOT
  elastic-package-stack-fleet-server-1 docker.elastic.co/elastic-agent/elastic-agent-complete:8.15.0-SNAPSHOT
  ```
- Setting `agent.base_image: complete`:
  ```shell
   $ docker ps --format "{{.Names}} {{.Image}}" |grep elastic-agent
  elastic-package-agent-nginx-access-46446-elastic-agent-1 docker.elastic.co/elastic-agent/elastic-agent-complete:8.15.0-SNAPSHOT
  elastic-package-stack-elastic-agent-1 docker.elastic.co/elastic-agent/elastic-agent-complete:8.15.0-SNAPSHOT
  elastic-package-stack-fleet-server-1 docker.elastic.co/elastic-agent/elastic-agent-complete:8.15.0-SNAPSHOT
  ```


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).


## Related issues

- Relates https://github.com/elastic/elastic-package/pull/2066