### PR TITLE
Expand configuration_links to support internal/external links

### DIFF
--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -245,6 +245,8 @@ func TestValidateFile(t *testing.T) {
 			[]string{
 				"field policy_templates.0.configuration_links: Array must have at least 1 items",
 				"field policy_templates.1.configuration_links.0: url is required",
+				"field policy_templates.1.configuration_links.1.url: Does not match pattern '^http(s)?://'",
+				"field policy_templates.1.configuration_links.2.url: Does not match pattern '^http(s)?://"
 			},
 		},
 	}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -245,7 +245,8 @@ func TestValidateFile(t *testing.T) {
 			[]string{
 				"field policy_templates.0.configuration_links: Array must have at least 1 items",
 				"field policy_templates.1.configuration_links.0: url is required",
-				"field policy_templates.1.configuration_links.1.url: Does not match pattern '^http(s)?://'",
+				"field policy_templates.1.configuration_links.1.url: Does not match pattern '^(http(s)?://|kbn:)",
+				"field policy_templates.1.configuration_links.2.url: Does not match pattern '^(http(s)?://|kbn:)",
 			},
 		},
 	}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -246,7 +246,7 @@ func TestValidateFile(t *testing.T) {
 				"field policy_templates.0.configuration_links: Array must have at least 1 items",
 				"field policy_templates.1.configuration_links.0: url is required",
 				"field policy_templates.1.configuration_links.1.url: Does not match pattern '^http(s)?://'",
-				"field policy_templates.1.configuration_links.2.url: Does not match pattern '^http(s)?://"
+				"field policy_templates.1.configuration_links.2.url: Does not match pattern '^http(s)?://",
 			},
 		},
 	}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -245,7 +245,7 @@ func TestValidateFile(t *testing.T) {
 			[]string{
 				"field policy_templates.0.configuration_links: Array must have at least 1 items",
 				"field policy_templates.1.configuration_links.0: url is required",
-				"field policy_templates.1.configuration_links.0: internal is required",
+				"field policy_templates.1.configuration_links.1: internal is required",
 			},
 		},
 	}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -246,7 +246,6 @@ func TestValidateFile(t *testing.T) {
 				"field policy_templates.0.configuration_links: Array must have at least 1 items",
 				"field policy_templates.1.configuration_links.0: url is required",
 				"field policy_templates.1.configuration_links.1.url: Does not match pattern '^http(s)?://'",
-				"field policy_templates.1.configuration_links.2.url: Does not match pattern '^http(s)?://",
 			},
 		},
 	}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -245,8 +245,8 @@ func TestValidateFile(t *testing.T) {
 			[]string{
 				"field policy_templates.0.configuration_links: Array must have at least 1 items",
 				"field policy_templates.1.configuration_links.0: url is required",
-				"field policy_templates.1.configuration_links.1.url: Does not match pattern '^(http(s)?://|kbn:)",
-				"field policy_templates.1.configuration_links.2.url: Does not match pattern '^(http(s)?://|kbn:)",
+				"field policy_templates.1.configuration_links.1.url: Does not match pattern '^(http(s)?://|kbn:/)'",
+				"field policy_templates.1.configuration_links.2.url: Does not match pattern '^(http(s)?://|kbn:/)'",
 			},
 		},
 	}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -245,6 +245,7 @@ func TestValidateFile(t *testing.T) {
 			[]string{
 				"field policy_templates.0.configuration_links: Array must have at least 1 items",
 				"field policy_templates.1.configuration_links.0: url is required",
+				"field policy_templates.1.configuration_links.0: internal is required",
 			},
 		},
 	}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -245,7 +245,6 @@ func TestValidateFile(t *testing.T) {
 			[]string{
 				"field policy_templates.0.configuration_links: Array must have at least 1 items",
 				"field policy_templates.1.configuration_links.0: url is required",
-				"field policy_templates.1.configuration_links.1: internal is required",
 			},
 		},
 	}

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -21,6 +21,9 @@
     - description: Add support for configuration links to kibana manifest.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/834
+    - description: Expand support to internal and external configuration_links defined in kibana manifest.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/
 - version: 3.3.0
   changes:
     - description: Add support for content packages.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -23,7 +23,7 @@
       link: https://github.com/elastic/package-spec/pull/834
     - description: Expand support to internal and external configuration_links defined in kibana manifest.
       type: enhancement
