### PR TITLE
Add setting to manage policy templates behaviour in Kibana

### DIFF
--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -205,7 +205,6 @@ spec:
                   - organization
                   - division
                   - team
-
     icons:
       description: List of icons for by this package.
       type: array
@@ -363,6 +362,20 @@ spec:
       $ref: "#/definitions/categories"
     conditions:
       $ref: "#/definitions/conditions"
+    # requires a conditional JSON schema to update the value depending
+    # on the policy_templates length
+    policy_templates_behaviour:
+      description: >
+        Behaviour to manage the policy templates (policy_templates field) defined that must be available in Kibana as tiles.
+        This is just applicable for those packages that define more than one policy template. By default for these packages, Kibana
+        shows all the policy templates defined in the manifest separately plus another one refering to the
+        whole integraton (that contains all the policy templates definitions) available to the user.
+
+        If the `integration_package_only` option is selected, then just one policy template for the whole integration containing all policy
+        templates will be available in Kibana. If the `policy_templates_only` option is selected, then just the policy templates defined
+        in the manifest will be available in Kibana without the specific policy template for the whole integration. If the `default` option
+        is selected, then Kibana keeps the same behaviour described above.
+      type: string
     policy_templates:
       description: List of policy templates offered by this package.
       type: array
@@ -487,6 +500,25 @@ spec:
     - version
     - type
     - owner
+  allOf:
+    - if:
+        properties:
+          policy_templates:
+            maxItems: 1
+      then:
+        properties:
+          policy_templates_behaviour:
+            enum:
+              - default
+            default: default
+      else:
+        properties:
+          policy_templates_behaviour:
+            enum:
+              - integration_package_only
+              - policy_templates_only
+              - default
+            default: default
 
 # JSON patches for newer versions should be placed on top
 versions:

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -28,6 +28,7 @@ vars:
     title: A URL to get secrets, but not a secret itself.
     type: url
     show_user: true
+policy_templates_behaviour: policy_templates_only
 policy_templates:
   - name: apache
     title: Apache logs and metrics
@@ -68,7 +69,7 @@ policy_templates:
               - http://127.0.0.1
             hide_in_deployment_modes:
               - agentless
-  - name: apache
+  - name: apache-agentless
     title: Apache logs and metrics in agentless
     description: Collect logs and metrics from Apache instances in agentless
     deployment_modes:


### PR DESCRIPTION
## What does this PR do?

Adds a new setting `policy_templates_behaviour` to manage how the policy templates / tiles are shown to the user in Kibana.

## Why is it important?

There are some integrations that do not require to show a tile for the integration itself, or viceversa, there could be integrations that it is not desired to show each of the policy templates (child policy templates) defined as tiles, just the one refering to the integration itself (parent tile)

## Checklist

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Closes #802 
