### PR TITLE
Remove required agent version requirement

### DIFF
--- a/code/go/internal/validator/semantic/validate_agent_version.go
+++ b/code/go/internal/validator/semantic/validate_agent_version.go
@@ -5,7 +5,6 @@
 package semantic
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
@@ -34,7 +33,7 @@ func ValidateMinimumAgentVersion(fsys fspath.FS) specerrors.ValidationErrors {
 
 	if agentVersionCondition != "" {
 		if _, err := semver.NewConstraint(agentVersionCondition); err != nil {
-			return specerrors.ValidationErrors{specerrors.NewStructuredError(errors.Join(err, errInvalidAgentVersionCondition), specerrors.UnassignedCode)}
+			return specerrors.ValidationErrors{specerrors.NewStructuredErrorf("file \"%s\" is invalid: %w: %w", fsys.Path(manifest.Name()), errInvalidAgentVersionCondition, err)}
 		}
 	}
 

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -321,7 +321,7 @@ func TestValidateFile(t *testing.T) {
 		"bad_agent_version_v3": {
 			"manifest.yml",
 			[]string{
-				"field conditions.agent: version is required",
+				"invalid agent.version condition: improper constraint: version",
 			},
 		},
 		"bad_integration_stream_template_path": {

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -8,9 +8,6 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
-    - description: Require defining agent version constraints in input and integration packages.
-      type: breaking-change
-      link: https://github.com/elastic/package-spec/pull/999
     - description: Add pipeline tag validations.
       type: breaking-change
       link: https://github.com/elastic/package-spec/pull/1010

--- a/spec/input/manifest.spec.yml
+++ b/spec/input/manifest.spec.yml
@@ -124,14 +124,11 @@ spec:
   - version
   - type
   - owner
-  - conditions
 
 # JSON patches for newer versions should be placed on top
 versions:
   - before: 3.6.0
     patch:
-      - op: remove
-        path: "/required/7" # removes requirement for conditions
       - op: remove
         path: "/properties/deprecated" # removes deprecated field for package
       - op: remove

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -227,10 +227,6 @@ spec:
               description: Elastic Agent versions compatible with this package.
               examples:
                 - "^9.5.0"
-          required:
-            - version
-      required:
-        - agent
     description:
       description: >
         A longer description of the package. It should describe, at least all the kinds of
@@ -723,7 +719,6 @@ spec:
     - version
     - type
     - owner
-    - conditions
   allOf:
     - if:
         properties:
@@ -748,12 +743,6 @@ spec:
 versions:
   - before: 3.6.0
     patch:
-      - op: remove
-        path: "/required/7" # removes requirement for conditions
-      - op: remove
-        path: "/definitions/conditions/required/0" # removes requirement for agent
-      - op: remove
-        path: "/definitions/conditions/properties/agent/required/0" # removes requirement for version
       - op: remove # removes package deprecation info
         path: "/properties/deprecated"
       - op: remove # removes policy template input deprecation info

--- a/test/packages/bad_agent_version_v3/manifest.yml
+++ b/test/packages/bad_agent_version_v3/manifest.yml
@@ -14,7 +14,8 @@ conditions:
     capabilities:
       - observability
       - security
-  agent: {}
+  agent:
+    version: version  # This is an invalid version to test bad agent version handling
 vars:
   - name: package_password
     type: password


### PR DESCRIPTION
## What does this PR do?

This is a follow up from https://github.com/elastic/package-spec/pull/999 where agent.version was being made required since 3.6

This PR removes the version constraint so now specific agent version is available but not required.


## Why is it important?

New definition for agent compatibility https://github.com/elastic/package-spec/issues/165

## Checklist



- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/6432
- Related to https://github.com/elastic/package-spec/issues/165
- Follow up https://github.com/elastic/package-spec/pull/999
