### PR TITLE
[CI] Fix trigger test integrations pipeline errors

### DIFF
--- a/.buildkite/scripts/run-installer-compliance.sh
+++ b/.buildkite/scripts/run-installer-compliance.sh
@@ -44,13 +44,13 @@ function start_stack() {
     local elastic_package="go run github.com/elastic/elastic-package"
 
     cd compliance
-    $elastic_package stack up -d --version $stack_version
+    $elastic_package stack up -d --version "$stack_version"
     eval $($elastic_package stack shellinit)
     cd -
 }
 
 echo "--- Start local Elastic Stack $STACK_VERSION with elastic-package"
-start_stack $STACK_VERSION
+start_stack "$STACK_VERSION"
 
 echo "--- Check compliance with Package Spec $SPEC_VERSION"
-TEST_SPEC_VERSION=$SPEC_VERSION TEST_SPEC_JUNIT=report-$STACK_VERSION-$SPEC_VERSION.xml make -C compliance test
+TEST_SPEC_VERSION="$SPEC_VERSION" TEST_SPEC_JUNIT="report-$STACK_VERSION-$SPEC_VERSION.xml" make -C compliance test

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -69,7 +69,20 @@ clone_repository() {
     retry 5 git clone https://github.com/elastic/integrations "${target}"
 }
 
+# This function retrieves the assignees for the pull request.
+# It checks if the head user is not "elastic" or the trigger user, and adds it to the list of assignees.
+# It returns a comma-separated list of assignees.
+get_assignees() {
+    local assignees="${GITHUB_PR_TRIGGER_USER}"
+    if [[ "${GITHUB_PR_HEAD_USER}" != "elastic" && "${GITHUB_PR_HEAD_USER}" != "${GITHUB_PR_TRIGGER_USER}" ]]; then
+        assignees="${assignees},${GITHUB_PR_HEAD_USER}"
+    fi
+    echo "${assignees}"
+}
+
 create_integrations_pull_request() {
+    local assignees=""
+    assignees=$(get_assignees)
     # requires GITHUB_TOKEN
     local temp_path
     temp_path=$(mktemp -d -p "${WORKSPACE}" -t "${TMP_FOLDER_TEMPLATE}")
@@ -83,7 +96,7 @@ create_integrations_pull_request() {
         --draft \
         --base "${INTEGRATIONS_SOURCE_BRANCH}" \
         --head "${INTEGRATIONS_PR_BRANCH}" \
-        --assignee "${GITHUB_PR_HEAD_USER}"
+        --assignee "${assignees}"
 }
 
 update_dependency() {
@@ -95,7 +108,7 @@ update_dependency() {
     local source_dep="github.com/${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}${VERSION_DEP}"
     local target_dep="github.com/${GITHUB_PR_OWNER}/${GITHUB_PR_REPO}${VERSION_DEP}@${GITHUB_PR_HEAD_SHA}"
 
-    go mod edit -replace ${source_dep}=${target_dep}
+    go mod edit -replace "${source_dep}=${target_dep}"
     go mod tidy
 
     git add go.mod
@@ -111,7 +124,6 @@ update_dependency() {
     git --no-pager show --format=oneline HEAD
     echo ""
 }
-
 
 exists_branch() {
     local owner="$1"
@@ -173,7 +185,6 @@ create_or_update_pull_request() {
     add_pr_comment "${BUILDKITE_PULL_REQUEST}" "$(get_integrations_pr_link "${integrations_pr_number}")"
 }
 
-
 add_pr_comment() {
     local source_pr_number="$1"
     local integrations_pr_link="$2"
@@ -184,6 +195,10 @@ add_pr_comment() {
         --repo "${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}"
 }
 
+if [[ "${BUILDKITE_PULL_REQUEST}" == "false" ]]; then
+    echo "Currently, this pipeline is just supported in Pull Requests."
+    exit 1
+fi
 
 echo "--- creating or updating integrations pull request"
 create_or_update_pull_request


### PR DESCRIPTION
This PR fixes the pipeline that test the PR with the packages defined in the integrations repository when it is used in PRs created by dependabot or updatecli automations.

This PR adds as assignee both:
- the user of the last commit push to the PR branch.
- the user that posted the comment `test integrations`.

Example of the error (e.g. dependabot PRs):
https://buildkite.com/elastic/elastic-package-test-with-integrations/builds/273

Example of PR assigning two users:
https://github.com/elastic/integrations/pull/14605

Relates https://github.com/elastic/elastic-package/pull/2749