### PR TITLE
Extend synthetic source compliance test and test with 8.18

### DIFF
--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -28,7 +28,7 @@ steps:
 EOF
 
 # Generate each test we want to do.
-compliance_test 8.17.0-SNAPSHOT 3.3.1
+compliance_test 8.18.0-SNAPSHOT 3.3.2
 compliance_test 8.16.0 3.3.0
 compliance_test 8.14.0 3.1.5
 compliance_test 8.9.0 2.7.0

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -205,6 +205,31 @@ func thereIsATransformAlias(transformAliasName string) error {
 	return godog.ErrPending
 }
 
+func indexTemplateIsConfiguredFor(indexTemplateName, option string) error {
+	es, err := NewElasticsearchClient()
+	if err != nil {
+		return err
+	}
+
+	indexTemplate, err := es.SimulateIndexTemplate(indexTemplateName)
+	if err != nil {
+		return err
+	}
+
+	switch option {
+	case "synthetic source mode":
+		if indexTemplate.Settings.Index.Mapping.Source.Mode == "synthetic" {
+			return nil
+		}
+		if indexTemplate.Mappings.Source.Mode == "synthetic" {
+			return nil
+		}
+		return errors.New("synthetic source mode is not enabled")
+	}
+
+	return godog.ErrPending
+}
+
 func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
 		skipped := slices.ContainsFunc(sc.Tags, func(elem *messages.PickleTag) bool {
@@ -223,4 +248,5 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^there is an index template "([^"]*)" with pattern "([^"]*)"$`, thereIsAnIndexTemplateWithPattern)
 	ctx.Step(`^there is a transform "([^"]*)"$`, thereIsATransform)
 	ctx.Step(`^there is a transform alias "([^"]*)"$`, thereIsATransformAlias)
+	ctx.Step(`^index template "([^"]*)" is configured for "([^"]*)"$`, indexTemplateIsConfiguredFor)
 }

--- a/compliance/features/synthetic-source.feature
+++ b/compliance/features/synthetic-source.feature
@@ -2,7 +2,8 @@ Feature: Synthetic source
   Support synthetic source
 
   @3.2.0
-  Scenario: Installer leverages source true
+  Scenario: Installer leverages synthetic source mode and fields with store true
    Given the "logs_synthetic_mode" package is installed
      And a policy is created with "logs_synthetic_mode" package and "1.0.0-beta1" version
-    Then index template "logs-logs_synthetic_mode.synthetic" has a field "decision_id" with "store:true"
+    Then index template "logs-logs_synthetic_mode.synthetic" is configured for "synthetic source mode"
+     And index template "logs-logs_synthetic_mode.synthetic" has a field "decision_id" with "store:true"

--- a/compliance/indextemplate.go
+++ b/compliance/indextemplate.go
@@ -21,7 +21,19 @@ type IndexTemplate struct {
 // SimulatedIndexTemplate contains the result of simulating an index template,
 // with the component templates resolved.
 type SimulatedIndexTemplate struct {
+	Settings struct {
+		Index struct {
+			Mapping struct {
+				Source struct {
+					Mode string `json:"mode"`
+				} `json:"source"`
+			} `json:"mapping"`
+		} `json:"index"`
+	} `json:"settings"`
 	Mappings struct {
+		Source struct {
+			Mode string `json:"mode"`
+		} `json:"_source"`
 		Runtime    map[string]MappingProperty `json:"runtime"`
 		Properties map[string]MappingProperty `json:"properties"`
 	} `json:"mappings"`

--- a/test/packages/logs_synthetic_mode/data_stream/synthetic/fields/some-fields.yml
+++ b/test/packages/logs_synthetic_mode/data_stream/synthetic/fields/some-fields.yml
@@ -1,3 +1,3 @@
 - name: decision_id
-  type: text
+  type: long
   store: true

--- a/test/packages/logs_synthetic_mode/data_stream/synthetic/fields/some-fields.yml
+++ b/test/packages/logs_synthetic_mode/data_stream/synthetic/fields/some-fields.yml
@@ -1,3 +1,5 @@
 - name: decision_id
+  # Checking with a long field because for text fields "store" is enabled by
+  # default since 8.18.
   type: long
   store: true


### PR DESCRIPTION
## What does this PR do?

Enable compliance tests with 8.18.

In compliance tests for synthetic source, explicitly check that synthetic source is enabled apart from checking the field with `store: true`.

## Why is it important?

Test with latest 8.x development branch.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Issues with this test discovered in https://github.com/elastic/package-spec/pull/859.