### PR TITLE
[CI] Use buildkite plugin to set github token

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,17 +4,8 @@ source .buildkite/scripts/tooling.sh
 
 set -euo pipefail
 
-GO_VERSION=$(cat .go-version)
-export GO_VERSION
-
 # Secrets must be redacted
 # https://buildkite.com/docs/pipelines/managing-log-output#redacted-environment-variables
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "package-spec-test-with-integrations" && "$BUILDKITE_STEP_KEY" == "pr-integrations" ]]; then
-    # required to set the git commit information
-    GITHUB_USERNAME_SECRET="elasticmachine"
-    export GITHUB_USERNAME_SECRET=$GITHUB_USERNAME_SECRET
-    export GITHUB_EMAIL_SECRET="elasticmachine@elastic.co"
-    # required by `gh` commands
-    export GITHUB_TOKEN=$VAULT_GITHUB_TOKEN
-fi
+GO_VERSION=$(cat .go-version)
+export GO_VERSION

--- a/.buildkite/pipeline.test-with-integrations-repo.yml
+++ b/.buildkite/pipeline.test-with-integrations-repo.yml
@@ -26,6 +26,11 @@ steps:
   - label: ":hammer: Create PR in integrations"
     key: pr-integrations
     command: ".buildkite/scripts/test-with-integrations.sh"
+    env:
+      GITHUB_EMAIL: "elasticmachine@elastic.co"
+      GITHUB_USERNAME: "elastic-vault-github-plugin-prod"
+    plugins:
+      - elastic/vault-github-token#v0.1.0:
     agents:
       provider: "gcp"
     depends_on:

--- a/.buildkite/pipeline.test-with-integrations-repo.yml
+++ b/.buildkite/pipeline.test-with-integrations-repo.yml
@@ -30,6 +30,7 @@ steps:
       GITHUB_EMAIL: "elasticmachine@elastic.co"
       GITHUB_USERNAME: "elastic-vault-github-plugin-prod"
     plugins:
+      # Required to push branches, create PRs and post comments on PRs
       - elastic/vault-github-token#v0.1.0:
     agents:
       provider: "gcp"

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -104,7 +104,7 @@ update_dependency() {
     # allow not to commit if there are no changes
     # previous execution could fail and just pushed the branch but PR is not created
     if ! git diff-index --quiet HEAD ; then
-        git commit -m "Test elastic-package from PR ${BUILDKITE_PULL_REQUEST} - ${GITHUB_PR_HEAD_SHA}"
+        git commit -m "Test package-spec from PR ${BUILDKITE_PULL_REQUEST} - ${GITHUB_PR_HEAD_SHA}"
     fi
 
     echo ""

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -95,7 +95,7 @@ update_dependency() {
     local source_dep="github.com/${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}${VERSION_DEP}"
     local target_dep="github.com/${GITHUB_PR_OWNER}/${GITHUB_PR_REPO}${VERSION_DEP}@${GITHUB_PR_HEAD_SHA}"
 
-    go mod edit -replace ${source_dep}=${target_dep}
+    go mod edit -replace "${source_dep}=${target_dep}"
     go mod tidy
 
     git add go.mod

--- a/.buildkite/scripts/test-with-integrations.sh
+++ b/.buildkite/scripts/test-with-integrations.sh
@@ -54,8 +54,8 @@ get_source_commit_link() {
 }
 
 set_git_config() {
-    git config user.name "${GITHUB_USERNAME_SECRET}"
-    git config user.email "${GITHUB_EMAIL_SECRET}"
+    git config user.name "${GITHUB_USERNAME}"
+    git config user.email "${GITHUB_EMAIL}"
 }
 
 git_push() {


### PR DESCRIPTION
## What does this PR do?

Use https://github.com/elastic/vault-github-token-buildkite-plugin instead of using pre-command hooks with complicated conditions.
This helps to know what Buildkite step uses `VAULT_GITHUB_TOKEN` and self-document those sensitive details as it's a declarative syntax.

PR created after adding `test integrations` comment: https://github.com/elastic/integrations/pull/14610

### Author's checklist
- [x] Create integrations PR with `test integrations`
- [x] Posted the expected comments in the PR after `test integrations` comment.


### Related issues

- Relates https://github.com/elastic/integrations/pull/14408

