### PR TITLE
add flag which indicates if an integration package policy template is FIPS compatible

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -21,6 +21,9 @@
     - description: Add support for *.link files in agent, pipelines, and fields folders.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/888
+    - description: Add fips_compatible boolean flag for integration package policy templates.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/894
 - version: 3.3.5
   changes:
     - description: Allow security_rule assets in content package.

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -564,7 +564,7 @@ spec:
                 type: string
     allowed_in_fedramp_high:
       type: boolean
-      description: A flag which indicates if this integration is allowed in our ECH FedRAMP High product offering.
+      description: Indicate if this package is capable of satisfying FIPS requirements. Set to false if it uses any input that cannot be configured to use FIPS cryptography.
       default: true
   required:
     - format_version

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -532,6 +532,10 @@ spec:
             $ref: "#/definitions/screenshots"
           vars:
             $ref: "./data_stream/manifest.spec.yml#/definitions/vars"
+          fips_compatible:
+            type: boolean
+            description: Indicate if this package is capable of satisfying FIPS requirements. Set to false if it uses any input that cannot be configured to use FIPS cryptography.
+            default: true
         required:
           - name
           - title
@@ -562,10 +566,6 @@ spec:
               type: array
               items:
                 type: string
-    allowed_in_fedramp_high:
-      type: boolean
-      description: Indicate if this package is capable of satisfying FIPS requirements. Set to false if it uses any input that cannot be configured to use FIPS cryptography.
-      default: true
   required:
     - format_version
     - name

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -562,6 +562,10 @@ spec:
               type: array
               items:
                 type: string
+    allowed_in_fedramp_high:
+      type: boolean
+      description: A flag which indicates if this integration is allowed in our ECH FedRAMP High product offering.
+      default: true
   required:
     - format_version
     - name


### PR DESCRIPTION
add flag which indicates if an integration package is allowed to be installed in our ECH FedRAMP High environment