### PR TITLE
Revert "Add support for an optional value in discovery fields"

### DIFF
--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -278,7 +278,7 @@ func TestValidateFile(t *testing.T) {
 			[]string{
 				"field discovery.fields.0.name: Invalid type. Expected: string, given: integer",
 				"field discovery.fields.1: name is required",
-				"field discovery.fields.2.value: String length must be greater than or equal to 1",
+				"field discovery.fields.2: name is required",
 			},
 		},
 	}

--- a/compliance/testdata/packages/basic_content/manifest.yml
+++ b/compliance/testdata/packages/basic_content/manifest.yml
@@ -19,14 +19,6 @@ conditions:
 discovery:
   fields:
     - name: process.pid
-    - name: event.dataset
-      value: nginx.access
-    - name: event.dataset
-      value: nginx.error
-    - name: process.owner.id
-      value: 12345
-    - name: test.boolean
-      value: true
 screenshots:
   - src: /img/kibana-system.png
     title: kibana system

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -15,9 +15,6 @@
     - description: Add fips_compatible boolean flag for input package policy templates.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/914
-    - description: Add support to define an optional value for discovery fields.
-      type: enhancement
-      link: https://github.com/elastic/package-spec/pull/917
 - version: 3.4.0
   changes:
     - description: Add kibana/security_ai_prompt to support security AI prompt assets.

--- a/spec/content/manifest.spec.yml
+++ b/spec/content/manifest.spec.yml
@@ -22,18 +22,6 @@ spec:
               name:
                 description: Name of the field.
                 type: string
-              value:
-                description: >
-                  An optional expected value for the "name" field.
-                oneOf:
-                - type: string
-                  minLength: 1
-                - type: number
-                - type: boolean
-                examples:
-                - "nginx.access"
-                - true
-                - 12345
             required:
               - name
   properties:

--- a/test/packages/bad_discovery_fields/manifest.yml
+++ b/test/packages/bad_discovery_fields/manifest.yml
@@ -16,9 +16,8 @@ conditions:
 discovery:
   fields:
     - name: 12345
+    - {}
     - value: nginx.access
-    - name: event.dataset
-      value: ""
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot

--- a/test/packages/good_content/manifest.yml
+++ b/test/packages/good_content/manifest.yml
@@ -18,14 +18,6 @@ conditions:
 discovery:
   fields:
     - name: process.pid
-    - name: event.dataset
-      value: nginx.access
-    - name: event.dataset
-      value: nginx.error
-    - name: process.owner.id
-      value: 12345
-    - name: test.boolean
-      value: true
 screenshots:
   - src: /img/kibana-system.png
     title: kibana system


### PR DESCRIPTION
## What does this PR do?

Revert the addition of the optional `value` field under `discovery.fields` in favor of `discovery.datasets` https://github.com/elastic/package-spec/issues/919


## Related issues

- Reverts elastic/package-spec#917
- Relates elastic/package-spec#919
