### PR TITLE
fix(spec): remove additionalProperties=true

### DIFF
--- a/spec/integration/_dev/benchmark/system.scenario.spec.yml
+++ b/spec/integration/_dev/benchmark/system.scenario.spec.yml
@@ -96,7 +96,6 @@ spec:
                 raw:
                   description: Raw config.
                   type: object
-                  additionalProperties: true
                 path:
                   description: Config path.
                   type: string
@@ -108,7 +107,6 @@ spec:
                 raw:
                   description: Raw fields.
                   type: object
-                  additionalProperties: true
                 path:
                   description: Fields path.
                   type: string

--- a/spec/integration/_dev/deploy/variants.spec.yml
+++ b/spec/integration/_dev/deploy/variants.spec.yml
@@ -10,7 +10,6 @@ spec:
     variants:
       description: Variant names and their configurations
       type: object
-      additionalProperties: true
     default:
       description: Default variant to use
       type: string

--- a/spec/integration/data_stream/_dev/benchmark/pipeline/event.spec.yml
+++ b/spec/integration/data_stream/_dev/benchmark/pipeline/event.spec.yml
@@ -11,5 +11,4 @@ spec:
       type: array
       items:
         type: object
-        additionalProperties: true
   required: [ "events" ]

--- a/spec/integration/data_stream/_dev/test/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/config.spec.yml
@@ -25,7 +25,6 @@ spec:
       type:
         - "null"
         - object
-      additionalProperties: true
       properties:
         "data_stream.dataset":
           type: string

--- a/spec/integration/data_stream/_dev/test/pipeline/common_config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/pipeline/common_config.spec.yml
@@ -7,14 +7,12 @@ spec:
     fields:
       description: Field definitions
       type: object
-      additionalProperties: true
     dynamic_fields:
       description: Dynamic fields with regular expressions defining their variable values.
       type: object
     multiline:
       description: Multi-line configuration
       type: object
-      additionalProperties: true
     numeric_keyword_fields:
       description: List of keyword type fields allowed to have a numeric value.
       type: array

--- a/spec/integration/data_stream/_dev/test/pipeline/config_json.spec.yml
+++ b/spec/integration/data_stream/_dev/test/pipeline/config_json.spec.yml
@@ -7,7 +7,6 @@ spec:
     fields:
       description: Field definitions
       type: object
-      additionalProperties: true
     dynamic_fields:
       description: Dynamic fields with regular expressions defining their variable values.
       type: object

--- a/spec/integration/data_stream/_dev/test/pipeline/config_raw.spec.yml
+++ b/spec/integration/data_stream/_dev/test/pipeline/config_raw.spec.yml
@@ -7,14 +7,12 @@ spec:
     fields:
       description: Field definitions
       type: object
-      additionalProperties: true
     dynamic_fields:
       description: Dynamic fields with regular expressions defining their variable values.
       type: object
     multiline:
       description: Multi-line configuration
       type: object
-      additionalProperties: true
     numeric_keyword_fields:
       description: List of keyword type fields allowed to have a numeric value.
       type: array

--- a/spec/integration/data_stream/_dev/test/pipeline/event.spec.yml
+++ b/spec/integration/data_stream/_dev/test/pipeline/event.spec.yml
@@ -11,5 +11,4 @@ spec:
       type: array
       items:
         type: object
-        additionalProperties: true
   required: [ "events" ]

--- a/spec/integration/data_stream/_dev/test/pipeline/expected.spec.yml
+++ b/spec/integration/data_stream/_dev/test/pipeline/expected.spec.yml
@@ -9,7 +9,6 @@ spec:
     optionalTestResult:
       anyOf:
         - type: object
-          additionalProperties: true
         - type: "null"
   properties:
     expected:

--- a/spec/integration/data_stream/_dev/test/static/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/static/config.spec.yml
@@ -4,7 +4,6 @@
 spec:
   # Everything under here follows JSON schema (https://json-schema.org/), written as YAML for readability
   type: object
-  additionalProperties: true
   properties:
     skip:
       $ref: "./../config.spec.yml#/definitions/skip"

--- a/spec/integration/data_stream/_dev/test/system/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/system/config.spec.yml
@@ -4,7 +4,6 @@
 spec:
   # Everything under here follows JSON schema (https://json-schema.org/), written as YAML for readability
   type: object
-  additionalProperties: true
   properties:
     skip:
       $ref: "./../config.spec.yml#/definitions/skip"
@@ -26,7 +25,6 @@ spec:
     agent:
       description: "Configuration overrides for the Elastic Agent"
       type: object
-      additionalProperties: true
       properties:
         runtime:
           description: "Runtime to run the Elastic Agent process"
@@ -165,7 +163,6 @@ spec:
       type:
         - "null"
         - object
-      additionalProperties: true
       properties:
         vars:
           description: Variables used to configure settings defined in the data stream manifest.

--- a/spec/integration/data_stream/fields/fields.spec.yml
+++ b/spec/integration/data_stream/fields/fields.spec.yml
@@ -121,7 +121,6 @@ spec:
                 - type: number
                 - type: boolean
           - type: object
-            additionalProperties: true
 
       metric_type:
         description: >


### PR DESCRIPTION
## What does this PR do?

The default behavior is to allow addional properties so setting the `additionalProperties` keyword to the true schema does not add any further constraint.

## Why is it important?

The explicit true value is misleading as it's the default behavior, causing developers to incorrectly assume it's required for validation to accept additional properties.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
