### PR TITLE
fix(data_stream manifest): dynamic_date_formats example type

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -13,14 +13,14 @@
     - description: Add `duration` variable data type with `min_duration` and `max_duration` validation properties.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/948
-    - description: Fix dynamic_date_formats example type in data stream manifest schema.
-      type: bugfix
-      link: https://github.com/elastic/package-spec/pull/966
 - version: 3.4.3-next
   changes:
     - description: Add support for lookup indices.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/936
+    - description: Fix dynamic_date_formats example type in data stream manifest schema.
+      type: bugfix
+      link: https://github.com/elastic/package-spec/pull/966
 - version: 3.4.2
   changes:
     - description: Add optional docs_structure_enforced parameter to validation.yml.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -13,6 +13,9 @@
     - description: Add `duration` variable data type with `min_duration` and `max_duration` validation properties.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/948
+    - description: Fix dynamic_date_formats example type in data stream manifest schema.
+      type: bugfix
+      link: https://github.com/elastic/package-spec/pull/966
 - version: 3.4.3-next
   changes:
     - description: Add support for lookup indices.

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -344,9 +344,9 @@ spec:
               type: array
               items:
                 type: string
-                examples:
-                  - ["strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"] # This is the default if not set.
-                  - ["MM/dd/yyyy"]
+              examples:
+                - ["strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"] # This is the default if not set.
+                - ["MM/dd/yyyy"]
             dynamic_templates:
               type: array
               items:


### PR DESCRIPTION
## What does this PR do?

The dynamic_date_formats examples values are arrays, but they are specified on a type=string. For the examples to be valid they need to be elevated up to the array.

The problematic JSON pointer is

    /definitions/elasticsearch_index_template/properties/mappings/properties/dynamic_date_formats/items/examples

## Why is it important?

The examples should be valid based on our specification.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
