### PR TITLE
Add opentelemetry category

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -4,6 +4,9 @@
 ##
 - version: 3.5.0-next
   changes:
+    - description: Add support for opentelemetry category.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/123
     - description: Add support for `slo` assets.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/767

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -72,6 +72,7 @@ spec:
           - network_security
           - notification
           - observability
+          - opentelemetry
           - os_system
           - process_manager
           - productivity


### PR DESCRIPTION
Add support for opentelemetry category

Relates: https://github.com/elastic/package-spec/issues/939 