-      link: https://github.com/elastic/package-spec/pull/
+      link: https://github.com/elastic/package-spec/pull/844
 - version: 3.3.0
   changes:
     - description: Add support for content packages.

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -219,9 +219,7 @@ spec:
           url:
             description: Link url. Format is `http://...` or `https://...` for external links,  `kbn:app/...` for links internal to Kibana.
             type: string
-            oneOf:
-              - type: string
-                pattern: '^(http(s)?://|kbn:/)'
+            pattern: '^(http(s)?://|kbn:/)'
           type:
             description: Type of link. `next_steps` for links to locations that can be relevant right after configuring the policy. `action` for actions that can be performed while the policy is in use.
             type: string

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -217,29 +217,26 @@ spec:
             description: Link title
             type: string
           url:
-            description: Link url
+            description: Link url. Format is `http://...` or `https://...` for external links,  `kbn:app/...` for links internal to Kibana.
             type: string
+            oneOf:
+              - type: string
+                pattern: '^http(s)?://'
+              - type: string
+                pattern: '^kbn:'
           type:
             description: Type of link. `next_steps` for links to locations that can be relevant right after configuring the policy. `action` for actions that can be performed while the policy is in use.
             type: string
             enum:
               - action
               - next_step
-          appId:
-            description: The identifier of the Kibana app to navigate to. Set this field when `internal` is true.
-            type: string
           content:
             description: Link description
             type: string
-          internal:
-            description: Set to true for internal kibana links, false for external links. Defaults to false.
-            type: boolean
-            default: false
         required:
         - title
         - url
         - type
-        - internal
     icons:
       description: List of icons for by this package.
       type: array

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -221,9 +221,7 @@ spec:
             type: string
             oneOf:
               - type: string
-                pattern: '^http(s)?://'
-              - type: string
-                pattern: '^kbn:'
+                pattern: '^(http(s)?://|kbn:)'
           type:
             description: Type of link. `next_steps` for links to locations that can be relevant right after configuring the policy. `action` for actions that can be performed while the policy is in use.
             type: string

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -217,7 +217,7 @@ spec:
             description: Link title
             type: string
           url:
-            description: Link url. Format is `http://...` or `https://...` for external links,  `kbn:app/...` for links internal to Kibana.
+            description: Link url. Format is `http://...` or `https://...` for external links,  `kbn:/app/...` for links internal to Kibana.
             type: string
             pattern: '^(http(s)?://|kbn:/)'
           type:

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -221,7 +221,7 @@ spec:
             type: string
             oneOf:
               - type: string
-                pattern: '^(http(s)?://|kbn:)'
+                pattern: '^(http(s)?://|kbn:/)'
           type:
             description: Type of link. `next_steps` for links to locations that can be relevant right after configuring the policy. `action` for actions that can be performed while the policy is in use.
             type: string

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -225,13 +225,21 @@ spec:
             enum:
               - action
               - next_step
+          appId:
+            description: The identifier of the Kibana app to navigate to. Set this field when `internal` is true.
+            type: string
           content:
             description: Link description
             type: string
+          internal:
+            description: Set to true for internal kibana links, false for external links. Defaults to false.
+            type: boolean
+            default: false
         required:
         - title
         - url
         - type
+        - internal
     icons:
       description: List of icons for by this package.
       type: array

--- a/test/packages/bad_configuration_links/manifest.yml
+++ b/test/packages/bad_configuration_links/manifest.yml
@@ -83,7 +83,6 @@ policy_templates:
       # bad format: missing field url
       - title: Security overview
         type: next_step
-        internal: true
       # bad format: doesn't match format kbn:/..
       - title: View Agents
         url: "app/fleet/agents"

--- a/test/packages/bad_configuration_links/manifest.yml
+++ b/test/packages/bad_configuration_links/manifest.yml
@@ -87,7 +87,7 @@ policy_templates:
       - title: View Agents
         url: "app/fleet/agents"
         type: next_step
-      # bad format: it should match either http/https format or kbn: format
+      # bad format: it should match either http/https format or kbn:/ format
       - title: View Agents
         url: "elastic.co"
         type: next_step

--- a/test/packages/bad_configuration_links/manifest.yml
+++ b/test/packages/bad_configuration_links/manifest.yml
@@ -84,17 +84,14 @@ policy_templates:
       - title: Security overview
         type: next_step
         internal: true
-      # bad format: missing field `internal`
+      # bad format: doesn't match format kbn:/..
       - title: View Agents
-        url: "/agents"
+        url: "app/fleet/agents"
         type: next_step
