### PR TITLE
Prepare release 3.3.0

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -4,17 +4,17 @@
 ##
 - version: 3.4.0-next
   changes:
-    - description: Add support for content packages.
-      type: enhancement
-      link: https://github.com/elastic/package-spec/pull/777
-    - description: Add support for semantic_text field definition
-      type: enhancement
-      link: https://github.com/elastic/package-spec/pull/807
-- version: 3.3.0-next
-  changes:
     - description: Add support for `slo` assets.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/767
+    - description: Add support for semantic_text field definition
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/807
+- version: 3.3.0
+  changes:
+    - description: Add support for content packages.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/777
 - version: 3.2.3
   changes:
     - description: Add support for identity of agentless deployment mode, and make it mandatory when this mode is enabled.

--- a/spec/content/spec.yml
+++ b/spec/content/spec.yml
@@ -54,7 +54,7 @@ spec:
     $ref: "../integration/validation.spec.yml"
 
 versions:
-  - before: 3.4.0
+  - before: 3.3.0
     patch:
       - op: remove
         path: "/contents" # Package type not available before this version.

--- a/spec/integration/kibana/spec.yml
+++ b/spec/integration/kibana/spec.yml
@@ -137,7 +137,7 @@ spec:
       forbiddenPatterns:
         - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden 
 versions:
-  - before: 3.3.0
+  - before: 3.4.0
     patch:
       - op: remove
         path: "/contents/13" # remove SLO definitions

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.3.0
+format_version: 3.4.0
 name: good_v3
 title: Good package
 description: This package is good for format version 3


### PR DESCRIPTION
It includes preview release of content packages.

It also delays introduction of SLO assets to 3.4. There is no package using SLO yet and implementation in Fleet is not complete.