### PR TITLE
Fix changelog, 3.4.2 version has not been released

### DIFF
--- a/.buildkite/pipeline.trigger.compliance.tests.sh
+++ b/.buildkite/pipeline.trigger.compliance.tests.sh
@@ -28,8 +28,8 @@ steps:
 EOF
 
 # Generate each test we want to do.
-compliance_test 9.1.0-SNAPSHOT 3.4.3
-compliance_test 8.19.0-SNAPSHOT 3.4.3
+compliance_test 9.1.0-SNAPSHOT 3.4.2
+compliance_test 8.19.0-SNAPSHOT 3.4.2
 compliance_test 9.0.1 3.3.5
 compliance_test 8.14.0 3.1.5
 compliance_test 8.9.0 2.7.0

--- a/compliance/features/esql.feature
+++ b/compliance/features/esql.feature
@@ -1,7 +1,7 @@
 Feature: ES|QL
   Features related to ES|QL
 
-  @3.4.3
+  @3.4.2
   Scenario: Installer leverages lookup index mode
    Given the "good_lookup_index" package is installed
      And a policy is created with "good_lookup_index" package and "0.1.4" version

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -16,12 +16,7 @@
     - description: Add support for Kibana `alerting_rule_template` assets, which can be used to create alert rules.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/918
-- version: 3.4.3-next
-  changes:
-    - description: Add support for lookup indices.
-      type: enhancement
-      link: https://github.com/elastic/package-spec/pull/936
-- version: 3.4.2
+- version: 3.4.2-next
   changes:
     - description: Add optional docs_structure_enforced parameter to validation.yml.
       type: enhancement
@@ -35,6 +30,9 @@
     - description: Fix paths with slashes displayed on Windows.
       type: bugfix
       link: https://github.com/elastic/package-spec/pull/953
+    - description: Add support for lookup indices.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/936
 - version: 3.4.1
   changes:
     - description: Add fips_compatible boolean flag for input package policy templates.

--- a/test/packages/good_lookup_index/manifest.yml
+++ b/test/packages/good_lookup_index/manifest.yml
@@ -1,5 +1,4 @@
-
-format_version: 3.4.3
+format_version: 3.4.2
 name: good_lookup_index
 title: "good_lookup_index"
 version: 0.1.4


### PR DESCRIPTION
## What does this PR do?

Fix changelog and referenced versions, 3.4.2 version has not been released yet.

## Why is it important?

It shows some changes as released but they haven't been released yet.