### PR TITLE
Fix transform index spec

### DIFF
--- a/code/go/internal/yamlschema/schema_spec.go
+++ b/code/go/internal/yamlschema/schema_spec.go
@@ -28,6 +28,7 @@ func (i *itemSchemaSpec) resolve(target semver.Version) (map[string]interface{},
 		// Nothing to do.
 		return i.Spec, nil
 	}
+
 	spec, err := specpatch.ResolvePatch(i.Spec, patchJSON)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply patch: %w", err)

--- a/spec/integration/elasticsearch/transform/manifest.spec.yml
+++ b/spec/integration/elasticsearch/transform/manifest.spec.yml
@@ -11,6 +11,24 @@ spec:
           type: object
           additionalProperties: false
           properties:
+            analysis:
+              type: object
+              additionalProperties: false
+              properties:
+                analyzer:
+                  description: Definition of custom analyzer.
+                  type: object
+                  additionalProperties:
+                    type: object
+                    additionalProperties: false
+                    properties:
+                      type:
+                        description: Type of analyzer
+                        type: string
+                        enum:
+                          - pattern
+                      pattern:
+                        type: string
             index:
               type: object
               additionalProperties: false
@@ -21,15 +39,67 @@ spec:
                   enum:
                     - lookup
                 codec:
-                  $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/index/properties/codec"
+                  description: >
+                    Type of compression to use. The default is to use LZ4, `best_compression` uses DEFLATE,
+                    with higher compression but lower ingestion performance.
+                  type: string
+                  enum:
+                    - default
+                    - best_compression
+                refresh_interval:
+                  description: >
+                    How often to perform a refresh operation, which makes recent changes to the index visible to search.
+                  type: string
+                  example: 1s
                 mapping:
-                  $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/index/properties/mapping"
+                  type: object
+                  additionalProperties: false
+                  patternProperties:
+                    "^(dimension|nested|total)_fields$":
+                      type: object
+                      additionalProperties: false
+                      properties:
+                        limit:
+                          description: Limit on the number of fields of this kind on this data stream.
+                          type: integer
                 sort:
-                  $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/index/properties/sort"
-            number_of_shards:
-              $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/number_of_shards"
-            analysis:
-              $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/analysis"
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    field:
+                      description: Fields used to sort the document in the Lucene segments.
+                      oneOf:
+                        - type: string
+                        - type: array
+                          items:
+                            type: string
+                    order:
+                      description: The sort order to use for each field.
+                      oneOf:
+                        - type: string
+                          enum:
+                            - asc
+                            - desc
+                        - type: array
+                          items:
+                            type: string
+                            enum:
+                              - asc
+                              - desc
+                number_of_shards:
+                  description: Number of primary shards that the data stream should have.
+                  type: integer
+                  minimum: 1
+                  default: 1
+                number_of_routing_shards:
+                  description: Number used when splitting shards.
+                  type: integer
+                  minimum: 1
+                  default: 1
+                hidden:
+                  description: Makes the index hidden.
+                  type: boolean
+                  default: false
         mappings:
           $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/mappings"
         ingest_pipeline:
@@ -42,8 +112,8 @@ spec:
       default: true
 
 
-#versions:
-#  - before: 3.4.0
-#    patch:
-#      - op: remove
-#        path: "/properties/destination_index_template/properties/settings/properties/index" # Lookup index mode is not supported in older stacks.
+versions:
+  - before: 3.4.0
+    patch:
+      - op: remove
+        path: "/properties/destination_index_template/properties/settings/properties/index/properties/mode" # Lookup index mode is not supported in older stacks.

--- a/spec/integration/elasticsearch/transform/manifest.spec.yml
+++ b/spec/integration/elasticsearch/transform/manifest.spec.yml
@@ -1,45 +1,49 @@
-type: object
-additionalProperties: false
-definitions:
-  index_template:
-    $ref: "../../data_stream/manifest.spec.yml#/properties/elasticsearch/properties/index_template"
-properties:
-  destination_index_template:
-    description: Elasticsearch index template for the transform's destination index
-    type: object
-    additionalProperties: false
-    properties:
-      settings:
-        type: object
-        additionalProperties: false
-        properties:
-          index:
-            type: object
-            additionalProperties: false
-            properties:
-              mode:
-                description: Index mode for lookup indices.
-                type: string
-                enum:
-                  - lookup
-              codec:
-                $ref: "../../data_stream/manifest.spec.yml#/properties/elasticsearch/properties/index_template/properties/settings/properties/index/properties/codec"
-              mapping:
-                $ref: "../../data_stream/manifest.spec.yml#/properties/elasticsearch/properties/index_template/properties/settings/properties/index/properties/mapping"
-              sort:
-                $ref: "../../data_stream/manifest.spec.yml#/properties/elasticsearch/properties/index_template/properties/settings/properties/index/properties/sort"
-          number_of_shards:
-            $ref: "../../data_stream/manifest.spec.yml#/properties/elasticsearch/properties/index_template/properties/settings/properties/number_of_shards"
-          analysis:
-            $ref: "../../data_stream/manifest.spec.yml#/properties/elasticsearch/properties/index_template/properties/settings/properties/analysis"
-      mappings:
-        $ref: "../../data_stream/manifest.spec.yml#/properties/elasticsearch/properties/index_template/properties/mappings"
-      ingest_pipeline:
-        $ref: "../../data_stream/manifest.spec.yml#/properties/elasticsearch/properties/index_template/properties/ingest_pipeline"
-      data_stream:
-        $ref: "../../data_stream/manifest.spec.yml#/properties/elasticsearch/properties/index_template/properties/data_stream"
-    required: false
-  start:
-    description: Determines if the transform will be started upon installation
-    type: boolean
-    default: true
+spec:
+  type: object
+  additionalProperties: false
+  properties:
+    destination_index_template:
+      description: Elasticsearch index template for the transform's destination index
+      type: object
+      additionalProperties: false
+      properties:
+        settings:
+          type: object
+          additionalProperties: false
+          properties:
+            index:
+              type: object
+              additionalProperties: false
+              properties:
+                mode:
+                  description: Index mode for lookup indices.
+                  type: string
+                  enum:
+                    - lookup
+                codec:
+                  $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/index/properties/codec"
+                mapping:
+                  $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/index/properties/mapping"
+                sort:
+                  $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/index/properties/sort"
+            number_of_shards:
+              $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/number_of_shards"
+            analysis:
+              $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/settings/properties/analysis"
+        mappings:
+          $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/mappings"
+        ingest_pipeline:
+          $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/ingest_pipeline"
+        data_stream:
+          $ref: "../../data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template/properties/data_stream"
+    start:
+      description: Determines if the transform will be started upon installation
+      type: boolean
+      default: true
+
+
+#versions:
+#  - before: 3.4.0
+#    patch:
+#      - op: remove
+#        path: "/properties/destination_index_template/properties/settings/properties/index" # Lookup index mode is not supported in older stacks.


### PR DESCRIPTION
While attempting to follow with https://github.com/elastic/package-spec/pull/936#discussion_r2298336064, I found that no spec was being applied to the transform index manifests.

## What does this PR do?

Fix transform index spec.

We removed `spec` from https://github.com/elastic/package-spec/pull/936 by mistake. After adding it back it is discovered that several mappings are not being properly imported.

Duplicate them by now.

Also, drop `index.mode` from spec versions older than 3.4, as `lookup` mode is not supported in old versions of the stack.

## Why is it important?

Properly validate transform index definitions.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~ There are tests covering this.
- [ ] ~~I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).~~ Fixes unreleased changes.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Follow up to https://github.com/elastic/package-spec/pull/936