### PR TITLE
[CI] Update junit buildkite plugin

### DIFF
--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -41,7 +41,7 @@ cat <<EOF
       - label: ":junit: Annotate compliance test results"
         agents:
           # requires at least "bash", "curl" and "git"
-          image: "ruby:3.4.5-bookworm"
+          image: "docker.elastic.co/ci-agent-images/buildkite-junit-annotate:1.0"
         plugins:
           - junit-annotate#v2.7.0:
               artifacts: "compliance/report-*.xml"

--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -39,12 +39,14 @@ cat <<EOF
       - wait: ~
         continue_on_failure: true
       - label: ":junit: Annotate compliance test results"
+        agents:
+          # requires at least "bash", "curl" and "git"
+          image: "ruby:3.4.5-bookworm"
         plugins:
-          - junit-annotate#v2.5.0:
+          - junit-annotate#v2.7.0:
               artifacts: "compliance/report-*.xml"
               context: "compliance"
               report-skipped: true
               always-annotate: true
-        agents:
-          provider: "gcp"
+              run-in-docker: false
 EOF

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,14 +59,16 @@ steps:
             allow_failure: true
 
       - label: ":junit: Junit annotate"
+        agents:
+          # requires at least "bash", "curl" and "git"
+          image: "ruby:3.4.5-bookworm"
         plugins:
-          - junit-annotate#v2.5.0:
+          - junit-annotate#v2.7.0:
               artifacts: "build/test-results/*.xml"
               report-skipped: true
               always-annotate: true
               fail-build-on-error: true
-        agents:
-          provider: "gcp"
+              run-in-docker: false
         depends_on:
           - step: "preprocess-win-unit-results-files"
             allow_failure: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,7 +61,7 @@ steps:
       - label: ":junit: Junit annotate"
         agents:
           # requires at least "bash", "curl" and "git"
-          image: "ruby:3.4.5-bookworm"
+          image: "docker.elastic.co/ci-agent-images/buildkite-junit-annotate:1.0"
         plugins:
           - junit-annotate#v2.7.0:
               artifacts: "build/test-results/*.xml"


### PR DESCRIPTION
## What does this PR do?

Update [Buildkite junit-annotate plugin](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin) up to version 2.7.0

Set `run-in-docker: false` to use the ruby from the agent.