-        content: "Check your agents in Fleet"
-        appId: "fleet"
-      # bad format: `internal: false` should match http or https format
+      # bad format: it should match either http/https format or kbn: format
       - title: View Agents
-        url: "/agents"
+        url: "elastic.co"
         type: next_step
-        internal: false
     inputs:
       - type: apache/metrics
         title: Collect metrics in agentless

--- a/test/packages/bad_configuration_links/manifest.yml
+++ b/test/packages/bad_configuration_links/manifest.yml
@@ -83,6 +83,17 @@ policy_templates:
     configuration_links:
       - title: Security overview
         type: next_step
+      # bad format: missing field `internal`
+      - title: View Agents
+        url: "/agents"
+        type: next_step
+        content: "Check your agents in Fleet"
+        appId: "fleet"
+      # bad format: `internal: false` should match http or https format
+      - title: View Agents
+        url: "/agents"
+        type: next_step
+        internal: false
     inputs:
       - type: apache/metrics
         title: Collect metrics in agentless

--- a/test/packages/bad_configuration_links/manifest.yml
+++ b/test/packages/bad_configuration_links/manifest.yml
@@ -79,10 +79,11 @@ policy_templates:
         organization: security
         division: engineering
         team: cloud-security
-        # bad format: missing fields
     configuration_links:
+      # bad format: missing field url
       - title: Security overview
         type: next_step
+        internal: true
       # bad format: missing field `internal`
       - title: View Agents
         url: "/agents"

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -41,9 +41,21 @@ policy_templates:
         team: obs-infraobs-integrations
     configuration_links:
       - title: Security overview
-        url: "/security/overview"
+        url: "/overview"
         type: next_step
         content: "View security overview"
+        appId: "security"
+        internal: true
+      - title: Elastic website
+        url: "https://www.elastic.co/"
+        type: action
+        content: "See more"
+        internal: false
+      - title: Configure fleet
+        url: "https://www.elastic.co/guide/en/fleet/master/fleet-overview.html"
+        type: next_step
+        content: "See docs"
+        internal: false
     inputs:
       - type: apache/metrics
         title: Collect metrics from Apache instances

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -41,21 +41,17 @@ policy_templates:
         team: obs-infraobs-integrations
     configuration_links:
       - title: View Agents
-        url: "/agents"
+        url: "kbn:app/fleet/agents"
         type: next_step
         content: "Check your agents in Fleet"
-        appId: "fleet"
-        internal: true
       - title: Elastic website
         url: "https://www.elastic.co/"
         type: action
         content: "See more"
-        internal: false
-      - title: Configure fleet
-        url: "https://www.elastic.co/guide/en/fleet/master/fleet-overview.html"
+      - title: See agents
+        url: "http://localhost:5601/app/fleet/agents"
         type: next_step
-        content: "See docs"
-        internal: false
+        description: Example of http link
     inputs:
       - type: apache/metrics
         title: Collect metrics from Apache instances

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -41,7 +41,7 @@ policy_templates:
         team: obs-infraobs-integrations
     configuration_links:
       - title: View Agents
-        url: "kbn:app/fleet/agents"
+        url: "kbn:/app/fleet/agents"
         type: next_step
         content: "Check your agents in Fleet"
       - title: Elastic website

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -40,11 +40,11 @@ policy_templates:
         division: observability
         team: obs-infraobs-integrations
     configuration_links:
-      - title: Security overview
-        url: "/overview"
+      - title: View Agents
+        url: "/agents"
         type: next_step
-        content: "View security overview"
-        appId: "security"
+        content: "Check your agents in Fleet"
+        appId: "fleet"
         internal: true
       - title: Elastic website
         url: "https://www.elastic.co/"

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -51,7 +51,6 @@ policy_templates:
       - title: See agents
         url: "http://localhost:5601/app/fleet/agents"
         type: next_step
-        description: Example of http link
     inputs:
       - type: apache/metrics
         title: Collect metrics from Apache instances

--- a/test/packages/kibana_configuration_links/changelog.yml
+++ b/test/packages/kibana_configuration_links/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Expand kibana configuration links
       type: enhancement
-      link: https://github.com/elastic/package-spec/pull/
+      link: https://github.com/elastic/package-spec/pull/844
 - version: 1.0.1
   changes:
     - description: Add kibana configuration links

--- a/test/packages/kibana_configuration_links/changelog.yml
+++ b/test/packages/kibana_configuration_links/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.0.2
+  changes:
+    - description: Expand kibana configuration links
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/
 - version: 1.0.1
   changes:
     - description: Add kibana configuration links

