### PR TITLE
fix(data_stream manifest): move required_var minItems

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -13,6 +13,9 @@
     - description: Add `duration` variable data type with `min_duration` and `max_duration` validation properties.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/948
+    - description: Fix required_var minItems validation in data stream manifest schema.
+      type: bugfix
+      link: https://github.com/elastic/package-spec/pull/965
 - version: 3.4.3-next
   changes:
     - description: Add support for lookup indices.

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -39,8 +39,8 @@ spec:
       patternProperties:
         "^[a-zA-Z0-9_]+$":
           type: array
+          minItems: 1
           items:
-            minItems: 1
             type: object
             required:
               - name


### PR DESCRIPTION
## What does this PR do?

minItems was placed incorrectly on an object rather than on the array.

The JSON pointer to the invalid attribute is:

    /definitions/required_vars/patternProperties/^[a-zA-Z0-9_]+$/items/minItems

https://json-schema.org/understanding-json-schema/reference/array#length

## Why is it important?

The validation of required_vars may not be working as intended by the author.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
