### PR TITLE
Add new integrations category: `siem`

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,6 +10,9 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
+    - description: Introduce siem category
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/807
 - version: 3.3.2
   changes:
     - description: Add support for required conditional groups of variables.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -12,7 +12,7 @@
       link: https://github.com/elastic/package-spec/pull/807
     - description: Introduce siem category
       type: enhancement
-      link: https://github.com/elastic/package-spec/pull/807
+      link: https://github.com/elastic/package-spec/pull/880
 - version: 3.3.2
   changes:
     - description: Add support for required conditional groups of variables.

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -79,6 +79,7 @@ spec:
           - proxy_security
           - sdk_search
           - security
+          - siem
           - stream_processing
           - support
           - threat_intel


### PR DESCRIPTION
## What does this PR do?

Introduces a new integrations category: `siem` 
(Will work on package registry and kibana changes next)

## Why is it important?

In order to support the designed figma for the AI4DSOC initiate, we need to have a new Security sub-category for `SIEM`. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~
- [X] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues
- https://github.com/elastic/security-team/issues/12103
