### PR TITLE
New changelog versions validation check

### DIFF
--- a/code/go/internal/validator/semantic/validate_changelog_links_test.go
+++ b/code/go/internal/validator/semantic/validate_changelog_links_test.go
@@ -1,0 +1,108 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package semantic
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/package-spec/v3/code/go/pkg/specerrors"
+)
+
+func TestValidateGithubLink(t *testing.T) {
+	var tests = []struct {
+		link        string
+		expectedErr error
+	}{
+		{
+			"https://github.com/elastic/integrations/pull/2897",
+			nil,
+		},
+		{
+			"https://github.com/elastic/integrations/pull/abcd",
+			errGithubIssue,
+		},
+		{
+			"https://github.com/elastic/integrations/pull/0",
+			errGithubIssue,
+		},
+		{
+			"https://github.com/elastic/integrations/pull",
+			errGithubIssue,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.link, func(t *testing.T) {
+			linkURL, _ := url.Parse(test.link)
+			err := validateGithubLink(linkURL)
+			if err != nil {
+				assert.ErrorIs(t, err, test.expectedErr)
+			} else {
+				assert.Equal(t, err, test.expectedErr)
+			}
+		})
+	}
+}
+
+func TestEnsureLinksAreValid(t *testing.T) {
+	var githubError = specerrors.NewStructuredError(errGithubIssue, specerrors.UnassignedCode)
+
+	var tests = []struct {
+		name   string
+		links  []string
+		errors specerrors.ValidationErrors
+	}{
+		{
+			"AllValidLinks",
+			[]string{
+				"https://github.com/elastic/integrations/pull/2897",
+				"https://github.com/elastic/integrations/pull/1001",
+				"https://github.com/elastic/integrations/pull/1",
+			},
+			nil,
+		},
+		{
+			"AllInvalidLinks",
+			[]string{
+				"https://github.com/elastic/integrations/pull/abcd",
+				"https://github.com/elastic/integrations/pull",
+			},
+			specerrors.ValidationErrors{
+				githubError,
+				githubError,
+			},
+		},
+		{
+			"SomeInvalidLinks",
+			[]string{
+				"https://github.com/elastic/integrations/pull/1234",
+				"https://github.com/elastic/integrations/pull",
+			},
+			specerrors.ValidationErrors{
+				githubError,
+			},
+		},
+		{
+			"IgnoreCasesOtherThanGithubDotCom",
+			[]string{
+				"https://gitlab.com/elastic/integrations/pull/abcd",
+				"https://zzz.com/elastic/integrations/pull/1234",
+			},
+			nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errs := ensureLinksAreValid(test.links)
+			if test.errors == nil {
+				assert.Equal(t, test.errors, errs)
+			} else {
+				assert.Equal(t, len(errs), len(test.errors))
+			}
+		})
+	}
+}

--- a/code/go/internal/validator/semantic/validate_version_integrity.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/elastic/package-spec/v3/code/go/internal/fspath"
 	"github.com/elastic/package-spec/v3/code/go/internal/pkgpath"
 	"github.com/elastic/package-spec/v3/code/go/pkg/specerrors"
@@ -33,6 +34,11 @@ func ValidateVersionIntegrity(fsys fspath.FS) specerrors.ValidationErrors {
 	}
 
 	err = ensureManifestVersionHasChangelogEntry(manifestVersion, changelogVersions)
+	if err != nil {
+		return specerrors.ValidationErrors{specerrors.NewStructuredError(err, specerrors.UnassignedCode)}
+	}
+
+	err = ensureChangelogLatestVersionIsGreaterThanOthers(changelogVersions)
 	if err != nil {
 		return specerrors.ValidationErrors{specerrors.NewStructuredError(err, specerrors.UnassignedCode)}
 	}
@@ -129,4 +135,25 @@ func ensureManifestVersionHasChangelogEntry(manifestVersion string, versions []s
 		}
 	}
 	return errors.New("current manifest version doesn't have changelog entry")
+}
+
+func ensureChangelogLatestVersionIsGreaterThanOthers(versions []string) error {
+	latestVersion, err := semver.NewVersion(versions[0])
+	if err != nil {
+		return fmt.Errorf("could not read package manifest version [%s]: %w", versions[0], err)
+	}
+
+	for i, v := range versions {
+		if i == 0 {
+			continue
+		}
+		changelogVersion, err := semver.NewVersion(v)
+		if err != nil {
+			return fmt.Errorf("could not read package manifest version [%s]: %w", changelogVersion, err)
+		}
+		if changelogVersion.GreaterThanEqual(latestVersion) {
+			return fmt.Errorf("changelog entry %s is greater than or equal to first changelog entry: %s", changelogVersion, latestVersion)
+		}
+	}
+	return nil
 }

--- a/code/go/internal/validator/semantic/validate_version_integrity.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+
 	"github.com/elastic/package-spec/v3/code/go/internal/fspath"
 	"github.com/elastic/package-spec/v3/code/go/internal/pkgpath"
 	"github.com/elastic/package-spec/v3/code/go/pkg/specerrors"
