### PR TITLE
Prepare release 3.2.3

### DIFF
--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -28,7 +28,7 @@ steps:
 EOF
 
 # Generate each test we want to do.
-compliance_test 8.16.0-SNAPSHOT 3.2.2
+compliance_test 8.16.0-SNAPSHOT 3.2.3
 compliance_test 8.14.0 3.1.5
 compliance_test 8.9.0 2.7.0
 

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -15,7 +15,7 @@
     - description: Add support for `slo` assets.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/767
-- version: 3.2.3-next
+- version: 3.2.3
   changes:
     - description: Add support for identity of agentless deployment mode, and make it mandatory when this mode is enabled.
       type: breaking-change


### PR DESCRIPTION
Prepare changelog for 3.2.3 release. It includes some new required fields, what is a breaking change but only when defining agentless deployment modes, what is in tech preview. It also includes additional checks for the changelog.