### PR TITLE
Allow to override default deployment mode

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -15,6 +15,9 @@
     - description: Add support for Agentless resources.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/853
+    - description: Allow to override default deployment mode.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/854
 - version: 3.3.1
   changes:
     - description: Add validation rule to ensure security capability is added if there is any security rule asset.

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -163,6 +163,9 @@ spec:
           type: object
           properties:
             enabled:
+              description: >
+                Indicates if the default deployment mode is available for this template policy.
+                It is enabled by default.
               type: boolean
               default: true
         agentless:
@@ -174,7 +177,8 @@ spec:
           properties:
             enabled:
               description: >
-                Indicates if this deployment mode is available for this package.
+                Indicates if the agentless deployment mode is available for this template policy.
+                It is disabled by default.
               type: boolean
               default: false
             is_default:

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -173,6 +173,14 @@ spec:
           additionalProperties: false
           properties:
             enabled:
+              description: >
+                Indicates if this deployment mode is available for this package.
+              type: boolean
+              default: false
+            is_default:
+              description: >
+                On policy templates that support multiple deployment modes, this setting can be set to
+                true to use agentless mode by default.
               type: boolean
               default: false
             organization:
@@ -577,6 +585,12 @@ spec:
 
 # JSON patches for newer versions should be placed on top
 versions:
+  - before: 3.3.2
+    patch:
+      - op: remove
+        path: "/definitions/deployment_modes/properties/agentless/properties/is_default"
+      - op: remove
+        path: "/definitions/deployment_modes/properties/agentless/properties/resources"
   - before: 3.3.1
     patch:
       - op: remove

--- a/test/packages/bad_deployment_mode_resources/manifest.yml
+++ b/test/packages/bad_deployment_mode_resources/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.2.2
+format_version: 3.3.2
 name: bad_deployment_mode
 title: "Bad Deployment Mode"
 version: 0.0.1

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -36,6 +36,7 @@ policy_templates:
     deployment_modes:
       agentless:
         enabled: true
+        is_default: true
         organization: elastic
         division: observability
         team: obs-infraobs-integrations


### PR DESCRIPTION
## What does this PR do?

Add a setting that allows to make agentless the default deployment mode in cases where a policy template has multiple deployment modes enabled.

## Why is it important?

We have cases when policy templates can have multiple deployment modes, and developers want the agentless mode to be used by default.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/package-spec/issues/850.