### PR TITLE
Add fips_compatible boolean flag for input package policy templates

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,6 +10,11 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
+- version: 3.4.1
+  changes:
+    - description: Add fips_compatible boolean flag for input package policy templates.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/914
 - version: 3.4.0
   changes:
     - description: Add kibana/security_ai_prompt to support security AI prompt assets.

--- a/spec/input/manifest.spec.yml
+++ b/spec/input/manifest.spec.yml
@@ -71,6 +71,8 @@ spec:
             $ref: "../integration/manifest.spec.yml#/definitions/deployment_modes"
           configuration_links:
             $ref: "../integration/manifest.spec.yml#/definitions/configuration_links"
+          fips_compatible:
+            $ref: "../integration/manifest.spec.yml#/definitions/fips_compatible"
           icons:
             $ref: "../integration/manifest.spec.yml#/definitions/icons"
           screenshots:

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -274,6 +274,10 @@ spec:
         - title
         - url
         - type
+    fips_compatible:
+      type: boolean
+      description: Indicate if this package is capable of satisfying FIPS requirements. Set to false if it uses any input that cannot be configured to use FIPS cryptography.
+      default: true
     icons:
       description: List of icons for by this package.
       type: array
@@ -481,6 +485,8 @@ spec:
             $ref: "#/definitions/deployment_modes"
           configuration_links:
             $ref: "#/definitions/configuration_links"
+          fips_compatible:
+            $ref: "#/definitions/fips_compatible"
           inputs:
             description: List of inputs supported by policy template.
             type: array
@@ -532,10 +538,6 @@ spec:
             $ref: "#/definitions/screenshots"
           vars:
             $ref: "./data_stream/manifest.spec.yml#/definitions/vars"
-          fips_compatible:
-            type: boolean
-            description: Indicate if this package is capable of satisfying FIPS requirements. Set to false if it uses any input that cannot be configured to use FIPS cryptography.
-            default: true
         required:
           - name
           - title

--- a/test/packages/good_input/manifest.yml
+++ b/test/packages/good_input/manifest.yml
@@ -22,6 +22,7 @@ policy_templates:
     description: Query the database to capture metrics.
     input: sql
     template_path: input.yml.hbs
+    fips_compatible: false
     vars:
       - name: hosts
         type: text

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -44,6 +44,7 @@ policy_templates:
           requests:
             memory: 1024M
             cpu: "0.5"
+    fips_compatible: false
     configuration_links:
       - title: View Agents
         url: "kbn:/app/fleet/agents"


### PR DESCRIPTION
## What does this PR do?

Add the `fips_compatible` flag to input packages too. It was added to integration packages in https://github.com/elastic/package-spec/pull/894.

Add tests for this flag.

## Why is it important?

We want this flag in input packages too, as of https://github.com/elastic/integrations/pull/14068/files#diff-fb59326b77824eddf3679997b911a05757b595bf8b64da7fef533e53f60401d6R15.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Required for part of https://github.com/elastic/integrations/pull/14068