### PR TITLE
Fix alerting_rule_template typeMigrationVersion values in test packages

### DIFF
--- a/test/packages/good_content/kibana/alerting_rule_template/apm-anomaly-rule-test.json
+++ b/test/packages/good_content/kibana/alerting_rule_template/apm-anomaly-rule-test.json
@@ -21,5 +21,5 @@
     }
   },
   "coreMigrationVersion": "8.8.0",
-  "typeMigrationVersion": "10.6.0"
+  "typeMigrationVersion": "10.1.0"
 }

--- a/test/packages/good_v3/kibana/alerting_rule_template/apm-anomaly-rule-test.json
+++ b/test/packages/good_v3/kibana/alerting_rule_template/apm-anomaly-rule-test.json
@@ -21,5 +21,5 @@
     }
   },
   "coreMigrationVersion": "8.8.0",
-  "typeMigrationVersion": "10.6.0"
+  "typeMigrationVersion": "10.1.0"
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the `typeMigrationVersion` values for `alerting_rule_template` fixtures. 

## Why is it important?

If a user were to test package installation using one of these test packages it would fail on the alerting rule templates due to the wrong typeMigrationVersion for the saved object.

## Checklist

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

Relates: https://github.com/elastic/kibana/issues/229687