@@ -124,6 +125,10 @@ func ensureUniqueVersions(versions []string) error {
 }
 
 func ensureManifestVersionHasChangelogEntry(manifestVersion string, versions []string) error {
+	if len(versions) == 0 {
+		return errors.New("no versions found in changelog")
+	}
+
 	if manifestVersion == versions[0] {
 		return nil
 	}
@@ -138,15 +143,16 @@ func ensureManifestVersionHasChangelogEntry(manifestVersion string, versions []s
 }
 
 func ensureChangelogLatestVersionIsGreaterThanOthers(versions []string) error {
+	if len(versions) == 0 {
+		return errors.New("no versions found in changelog")
+	}
+
 	latestVersion, err := semver.NewVersion(versions[0])
 	if err != nil {
 		return fmt.Errorf("could not read package manifest version [%s]: %w", versions[0], err)
 	}
 
-	for i, v := range versions {
-		if i == 0 {
-			continue
-		}
+	for _, v := range versions[1:] {
 		changelogVersion, err := semver.NewVersion(v)
 		if err != nil {
 			return fmt.Errorf("could not read package manifest version [%s]: %w", changelogVersion, err)

--- a/code/go/internal/validator/semantic/validate_version_integrity_test.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity_test.go
@@ -5,12 +5,9 @@
 package semantic
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/elastic/package-spec/v3/code/go/pkg/specerrors"
 )
 
 func TestChangelogUniqueVersions(t *testing.T) {
@@ -148,100 +145,6 @@ func TestChangelogLatestVersionIsGreaterThanOthers(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestValidateGithubLink(t *testing.T) {
-	var tests = []struct {
-		link        string
-		expectedErr error
-	}{
-		{
-			"https://github.com/elastic/integrations/pull/2897",
-			nil,
-		},
-		{
-			"https://github.com/elastic/integrations/pull/abcd",
-			errGithubIssue,
-		},
-		{
-			"https://github.com/elastic/integrations/pull/0",
-			errGithubIssue,
-		},
-		{
-			"https://github.com/elastic/integrations/pull",
-			errGithubIssue,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.link, func(t *testing.T) {
-			linkURL, _ := url.Parse(test.link)
-			err := validateGithubLink(linkURL)
-			if err != nil {
-				assert.ErrorIs(t, err, test.expectedErr)
-			} else {
-				assert.Equal(t, err, test.expectedErr)
-			}
-		})
-	}
-}
-
-func TestEnsureLinksAreValid(t *testing.T) {
-	var githubError = specerrors.NewStructuredError(errGithubIssue, specerrors.UnassignedCode)
-
-	var tests = []struct {
-		name   string
-		links  []string
-		errors specerrors.ValidationErrors
-	}{
-		{
-			"AllValidLinks",
-			[]string{
-				"https://github.com/elastic/integrations/pull/2897",
-				"https://github.com/elastic/integrations/pull/1001",
-				"https://github.com/elastic/integrations/pull/1",
-			},
-			nil,
-		},
-		{
-			"AllInvalidLinks",
-			[]string{
-				"https://github.com/elastic/integrations/pull/abcd",
-				"https://github.com/elastic/integrations/pull",
-			},
-			specerrors.ValidationErrors{
-				githubError,
-				githubError,
-			},
-		},
-		{
-			"SomeInvalidLinks",
-			[]string{
-				"https://github.com/elastic/integrations/pull/1234",
-				"https://github.com/elastic/integrations/pull",
-			},
-			specerrors.ValidationErrors{
-				githubError,
-			},
-		},
-		{
-			"IgnoreCasesOtherThanGithubDotCom",
-			[]string{
-				"https://gitlab.com/elastic/integrations/pull/abcd",
-				"https://zzz.com/elastic/integrations/pull/1234",
-			},
-			nil,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			errs := ensureLinksAreValid(test.links)
-			if test.errors == nil {
-				assert.Equal(t, test.errors, errs)
-			} else {
-				assert.Equal(t, len(errs), len(test.errors))
 			}
 		})
 	}

--- a/code/go/internal/validator/semantic/validate_version_integrity_test.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity_test.go
@@ -13,6 +13,146 @@ import (
 	"github.com/elastic/package-spec/v3/code/go/pkg/specerrors"
 )
 
+func TestChangelogUniqueVersions(t *testing.T) {
+	var tests = []struct {
+		title       string
+		versions    []string
+		expectedErr bool
+	}{
+		{
+			"unique changelog versions",
+			[]string{
+				"1.0.0",
+				"1.0.1",
+			},
+			false,
+		},
+		{
+			"repeated changelog versions",
+			[]string{
+				"1.0.0",
+				"1.0.1",
+				"1.0.0",
+			},
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			err := ensureUniqueVersions(test.versions)
+			if test.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestManifestVersionHasChangelogEntry(t *testing.T) {
+	var tests = []struct {
+		title           string
+		manifestVersion string
+		versions        []string
+		expectedErr     bool
+	}{
+		{
+			"manifest version exists",
+			"1.0.1",
+			[]string{
+				"1.0.1",
+				"1.0.0",
+			},
+			false,
+		},
+		{
+			"manifest version does not exist",
+			"1.1.0",
+			[]string{
+				"1.0.2",
+				"1.0.1",
+				"1.0.0",
+			},
+			true,
+		},
+		{
+			"changelog next version",
+			"1.0.1",
+			[]string{
+				"1.1.0-next",
+				"1.0.1",
+				"1.0.0",
+			},
+			false,
+		},
+		{
+			"changelog next version manifest older version",
+			"1.0.0",
+			[]string{
+				"1.1.0-next",
+				"1.0.1",
+				"1.0.0",
+			},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			err := ensureManifestVersionHasChangelogEntry(test.manifestVersion, test.versions)
+			if test.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestChangelogLatestVersionIsGreaterThanOthers(t *testing.T) {
+	var tests = []struct {
+		title       string
+		versions    []string
+		expectedErr bool
+	}{
+		{
+			"latest changelog entry greater",
+			[]string{
+				"1.0.1",
+				"1.0.0",
+			},
+			false,
+		},
+		{
+			"latest changelog entry lower prerelease tag",
+			[]string{
+				"1.0.1-preview01",
+				"1.0.1",
+				"1.0.0",
+			},
+			true,
+		},
+		{
+			"latest changelog entry lower stable version",
+			[]string{
+				"1.0.1",
+				"1.1.0",
+				"1.0.0",
+			},
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			err := ensureChangelogLatestVersionIsGreaterThanOthers(test.versions)
+			if test.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateGithubLink(t *testing.T) {
 	var tests = []struct {
 		link        string

--- a/code/go/internal/validator/semantic/validate_version_integrity_test.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity_test.go
@@ -137,6 +137,24 @@ func TestChangelogLatestVersionIsGreaterThanOthers(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"latest changelog entry next version",
+			[]string{
+				"1.2.0-next",
+				"1.1.0",
+				"1.0.0",
+			},
+			false,
+		},
+		{
+			"latest changelog entry next version older",
+			[]string{
+				"1.0.1-next",
+				"1.1.0",
+				"1.0.0",
+			},
+			true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.title, func(t *testing.T) {

--- a/code/go/internal/validator/semantic/validate_version_integrity_test.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity_test.go
@@ -155,6 +155,15 @@ func TestChangelogLatestVersionIsGreaterThanOthers(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"latest changelog entry prerelease tag",
+			[]string{
+				"1.1.1-preview01",
+				"1.1.0",
+				"1.0.0",
+			},
+			false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.title, func(t *testing.T) {

--- a/code/go/internal/validator/semantic/validate_version_integrity_test.go
+++ b/code/go/internal/validator/semantic/validate_version_integrity_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestChangelogUniqueVersions(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		title       string
 		versions    []string
 		expectedErr bool
@@ -47,7 +47,7 @@ func TestChangelogUniqueVersions(t *testing.T) {
 }
 
 func TestManifestVersionHasChangelogEntry(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		title           string
 		manifestVersion string
 		versions        []string
@@ -92,6 +92,16 @@ func TestManifestVersionHasChangelogEntry(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"changelog and manifest next version",
+			"1.1.0-next",
+			[]string{
+				"1.1.0-next",
+				"1.0.1",
+				"1.0.0",
+			},
+			false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.title, func(t *testing.T) {
@@ -106,13 +116,13 @@ func TestManifestVersionHasChangelogEntry(t *testing.T) {
 }
 
 func TestChangelogLatestVersionIsGreaterThanOthers(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		title       string
 		versions    []string
 		expectedErr bool
 	}{
 		{
-			"latest changelog entry greater",
+			"valid latest changelog entry",
 			[]string{
 				"1.0.1",
 				"1.0.0",
@@ -129,7 +139,7 @@ func TestChangelogLatestVersionIsGreaterThanOthers(t *testing.T) {
 			true,
 		},
 		{
-			"latest changelog entry lower stable version",
+			"latest changelog entry lower than stable version",
 			[]string{
 				"1.0.1",
 				"1.1.0",

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -17,6 +17,9 @@
     - description: Add support for identity of agentless deployment mode, and make it mandatory when this mode is enabled.
       type: breaking-change
       link: https://github.com/elastic/package-spec/pull/801
+    - description: Add a new validation to check order of the newer changelog entry.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1
 - version: 3.2.2
   changes:
     - description: Add spec for img directory.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -19,7 +19,7 @@
       link: https://github.com/elastic/package-spec/pull/801
     - description: Add a new validation to check order of the newer changelog entry.
       type: enhancement
-      link: https://github.com/elastic/package-spec/pull/1
+      link: https://github.com/elastic/package-spec/pull/808
 - version: 3.2.2
   changes:
     - description: Add spec for img directory.


### PR DESCRIPTION
## What does this PR do?

Add a new validation check to ensure that the first (newer) changelog entry defined in the changelog file is not lower than the other versions.

Example of PR releasing an old version: https://github.com/elastic/integrations/pull/10800

## Why is it important?

Ensure that it is not released a older version. Releasing an older version should be performed through another mechanism.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
