### PR TITLE
## What does this PR do?

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,6 +10,9 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
+    - description: Add kibana/security_ai_prompt to support security AI prompt assets.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/TODO_UPDATE_LINK_AFTER_OPENING_PR
 - version: 3.3.2
   changes:
     - description: Add support for required conditional groups of variables.

--- a/spec/integration/kibana/spec.yml
+++ b/spec/integration/kibana/spec.yml
@@ -65,6 +65,15 @@ spec:
       type: file
       contentMediaType: "application/json"
       pattern: '^.+\.json$'
+  - description: Folder containing security AI prompt assets
+    type: folder
+    name: security_ai_prompt
+    required: false
+    contents:
+    - description: A security AI prompt asset file
+      type: file
+      contentMediaType: "application/json"
+      pattern: '^{PACKAGE_NAME}-.+\.json$'
   - description: Folder containing rules
     type: folder
     name: "security_rule"
@@ -135,7 +144,7 @@ spec:
       contentMediaType: "application/json"
       pattern: '^{PACKAGE_NAME}-.+\.json$'
       forbiddenPatterns:
-        - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden 
+        - '^.+-(ecs|ECS)\.json$' # ECS suffix is forbidden
 versions:
   - before: 3.4.0
     patch:

--- a/test/packages/good/kibana/security_ai_prompt/good-security-ai-prompt-1.json
+++ b/test/packages/good/kibana/security_ai_prompt/good-security-ai-prompt-1.json
@@ -1,0 +1,12 @@
+{
+  "attributes": {
+    "promptId": "systemPrompt",
+    "promptGroupId": "aiAssistant",
+    "provider": "openai",
+    "prompt": {
+      "default": "You always talk like a pirate."
+    }
+  },
+  "id": "security_ai_prompts-6e46c1bd-84d5-4609-9bf0-2f9ec1fc789d",
+  "type": "security-ai-prompt"
+}


### PR DESCRIPTION
Adds `kibana/security_ai_prompt` to support security AI prompt assets.

## Why is it important?

In order to have the flexibility to tweak AI prompts outside of our regular ESS release schedule, `kibana/security_ai_prompt` assets introduce the ability to ship prompt updates for the security AI Assistant and Attack Discovery.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- <https://github.com/elastic/security-team/issues/11196>

## What does this PR do?

<!-- Mandatory
Explain here WHAT changes you made in the PR.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
