### PR TITLE
Fix issue blocking release of GA content packages

### DIFF
--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -28,8 +28,8 @@ steps:
 EOF
 
 # Generate each test we want to do.
-compliance_test 8.16.0-SNAPSHOT 3.3.0
-compliance_test 8.15.0 3.2.3
+compliance_test 8.17.0-SNAPSHOT 3.3.0
+compliance_test 8.16.0 3.3.0
 compliance_test 8.14.0 3.1.5
 compliance_test 8.9.0 2.7.0
 

--- a/compliance/features/basic.feature
+++ b/compliance/features/basic.feature
@@ -12,3 +12,8 @@ Feature: Basic package types support
    Given the "basic_input" package is installed
      And a policy is created with "basic_input" package, "test" template, "test" input, "logfile" input type and dataset "spec.input_test"
     Then there is an index template "logs-spec.input_test" with pattern "logs-spec.input_test-*"
+
+  @3.3.0
+  Scenario: Content package can be installed
+   Given the "good_content" package is installed
+   #Then there are no errors.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -18,6 +18,9 @@
     - description: Added new policy_templates_behavior setting to manage how to show policy templates to the user in Kibana.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/825
+    - description: Fix content packages so they can be actually released as GA versions.
+      type: bugfix
+      link: https://github.com/elastic/package-spec/issues/841
 - version: 3.3.0
   changes:
     - description: Add support for content packages.

--- a/spec/content/spec.yml
+++ b/spec/content/spec.yml
@@ -11,7 +11,6 @@ spec:
   sizeLimit: 150MB
   configurationSizeLimit: 5MB
   relativePathSizeLimit: 3MB
-  release: beta
   contents:
   - description: The main package manifest file
     type: file

--- a/test/packages/good_content/changelog.yml
+++ b/test/packages/good_content/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.0.0
+  changes:
+    - description: GA release
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/841
 - version: 0.1.0
   changes:
     - description: Initial release

--- a/test/packages/good_content/manifest.yml
+++ b/test/packages/good_content/manifest.yml
@@ -1,17 +1,17 @@
-format_version: 3.4.0
+format_version: 3.3.0
 name: good_content
 title: Good content package
 description: >
   This package is a dummy example for packages with the content type.
   These packages contain resources that are useful with data ingested by other integrations.
   They are not used to configure data sources.
-version: 0.1.0
+version: 1.0.0
 type: content
 source:
   license: "Apache-2.0"
 conditions:
   kibana:
-    version: '^8.16.0' #TBD
+    version: '^8.16.0'
   elastic:
     subscription: 'basic'
 discovery:

--- a/test/packages/good_content/validation.yml
+++ b/test/packages/good_content/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - PSR00002 # Allow to use non-GA features.


### PR DESCRIPTION
## What does this PR do?

Remove beta tag from content packages spec.
Update tests for content packages so they represent GA use cases.

## Why is it important?

So content packages can be actually released as GA, as supposed since 3.3.0.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).
