### PR TITLE
Enable compliance test about synthetic source

### DIFF
--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -130,13 +130,16 @@ func findTestPackage(packageName string) (string, error) {
 }
 
 func aPolicyIsCreatedWithPackage(packageName string) error {
-	const version = "1.0.0" // TODO: Add support for package and version
+	const version = "1.0.0"
+	return aPolicyIsCreatedWithPackageAndVersion(packageName, version)
+}
 
+func aPolicyIsCreatedWithPackageAndVersion(packageName, packageVersion string) error {
 	kibana, err := NewKibanaClient()
 	if err != nil {
 		return err
 	}
-	_, err = kibana.CreatePolicyForPackage(packageName, version)
+	_, err = kibana.CreatePolicyForPackage(packageName, packageVersion)
 	if err != nil {
 		return err
 	}
@@ -215,6 +218,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^index template "([^"]*)" has a field "([^"]*)" with "([^"]*)"$`, indexTemplateHasAFieldWith)
 	ctx.Step(`^the "([^"]*)" package is installed$`, thePackageIsInstalled)
 	ctx.Step(`^a policy is created with "([^"]*)" package$`, aPolicyIsCreatedWithPackage)
+	ctx.Step(`^a policy is created with "([^"]*)" package and "([^"]*)" version$`, aPolicyIsCreatedWithPackageAndVersion)
 	ctx.Step(`^a policy is created with "([^"]*)" package, "([^"]*)" template, "([^"]*)" input, "([^"]*)" input type and dataset "([^"]*)"$`, aPolicyIsCreatedWithPackageInputAndDataset)
 	ctx.Step(`^there is an index template "([^"]*)" with pattern "([^"]*)"$`, thereIsAnIndexTemplateWithPattern)
 	ctx.Step(`^there is a transform "([^"]*)"$`, thereIsATransform)

--- a/compliance/elasticpackage.go
+++ b/compliance/elasticpackage.go
@@ -41,7 +41,7 @@ func (ep *ElasticPackage) Close() error {
 
 // Install installs the package in the given path.
 func (ep *ElasticPackage) Install(packagePath string) error {
-	cmd := exec.Command("go", "run", elasticPackageImportPath, "install")
+	cmd := exec.Command("go", "run", elasticPackageImportPath, "-C", packagePath, "install")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Env = append(os.Environ(),
@@ -51,7 +51,6 @@ func (ep *ElasticPackage) Install(packagePath string) error {
 		elasticPackageGetEnv("ELASTICSEARCH_USERNAME"),
 		elasticPackageGetEnv("KIBANA_HOST"),
 	)
-	cmd.Dir = packagePath
 	err := cmd.Run()
 	if err != nil {
 		return fmt.Errorf("elastic-package failed: %w", err)

--- a/compliance/features/synthetic-source.feature
+++ b/compliance/features/synthetic-source.feature
@@ -1,11 +1,8 @@
 Feature: Synthetic source
   Support synthetic source
 
-  # Requires a new elastic-package release to be able to use -C flag  to run tests
-  # of a package located in another directory (https://github.com/elastic/elastic-package/pull/1914)
-  @skip
   @3.2.0
   Scenario: Installer leverages source true
    Given the "logs_synthetic_mode" package is installed
-     And a policy is created with "logs_synthetic_mode" package
+     And a policy is created with "logs_synthetic_mode" package and "1.0.0-beta1" version
     Then index template "logs-logs_synthetic_mode.synthetic" has a field "decision_id" with "store:true"


### PR DESCRIPTION
## What does this PR do?

After being added the parameter `-C` into elastic-package (https://github.com/elastic/elastic-package/pull/1914), compliance test about synthetic source (logs) can be re-enabled.
