### PR TITLE
[CI] Update gvm version

### DIFF
--- a/.buildkite/pipeline.test-with-integrations-repo.yml
+++ b/.buildkite/pipeline.test-with-integrations-repo.yml
@@ -1,5 +1,5 @@
 env:
-  SETUP_GVM_VERSION: 'v0.5.1' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  SETUP_GVM_VERSION: 'v0.6.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   GO_LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   GH_CLI_VERSION: "2.29.0"
   JQ_VERSION: "1.7"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  SETUP_GVM_VERSION: 'v0.5.1' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  SETUP_GVM_VERSION: 'v0.6.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   SETUP_MAGE_VERSION: "latest"
   DOCKER_COMPOSE_VERSION: "v2.17.2"
   GO_LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"


### PR DESCRIPTION
## What does this PR do?

Update to the latest GVM version ([v0.6.0](https://github.com/andrewkroh/gvm/releases/tag/v0.6.0)) to avoid issues downloading Golang.

As a context:
- https://github.com/elastic/integrations/pull/15675
- https://github.com/elastic/integrations/pull/15675#issuecomment-3416806751
