### PR TITLE
feat(spec): Add duration variable data type

### DIFF
--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -51,8 +51,6 @@ func TestValidateFile(t *testing.T) {
 			[]string{
 				`field vars.1: Must not be present`,
 				`field vars.2: Must not be present`,
-				`field vars.3.default: Does not match pattern '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'`,
-				`field vars.4.default: Does not match pattern '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'`,
 			},
 		},
 		"bad_additional_content": {

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -51,6 +51,8 @@ func TestValidateFile(t *testing.T) {
 			[]string{
 				`field vars.1: Must not be present`,
 				`field vars.2: Must not be present`,
+				`field vars.3.default: Does not match pattern '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'`,
+				`field vars.4.default: Does not match pattern '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'`,
 			},
 		},
 		"bad_additional_content": {

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -46,6 +46,13 @@ func TestValidateFile(t *testing.T) {
 		"profiling_symbolizer":               {},
 		"logs_synthetic_mode":                {},
 		"kibana_configuration_links":         {},
+		"bad_duration_vars": {
+			"manifest.yml",
+			[]string{
+				`field vars.1: Must not be present`,
+				`field vars.2: Must not be present`,
+			},
+		},
 		"bad_additional_content": {
 			"bad-bad",
 			[]string{
@@ -361,7 +368,7 @@ func TestValidateItemNotAllowed(t *testing.T) {
 			},
 		},
 		"bad_nested_knowledge_base": {
-			"docs/knowledge_base" : []string{
+			"docs/knowledge_base": []string{
 				"nested_dir",
 				"file.txt",
 			},

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,6 +10,9 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
+    - description: Add `duration` variable data type with `min_duration` and `max_duration` validation properties.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/948
 - version: 3.4.2-next
   changes:
     - description: Allow to use underscores in benchmark file names.

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -67,7 +67,12 @@ spec:
             examples:
               - hosts
           type:
-            description: Data type of variable.
+            description: >
+              Data type of variable.
+              
+              A duration type is a sequence of decimal numbers, each with a unit
+              suffix, such as "60s", "1m" or "2h45m".
+              Valid time units are "ms", "s", "m", "h".
             type: string
             enum:
               - bool
@@ -80,6 +85,7 @@ spec:
               - time_zone
               - url
               - yaml
+              - duration
             examples:
               - text
           title:
@@ -144,6 +150,14 @@ spec:
               - ['http', 'https']
               - ['redis', 'rediss']
               - ['', 'mysql']
+          min_duration:
+            description: The minimum allowed duration value for duration data types.
+            type: string
+            pattern: '^(\d+[smh]|\d+ms)+$'
+          max_duration:
+            description: The maximum allowed duration value for duration data types.
+            type: string
+            pattern: '^(\d+[smh]|\d+ms)+$'
           default:
             description: Default value(s) for variable
             $ref: "#/definitions/input_variable_value"
@@ -197,6 +211,15 @@ spec:
            then:
              required:
                - secret
+         - if:
+             properties:
+               type:
+                 const: duration
+           then:
+             properties:
+               default:
+                 type: string
+                 pattern: '^(\d+[smh]|\d+ms)+$'
         required:
           - name
           - type
@@ -606,6 +629,16 @@ spec:
   - title
 # JSON patches for newer versions should be placed on top
 versions:
+  - before: 3.5.0
+    patch:
+      - op: remove
+        path: /definitions/vars/items/properties/type/enum/10
+      - op: remove
+        path: /definitions/vars/items/properties/max_duration
+      - op: remove
+        path: /definitions/vars/items/properties/min_duration
+      - op: remove
+        path: /definitions/vars/items/allOf/2
   - before: 3.3.2
     patch:
       - op: remove

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -72,7 +72,10 @@ spec:
               
               A duration type is a sequence of decimal numbers, each with a unit
               suffix, such as "60s", "1m" or "2h45m".
-              Valid time units are "ms", "s", "m", "h".
+              Duration values must follow these rules:
+              - Use time units of "ms", "s", "m", "h".
+              - When using min_duration, default, and max_duration,
+                they must satisfy: 0 <= min_duration <= default <= max_duration
             type: string
             enum:
               - bool
@@ -151,11 +154,11 @@ spec:
               - ['redis', 'rediss']
               - ['', 'mysql']
           min_duration:
-            description: The minimum allowed duration value for duration data types.
+            description: The minimum allowed duration value for duration data types. This property can only be used when the type is set to 'duration'.
             type: string
             pattern: '^(\d+[smh]|\d+ms)+$'
           max_duration:
-            description: The maximum allowed duration value for duration data types.
+            description: The maximum allowed duration value for duration data types. This property can only be used when the type is set to 'duration'.
             type: string
             pattern: '^(\d+[smh]|\d+ms)+$'
           default:
@@ -220,6 +223,16 @@ spec:
                default:
                  type: string
                  pattern: '^(\d+[smh]|\d+ms)+$'
+         - if:
+             not:
+               properties:
+                 type:
+                   const: duration
+           then:
+             not:
+               anyOf:
+                 - required: [min_duration]
+                 - required: [max_duration]
         required:
           - name
           - type
@@ -631,6 +644,7 @@ spec:
 versions:
   - before: 3.5.0
     patch:
+      # Require >=3.5.0 to use the duration variable type.
       - op: remove
         path: /definitions/vars/items/properties/type/enum/10
       - op: remove

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -76,8 +76,6 @@ spec:
               - Use time units of "ms", "s", "m", "h".
               - When using min_duration, default, and max_duration,
                 they must satisfy: 0 <= min_duration <= default <= max_duration
-              - Units must appear in descending order of magnitude (h->m->s->ms)
-              - Each unit can appear at most once in a duration value
             type: string
             enum:
               - bool
@@ -158,11 +156,11 @@ spec:
           min_duration:
             description: The minimum allowed duration value for duration data types. This property can only be used when the type is set to 'duration'.
             type: string
-            pattern: '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'
+            pattern: '^(\d+[smh]|\d+ms)+$'
           max_duration:
             description: The maximum allowed duration value for duration data types. This property can only be used when the type is set to 'duration'.
             type: string
-            pattern: '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'
+            pattern: '^(\d+[smh]|\d+ms)+$'
           default:
             description: Default value(s) for variable
             $ref: "#/definitions/input_variable_value"
@@ -224,7 +222,7 @@ spec:
              properties:
                default:
                  type: string
-                 pattern: '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'
+                 pattern: '^(\d+[smh]|\d+ms)+$'
          - if:
              not:
                properties:

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -76,6 +76,8 @@ spec:
               - Use time units of "ms", "s", "m", "h".
               - When using min_duration, default, and max_duration,
                 they must satisfy: 0 <= min_duration <= default <= max_duration
+              - Units must appear in descending order of magnitude (h->m->s->ms)
+              - Each unit can appear at most once in a duration value
             type: string
             enum:
               - bool
@@ -156,11 +158,11 @@ spec:
           min_duration:
             description: The minimum allowed duration value for duration data types. This property can only be used when the type is set to 'duration'.
             type: string
-            pattern: '^(\d+[smh]|\d+ms)+$'
+            pattern: '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'
           max_duration:
             description: The maximum allowed duration value for duration data types. This property can only be used when the type is set to 'duration'.
             type: string
-            pattern: '^(\d+[smh]|\d+ms)+$'
+            pattern: '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'
           default:
             description: Default value(s) for variable
             $ref: "#/definitions/input_variable_value"
@@ -222,7 +224,7 @@ spec:
              properties:
                default:
                  type: string
-                 pattern: '^(\d+[smh]|\d+ms)+$'
+                 pattern: '^(?:\d+h)?(?:\d+m)?(?:\d+s)?(?:\d+ms)?$'
          - if:
              not:
                properties:

--- a/test/packages/bad_duration_vars/changelog.yml
+++ b/test/packages/bad_duration_vars/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link

--- a/test/packages/bad_duration_vars/docs/README.md
+++ b/test/packages/bad_duration_vars/docs/README.md
@@ -1,0 +1,1 @@
+# Bad Duration Vars

--- a/test/packages/bad_duration_vars/manifest.yml
+++ b/test/packages/bad_duration_vars/manifest.yml
@@ -23,6 +23,12 @@ vars:
   - name: max_duration_requires_type_duration
     type: text
     max_duration: 2h
+  - name: duration_unit_may_be_used_only_once
+    type: duration
+    default: 1h1h
+  - name: duration_units_must_be_ordered
+    type: duration
+    default: 5m1h
 
 owner:
   github: elastic/ecosystem

--- a/test/packages/bad_duration_vars/manifest.yml
+++ b/test/packages/bad_duration_vars/manifest.yml
@@ -1,0 +1,29 @@
+format_version: 3.5.0
+name: bad_duration_vars
+title: "Bad Durations Vars"
+version: 0.0.1
+source:
+  license: "Apache-2.0"
+description: "Test invalid duration variable types."
+type: integration
+categories:
+  - custom
+conditions:
+  kibana:
+    version: "^9.2.0"
+  elastic:
+    subscription: "basic"
+vars:
+  - name: duration_valid
+    type: duration
+    default: 100h90m80s70ms
+  - name: min_duration_requires_type_duration
+    type: text
+    min_duration: 1h
+  - name: max_duration_requires_type_duration
+    type: text
+    max_duration: 2h
+
+owner:
+  github: elastic/ecosystem
+  type: elastic

--- a/test/packages/bad_duration_vars/manifest.yml
+++ b/test/packages/bad_duration_vars/manifest.yml
@@ -23,12 +23,6 @@ vars:
   - name: max_duration_requires_type_duration
     type: text
     max_duration: 2h
-  - name: duration_unit_may_be_used_only_once
-    type: duration
-    default: 1h1h
-  - name: duration_units_must_be_ordered
-    type: duration
-    default: 5m1h
 
 owner:
   github: elastic/ecosystem

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -105,6 +105,11 @@ policy_templates:
             title: API URL
             show_user: true
             required: true
+          - name: interval
+            type: duration
+            min_duration: 10s
+            max_duration: 4h3m2s1ms
+            default: 1m
   - name: apache-agentless
     title: Apache logs and metrics in agentless
     description: Collect logs and metrics from Apache instances in agentless


### PR DESCRIPTION
## What does this PR do?

```
Adds a new duration variable data type that allows defining time-based values
like "60s", "1m", or "2h45m". The valid time units are "ms", "s", "m", and "h".

This change introduces two new validation properties, min_duration and 
max_duration, which are only applicable to variables of type duration.  The 
default value for a duration variable must also conform to the duration format.

The 'd' (day) unit is intentionally not supported. This design decision mirrors
the Go language's time.Duration type, which avoids units of a day or larger.
The ambiguity of a "day" (which can be 23, 24, or 25 hours long due to daylight
saving time) can lead to subtle bugs in time-based calculations. By omitting
it, we enforce more precise and less ambiguous time interval definitions.

Includes test cases for valid and invalid duration configurations to ensure
correct validation.

Relates #44
```

> [!IMPORTANT]  
> This feature relies on Kibana support being added via https://github.com/elastic/kibana/pull/231027.


## Why is it important?

User input validation is important for good usability. Having a specific duration
type will support validation the user's inputs as early as possible.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Relates #44





