### PR TITLE
Add support for discovery content packages based on datasets

### DIFF
--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -279,6 +279,7 @@ func TestValidateFile(t *testing.T) {
 				"field discovery.fields.0.name: Invalid type. Expected: string, given: integer",
 				"field discovery.fields.1: name is required",
 				"field discovery.fields.2.value: String length must be greater than or equal to 1",
+				"field discovery.datasets.0.name: Invalid type. Expected: string, given: integer",
 			},
 		},
 	}

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -277,8 +277,9 @@ func TestValidateFile(t *testing.T) {
 			"manifest.yml",
 			[]string{
 				"field discovery.fields.0.name: Invalid type. Expected: string, given: integer",
-				"field discovery.fields.1: name is required",
-				"field discovery.fields.2.value: String length must be greater than or equal to 1",
+				"field discovery.fields.1: Additional property foo is not allowed",
+				"field discovery.fields.2: name is required",
+				"field discovery.fields.3.value: String length must be greater than or equal to 1",
 				"field discovery.datasets.0.name: Invalid type. Expected: string, given: integer",
 				"field discovery.datasets.1: Additional property foo is not allowed",
 			},

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -280,6 +280,7 @@ func TestValidateFile(t *testing.T) {
 				"field discovery.fields.1: name is required",
 				"field discovery.fields.2.value: String length must be greater than or equal to 1",
 				"field discovery.datasets.0.name: Invalid type. Expected: string, given: integer",
+				"field discovery.datasets.1: Additional property foo is not allowed",
 			},
 		},
 	}

--- a/compliance/testdata/packages/basic_content/manifest.yml
+++ b/compliance/testdata/packages/basic_content/manifest.yml
@@ -27,6 +27,9 @@ discovery:
       value: 12345
     - name: test.boolean
       value: true
+  datasets:
+    - name: nginx.stubstatus
+    - name: nginx.error
 screenshots:
   - src: /img/kibana-system.png
     title: kibana system

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -18,6 +18,9 @@
     - description: Add support to define an optional value for discovery fields.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/917
+    - description: Add support for discovery content packages based on datasets.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/922
 - version: 3.4.0
   changes:
     - description: Add kibana/security_ai_prompt to support security AI prompt assets.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -21,6 +21,9 @@
     - description: Add support for discovery content packages based on datasets.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/922
+    - description: Disallow to add additional properties in discovery.fields.
+      type: bugfix
+      link: https://github.com/elastic/package-spec/pull/922
 - version: 3.4.0
   changes:
     - description: Add kibana/security_ai_prompt to support security AI prompt assets.

--- a/spec/content/manifest.spec.yml
+++ b/spec/content/manifest.spec.yml
@@ -14,7 +14,7 @@ spec:
       additionalProperties: false
       properties:
         datasets:
-          description: Description of the datasets this package can be used with.
+          description: List of the datasets this package can be used with. For a package to be used with an index, the `data_stream.dataset` field of this index should be one of the datasets listed here.
           type: array
           items:
             type: object
@@ -26,7 +26,7 @@ spec:
             required:
               - name
         fields:
-          description: Description of the fields this package can be used with.
+          description: List of fields this package expects to find in an index. For a package to be used with an index, the index should contain all the fields listed here.
           type: array
           items:
             type: object

--- a/spec/content/manifest.spec.yml
+++ b/spec/content/manifest.spec.yml
@@ -13,6 +13,17 @@ spec:
       type: object
       additionalProperties: false
       properties:
+        datasets:
+          description: Description of the datasets this package can be used with.
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                description: Name of the dataset.
+                type: string
+            required:
+              - name
         fields:
           description: Description of the fields this package can be used with.
           type: array

--- a/spec/content/manifest.spec.yml
+++ b/spec/content/manifest.spec.yml
@@ -30,6 +30,7 @@ spec:
           type: array
           items:
             type: object
+            additionalProperties: false
             properties:
               name:
                 description: Name of the field.

--- a/spec/content/manifest.spec.yml
+++ b/spec/content/manifest.spec.yml
@@ -18,6 +18,7 @@ spec:
           type: array
           items:
             type: object
+            additionalProperties: false
             properties:
               name:
                 description: Name of the dataset.

--- a/test/packages/bad_discovery_fields/manifest.yml
+++ b/test/packages/bad_discovery_fields/manifest.yml
@@ -19,6 +19,8 @@ discovery:
     - value: nginx.access
     - name: event.dataset
       value: ""
+  datasets:
+    - name: 12345
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot

--- a/test/packages/bad_discovery_fields/manifest.yml
+++ b/test/packages/bad_discovery_fields/manifest.yml
@@ -16,6 +16,8 @@ conditions:
 discovery:
   fields:
     - name: 12345
+    - name: myfield
+      foo: bar
     - value: nginx.access
     - name: event.dataset
       value: ""

--- a/test/packages/bad_discovery_fields/manifest.yml
+++ b/test/packages/bad_discovery_fields/manifest.yml
@@ -21,6 +21,8 @@ discovery:
       value: ""
   datasets:
     - name: 12345
+    - name: dataset.foo
+      foo: bar
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot

--- a/test/packages/good_content/manifest.yml
+++ b/test/packages/good_content/manifest.yml
@@ -26,6 +26,9 @@ discovery:
       value: 12345
     - name: test.boolean
       value: true
+  datasets:
+    - name: good_content.logs
+    - name: good_content.metrics
 screenshots:
   - src: /img/kibana-system.png
     title: kibana system


### PR DESCRIPTION
## What does this PR do?

Add discovery of content packages based on datasets .
It allows to define a new `discovery.datasets` key in the package manifests.

```yaml
discovery:
  datasets:
    - name: nginx.access
    - name: nginx.error
```

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Closes #919
- Depends on https://github.com/elastic/package-spec/pull/923