--- a/test/packages/kibana_configuration_links/manifest.yml
+++ b/test/packages/kibana_configuration_links/manifest.yml
@@ -41,11 +41,11 @@ policy_templates:
         team: obs-infraobs-integrations
     configuration_links:
       - title: View Agents
-        url: "kbn:app/fleet/agents"
+        url: "kbn:/app/fleet/agents"
         type: next_step
         content: "Check your agents in Fleet"
       - title: Browse integrations
-        url: "kbn:app/integrations/browse"
+        url: "kbn:/app/integrations/browse"
         type: action
       - title: Elastic website
         url: "https://www.elastic.co/"

--- a/test/packages/kibana_configuration_links/manifest.yml
+++ b/test/packages/kibana_configuration_links/manifest.yml
@@ -46,7 +46,7 @@ policy_templates:
         content: "Check your agents in Fleet"
         appId: "fleet"
         internal: true
-      - title: Fleet
+      - title: Browse integrations
         url: "/browse"
         type: action
         appId: "integrations"

--- a/test/packages/kibana_configuration_links/manifest.yml
+++ b/test/packages/kibana_configuration_links/manifest.yml
@@ -41,26 +41,19 @@ policy_templates:
         team: obs-infraobs-integrations
     configuration_links:
       - title: View Agents
-        url: "/agents"
+        url: "kbn:app/fleet/agents"
         type: next_step
         content: "Check your agents in Fleet"
-        appId: "fleet"
-        internal: true
       - title: Browse integrations
-        url: "/browse"
+        url: "kbn:app/integrations/browse"
         type: action
-        appId: "integrations"
-        internal: true
       - title: Elastic website
         url: "https://www.elastic.co/"
         type: action
         content: "See more"
-        internal: false
-      - title: Configure fleet
-        url: "https://www.elastic.co/guide/en/fleet/master/fleet-overview.html"
+      - title: See agents
+        url: "http://localhost:5601/app/fleet/agents"
         type: next_step
-        content: "See docs"
-        internal: false
     inputs:
       - type: apache/metrics
         title: Collect metrics from Apache instances

--- a/test/packages/kibana_configuration_links/manifest.yml
+++ b/test/packages/kibana_configuration_links/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.3.1
 name: kibana_configuration_links
 title: Kibana Configuration Links
 description: Kibana configuration links examples
-version: 1.0.1
+version: 1.0.2
 type: integration
 source:
   license: "Apache-2.0"
@@ -40,10 +40,27 @@ policy_templates:
         division: observability
         team: obs-infraobs-integrations
     configuration_links:
-      - title: Security overview
-        url: "/security/overview"
+      - title: View Agents
+        url: "/agents"
         type: next_step
-        content: "View security overview"
+        content: "Check your agents in Fleet"
+        appId: "fleet"
+        internal: true
+      - title: Fleet
+        url: "/browse"
+        type: action
+        appId: "integrations"
+        internal: true
+      - title: Elastic website
+        url: "https://www.elastic.co/"
+        type: action
+        content: "See more"
+        internal: false
+      - title: Configure fleet
+        url: "https://www.elastic.co/guide/en/fleet/master/fleet-overview.html"
+        type: next_step
+        content: "See docs"
+        internal: false
     inputs:
       - type: apache/metrics
         title: Collect metrics from Apache instances


### PR DESCRIPTION
## What does this PR do?
Follow up to https://github.com/elastic/package-spec/pull/834

## Why is it important?
With https://github.com/elastic/package-spec/pull/834 I added support to configuration_links to kibana manifest. This PR expands upon the previous change setting explicit formats for the urls:

**External** links should have `url` field of type `http://...` or `https://..`
``` yml
      - title: Configure fleet
        url: "https://www.elastic.co/guide/en/fleet/master/fleet-overview.html"
        type: next_step
        content: "See docs"
```

**Internal** links should use the `kbn:/` prefix (similar to what it's done in Kiban dev tools) and of course the link should be a valid Kibana link in order to work . Example corresponding to `/app/integrations/browse`:
``` yml
      - title: Browse integrations
        url: "kbn:/app/integrations/browse"
        type: action
```

**NOTE** Kibana doesn't currently handle `configuration_links` field at all and just ignores this field, as I'm still working to the related changes. This change should be safe to merge.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

Related to https://github.com/elastic/package-spec/issues/832
