### PR TITLE
mergify: replace queue action for queue_rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    merge_method: squash
     conditions:
       - check-success=buildkite/package-spec
       - check-success=CLA
@@ -13,5 +14,4 @@ pull_request_rules:
       - author~=^dependabot(|-preview)\[bot\]$
     actions:
       queue:
-        method: squash
         name: default


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Use queue_rules instead of queue action

## Why

The queue action from workflow automation has deprecated all of its configuration options

https://changelog.mergify.com/changelog/queue-action-options-deprecation
