### PR TITLE
Remove invalid declaration of optional setting

### DIFF
--- a/spec/integration/elasticsearch/transform/manifest.spec.yml
+++ b/spec/integration/elasticsearch/transform/manifest.spec.yml
@@ -11,7 +11,6 @@ spec:
     destination_index_template:
       description: Elasticsearch index template for the transform's destination index
       $ref: "#/definitions/index_template"
-      required: false
     start:
       description: Determines if the transform will be started upon installation
       type: boolean


### PR DESCRIPTION
`required` cannot be used at this point. Remove it and keep it optional.

Closes https://github.com/elastic/package-spec/issues/957.