### PR TITLE
Add refresh_interval to spec

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,6 +10,9 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
+    - description: Add support for `refresh_interval` in data streams.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/911
 - version: 3.4.0
   changes:
     - description: Add kibana/security_ai_prompt to support security AI prompt assets.

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -280,6 +280,13 @@ spec:
               type: integer
               minimum: 1
               default: 1
+            refresh_interval:
+              description: >
+                The interval at which the index is refreshed. A lower value means that
+                documents are searchable sooner, but it can impact indexing performance.
+                Set to `-1` to disable automatic refreshes.
+              type: string
+              default: 1s
         mappings:
           description: Mappings section of index template
           type: object

--- a/test/packages/good_v3/data_stream/foo/manifest.yml
+++ b/test/packages/good_v3/data_stream/foo/manifest.yml
@@ -63,6 +63,7 @@ elasticsearch:
           dimension_fields:
             limit: 32
       number_of_shards: 1
+      refresh_interval: 1s
     mappings:
       dynamic: strict
       dynamic_templates:


### PR DESCRIPTION
## What does this PR do?

Add functionality to set the refresh_interval in the package

## Why is it important?

It allows to manage the refresh_interval settings inside the package, similar to the number_of_shards. This avoids having to create an @custom template.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).
