### PR TITLE
Add support for release field in agentless deployment mode

### DIFF
--- a/code/go/internal/validator/semantic/validate_deployment_modes.go
+++ b/code/go/internal/validator/semantic/validate_deployment_modes.go
@@ -19,9 +19,9 @@ type deploymentModesManifest struct {
 }
 
 type deploymentModesPolicyTemplate struct {
-	Name            string                    `yaml:"name"`
-	DeploymentModes deploymentModesSpec       `yaml:"deployment_modes"`
-	Inputs          []deploymentModesInput    `yaml:"inputs"`
+	Name            string                 `yaml:"name"`
+	DeploymentModes deploymentModesSpec    `yaml:"deployment_modes"`
+	Inputs          []deploymentModesInput `yaml:"inputs"`
 }
 
 type deploymentModesSpec struct {

--- a/code/go/internal/validator/semantic/validate_deployment_modes.go
+++ b/code/go/internal/validator/semantic/validate_deployment_modes.go
@@ -30,7 +30,8 @@ type deploymentModesSpec struct {
 }
 
 type deploymentModesDefault struct {
-	Enabled *bool `yaml:"enabled"` // pointer to detect if field was set; nil means enabled
+
+	Enabled *bool `yaml:"enabled"` // pointer to detect if field was set; when unset (nil) semantical meaning is default deployment is enabled
 }
 
 type deploymentModesAgentless struct {

--- a/code/go/internal/validator/semantic/validate_deployment_modes.go
+++ b/code/go/internal/validator/semantic/validate_deployment_modes.go
@@ -138,8 +138,8 @@ func validateAgentlessReleaseDeployment(manifest deploymentModesManifest) error 
 	}
 	tmpl := manifest.PolicyTemplates[0]
 	// Default.Enabled == nil means default mode is implicitly enabled, so agentless is not the only mode.
-	isSingleDeployment := tmpl.DeploymentModes.Default.Enabled != nil && !*tmpl.DeploymentModes.Default.Enabled
-	if isSingleDeployment && tmpl.DeploymentModes.Agentless.Release != "" {
+	defaultDeploymentDisabled := tmpl.DeploymentModes.Default.Enabled != nil && !*tmpl.DeploymentModes.Default.Enabled
+	if defaultDeploymentDisabled && tmpl.DeploymentModes.Agentless.Release != "" {
 		return fmt.Errorf("policy template \"%s\" sets agentless.release but agentless is the only deployment mode; use the package version to indicate maturity instead", tmpl.Name)
 	}
 	return nil

--- a/code/go/internal/validator/semantic/validate_deployment_modes.go
+++ b/code/go/internal/validator/semantic/validate_deployment_modes.go
@@ -31,7 +31,8 @@ func ValidateDeploymentModes(fsys fspath.FS) specerrors.ValidationErrors {
 					Enabled *bool `yaml:"enabled"` // Use pointer to detect if field was set, default is true
 				} `yaml:"default"`
 				Agentless struct {
-					Enabled bool `yaml:"enabled"`
+					Enabled bool   `yaml:"enabled"`
+					Release string `yaml:"release"`
 				} `yaml:"agentless"`
 			} `yaml:"deployment_modes"`
 			Inputs []struct {
@@ -47,6 +48,19 @@ func ValidateDeploymentModes(fsys fspath.FS) specerrors.ValidationErrors {
 	}
 
 	var errs specerrors.ValidationErrors
+
+	// Check that agentless.release is not set in a single-policy-template package
+	// where agentless is the only deployment mode. In that case the package version
+	// is the authoritative source of maturity and an explicit override would conflict.
+	if len(manifest.PolicyTemplates) == 1 {
+		tmpl := manifest.PolicyTemplates[0]
+		isSingleDeployment := tmpl.DeploymentModes.Default.Enabled != nil && !*tmpl.DeploymentModes.Default.Enabled
+		if isSingleDeployment && tmpl.DeploymentModes.Agentless.Release != "" {
+			err := fmt.Errorf("file \"%s\" is invalid: policy template \"%s\" sets agentless.release but agentless is the only deployment mode; use the package version to indicate maturity instead", fsys.Path(manifestPath), tmpl.Name)
+			errs = append(errs, specerrors.NewStructuredError(err, specerrors.UnassignedCode))
+		}
+	}
+
 	for _, template := range manifest.PolicyTemplates {
 		// Collect enabled deployment modes for this policy template
 		enabledModes := []string{}

--- a/code/go/internal/validator/semantic/validate_deployment_modes.go
+++ b/code/go/internal/validator/semantic/validate_deployment_modes.go
@@ -30,7 +30,6 @@ type deploymentModesSpec struct {
 }
 
 type deploymentModesDefault struct {
-
 	Enabled *bool `yaml:"enabled"` // pointer to detect if field was set; when unset (nil) semantical meaning is default deployment is enabled
 }
 

--- a/code/go/internal/validator/semantic/validate_deployment_modes.go
+++ b/code/go/internal/validator/semantic/validate_deployment_modes.go
@@ -14,6 +14,35 @@ import (
 	"github.com/elastic/package-spec/v3/code/go/pkg/specerrors"
 )
 
+type deploymentModesManifest struct {
+	PolicyTemplates []deploymentModesPolicyTemplate `yaml:"policy_templates"`
+}
+
+type deploymentModesPolicyTemplate struct {
+	Name            string                    `yaml:"name"`
+	DeploymentModes deploymentModesSpec       `yaml:"deployment_modes"`
+	Inputs          []deploymentModesInput    `yaml:"inputs"`
+}
+
+type deploymentModesSpec struct {
+	Default   deploymentModesDefault   `yaml:"default"`
+	Agentless deploymentModesAgentless `yaml:"agentless"`
+}
+
+type deploymentModesDefault struct {
+	Enabled *bool `yaml:"enabled"` // pointer to detect if field was set; nil means enabled
+}
+
+type deploymentModesAgentless struct {
+	Enabled bool   `yaml:"enabled"`
+	Release string `yaml:"release"`
+}
+
+type deploymentModesInput struct {
+	Type            string    `yaml:"type"`
+	DeploymentModes *[]string `yaml:"deployment_modes"` // pointer to detect if field was set
+}
+
 // ValidateDeploymentModes ensures that for each deployment mode enabled in a policy template,
 // there is at least one input that supports that deployment mode.
 func ValidateDeploymentModes(fsys fspath.FS) specerrors.ValidationErrors {
@@ -23,25 +52,7 @@ func ValidateDeploymentModes(fsys fspath.FS) specerrors.ValidationErrors {
 		return specerrors.ValidationErrors{specerrors.NewStructuredErrorf("file \"%s\" is invalid: failed to read manifest: %w", fsys.Path(manifestPath), err)}
 	}
 
-	var manifest struct {
-		PolicyTemplates []struct {
-			Name            string `yaml:"name"`
-			DeploymentModes struct {
-				Default struct {
-					Enabled *bool `yaml:"enabled"` // Use pointer to detect if field was set, default is true
-				} `yaml:"default"`
-				Agentless struct {
-					Enabled bool   `yaml:"enabled"`
-					Release string `yaml:"release"`
-				} `yaml:"agentless"`
-			} `yaml:"deployment_modes"`
-			Inputs []struct {
-				Type            string    `yaml:"type"`
-				DeploymentModes *[]string `yaml:"deployment_modes"` // Use pointer to detect if field was set
-			} `yaml:"inputs"`
-		} `yaml:"policy_templates"`
-	}
-
+	var manifest deploymentModesManifest
 	err = yaml.Unmarshal(d, &manifest)
 	if err != nil {
 		return specerrors.ValidationErrors{specerrors.NewStructuredErrorf("file \"%s\" is invalid: failed to parse manifest: %w", fsys.Path(manifestPath), err)}
@@ -49,16 +60,8 @@ func ValidateDeploymentModes(fsys fspath.FS) specerrors.ValidationErrors {
 
 	var errs specerrors.ValidationErrors
 
-	// Check that agentless.release is not set in a single-policy-template package
-	// where agentless is the only deployment mode. In that case the package version
-	// is the authoritative source of maturity and an explicit override would conflict.
-	if len(manifest.PolicyTemplates) == 1 {
-		tmpl := manifest.PolicyTemplates[0]
-		isSingleDeployment := tmpl.DeploymentModes.Default.Enabled != nil && !*tmpl.DeploymentModes.Default.Enabled
-		if isSingleDeployment && tmpl.DeploymentModes.Agentless.Release != "" {
-			err := fmt.Errorf("file \"%s\" is invalid: policy template \"%s\" sets agentless.release but agentless is the only deployment mode; use the package version to indicate maturity instead", fsys.Path(manifestPath), tmpl.Name)
-			errs = append(errs, specerrors.NewStructuredError(err, specerrors.UnassignedCode))
-		}
+	if err := validateAgentlessReleaseDeployment(manifest); err != nil {
+		errs = append(errs, specerrors.NewStructuredError(fmt.Errorf("file \"%s\" is invalid: %w", fsys.Path(manifestPath), err), specerrors.UnassignedCode))
 	}
 
 	for _, template := range manifest.PolicyTemplates {
@@ -123,4 +126,21 @@ func ValidateDeploymentModes(fsys fspath.FS) specerrors.ValidationErrors {
 	}
 
 	return errs
+}
+
+// validateAgentlessReleaseDeployment checks that agentless.release is not set in a
+// single-policy-template package where agentless is the only deployment mode. In that
+// case the package version is the authoritative source of maturity and an explicit
+// override would conflict.
+func validateAgentlessReleaseDeployment(manifest deploymentModesManifest) error {
+	if len(manifest.PolicyTemplates) != 1 {
+		return nil
+	}
+	tmpl := manifest.PolicyTemplates[0]
+	// Default.Enabled == nil means default mode is implicitly enabled, so agentless is not the only mode.
+	isSingleDeployment := tmpl.DeploymentModes.Default.Enabled != nil && !*tmpl.DeploymentModes.Default.Enabled
+	if isSingleDeployment && tmpl.DeploymentModes.Agentless.Release != "" {
+		return fmt.Errorf("policy template \"%s\" sets agentless.release but agentless is the only deployment mode; use the package version to indicate maturity instead", tmpl.Name)
+	}
+	return nil
 }

--- a/code/go/internal/validator/semantic/validate_deployment_modes_test.go
+++ b/code/go/internal/validator/semantic/validate_deployment_modes_test.go
@@ -231,7 +231,7 @@ func TestValidateAgentlessReleaseDeployment(t *testing.T) {
 						Name: "test",
 						DeploymentModes: deploymentModesSpec{
 							Default:   deploymentModesDefault{Enabled: boolPtr(true)},
-							Agentless: deploymentModesAgentless{Enabled: true, Release: "beta"},
+							Agentless: deploymentModesAgentless{Enabled: true, Release: "ga"},
 						},
 					},
 				},
@@ -245,7 +245,7 @@ func TestValidateAgentlessReleaseDeployment(t *testing.T) {
 						Name: "test",
 						DeploymentModes: deploymentModesSpec{
 							Default:   deploymentModesDefault{Enabled: nil},
-							Agentless: deploymentModesAgentless{Enabled: true, Release: "beta"},
+							Agentless: deploymentModesAgentless{Enabled: true, Release: "ga"},
 						},
 					},
 				},
@@ -280,7 +280,7 @@ func TestValidateAgentlessReleaseDeployment(t *testing.T) {
 						Name: "test2",
 						DeploymentModes: deploymentModesSpec{
 							Default:   deploymentModesDefault{Enabled: boolPtr(false)},
-							Agentless: deploymentModesAgentless{Enabled: true, Release: "beta"},
+							Agentless: deploymentModesAgentless{Enabled: true, Release: "ga"},
 						},
 					},
 				},
@@ -294,7 +294,7 @@ func TestValidateAgentlessReleaseDeployment(t *testing.T) {
 						Name: "test",
 						DeploymentModes: deploymentModesSpec{
 							Default:   deploymentModesDefault{Enabled: boolPtr(false)},
-							Agentless: deploymentModesAgentless{Enabled: true, Release: "beta"},
+							Agentless: deploymentModesAgentless{Enabled: true, Release: "ga"},
 						},
 					},
 				},

--- a/code/go/internal/validator/semantic/validate_deployment_modes_test.go
+++ b/code/go/internal/validator/semantic/validate_deployment_modes_test.go
@@ -187,78 +187,6 @@ policy_templates:
 				`input "httpjson" in policy template "test" specifies unsupported deployment mode "agentless"`,
 			},
 		},
-		{
-			title: "valid - agentless release set with both deployment modes enabled",
-			manifestYAML: `
-policy_templates:
-  - name: test
-    deployment_modes:
-      default:
-        enabled: true
-      agentless:
-        enabled: true
-        release: beta
-        organization: elastic
-        division: observability
-        team: test
-    inputs:
-      - type: httpjson
-`,
-			expectedErrs: nil,
-		},
-		{
-			title: "valid - agentless release set in multi-template package where one template is agentless-only",
-			manifestYAML: `
-policy_templates:
-  - name: test1
-    deployment_modes:
-      default:
-        enabled: true
-      agentless:
-        enabled: true
-        organization: elastic
-        division: observability
-        team: test
-    inputs:
-      - type: httpjson
-  - name: test2
-    deployment_modes:
-      default:
-        enabled: false
-      agentless:
-        enabled: true
-        release: beta
-        organization: elastic
-        division: observability
-        team: test
-    inputs:
-      - type: filestream
-        deployment_modes: ['agentless']
-`,
-			expectedErrs: nil,
-		},
-		{
-			title: "invalid - agentless release set in single-policy-template package where agentless is the only deployment mode",
-			manifestYAML: `
-policy_templates:
-  - name: test
-    deployment_modes:
-      default:
-        enabled: false
-      agentless:
-        enabled: true
-        release: beta
-        organization: elastic
-        division: observability
-        team: test
-    inputs:
-      - type: httpjson
-        deployment_modes: ['agentless']
-`,
-			expectedErrs: []string{
-				`policy template "test" sets agentless.release but agentless is the only deployment mode; use the package version to indicate maturity instead`,
-			},
-		},
 	}
 
 	for _, c := range cases {
@@ -282,6 +210,107 @@ policy_templates:
 				for i, expectedErr := range c.expectedErrs {
 					assert.Contains(t, errs[i].Error(), expectedErr)
 				}
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestValidateAgentlessReleaseDeployment(t *testing.T) {
+	cases := []struct {
+		title       string
+		manifest    deploymentModesManifest
+		expectedErr string
+	}{
+		{
+			title: "valid - default enabled explicitly, release set",
+			manifest: deploymentModesManifest{
+				PolicyTemplates: []deploymentModesPolicyTemplate{
+					{
+						Name: "test",
+						DeploymentModes: deploymentModesSpec{
+							Default:   deploymentModesDefault{Enabled: boolPtr(true)},
+							Agentless: deploymentModesAgentless{Enabled: true, Release: "beta"},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "valid - default enabled implicitly (nil), release set",
+			manifest: deploymentModesManifest{
+				PolicyTemplates: []deploymentModesPolicyTemplate{
+					{
+						Name: "test",
+						DeploymentModes: deploymentModesSpec{
+							Default:   deploymentModesDefault{Enabled: nil},
+							Agentless: deploymentModesAgentless{Enabled: true, Release: "beta"},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "valid - agentless-only single template, no release set",
+			manifest: deploymentModesManifest{
+				PolicyTemplates: []deploymentModesPolicyTemplate{
+					{
+						Name: "test",
+						DeploymentModes: deploymentModesSpec{
+							Default:   deploymentModesDefault{Enabled: boolPtr(false)},
+							Agentless: deploymentModesAgentless{Enabled: true},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "valid - multiple templates, one agentless-only with release set",
+			manifest: deploymentModesManifest{
+				PolicyTemplates: []deploymentModesPolicyTemplate{
+					{
+						Name: "test1",
+						DeploymentModes: deploymentModesSpec{
+							Default:   deploymentModesDefault{Enabled: boolPtr(true)},
+							Agentless: deploymentModesAgentless{Enabled: true},
+						},
+					},
+					{
+						Name: "test2",
+						DeploymentModes: deploymentModesSpec{
+							Default:   deploymentModesDefault{Enabled: boolPtr(false)},
+							Agentless: deploymentModesAgentless{Enabled: true, Release: "beta"},
+						},
+					},
+				},
+			},
+		},
+		{
+			title: "invalid - agentless-only single template with release set",
+			manifest: deploymentModesManifest{
+				PolicyTemplates: []deploymentModesPolicyTemplate{
+					{
+						Name: "test",
+						DeploymentModes: deploymentModesSpec{
+							Default:   deploymentModesDefault{Enabled: boolPtr(false)},
+							Agentless: deploymentModesAgentless{Enabled: true, Release: "beta"},
+						},
+					},
+				},
+			},
+			expectedErr: `policy template "test" sets agentless.release but agentless is the only deployment mode; use the package version to indicate maturity instead`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			err := validateAgentlessReleaseDeployment(c.manifest)
+			if c.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.expectedErr)
 			}
 		})
 	}

--- a/code/go/internal/validator/semantic/validate_deployment_modes_test.go
+++ b/code/go/internal/validator/semantic/validate_deployment_modes_test.go
@@ -187,6 +187,78 @@ policy_templates:
 				`input "httpjson" in policy template "test" specifies unsupported deployment mode "agentless"`,
 			},
 		},
+		{
+			title: "valid - agentless release set with both deployment modes enabled",
+			manifestYAML: `
+policy_templates:
+  - name: test
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        release: beta
+        organization: elastic
+        division: observability
+        team: test
+    inputs:
+      - type: httpjson
+`,
+			expectedErrs: nil,
+		},
+		{
+			title: "valid - agentless release set in multi-template package where one template is agentless-only",
+			manifestYAML: `
+policy_templates:
+  - name: test1
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: elastic
+        division: observability
+        team: test
+    inputs:
+      - type: httpjson
+  - name: test2
+    deployment_modes:
+      default:
+        enabled: false
+      agentless:
+        enabled: true
+        release: beta
+        organization: elastic
+        division: observability
+        team: test
+    inputs:
+      - type: filestream
+        deployment_modes: ['agentless']
+`,
+			expectedErrs: nil,
+		},
+		{
+			title: "invalid - agentless release set in single-policy-template package where agentless is the only deployment mode",
+			manifestYAML: `
+policy_templates:
+  - name: test
+    deployment_modes:
+      default:
+        enabled: false
+      agentless:
+        enabled: true
+        release: beta
+        organization: elastic
+        division: observability
+        team: test
+    inputs:
+      - type: httpjson
+        deployment_modes: ['agentless']
+`,
+			expectedErrs: []string{
+				`policy template "test" sets agentless.release but agentless is the only deployment mode; use the package version to indicate maturity instead`,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -379,6 +379,12 @@ func TestValidateFile(t *testing.T) {
 				`var "access_key_id" in non-required var_group "credential_type" should not have required: true (var_group is optional)`,
 			},
 		},
+		"bad_agentless_release": {
+			"manifest.yml",
+			[]string{
+				`policy template "test" sets agentless.release but agentless is the only deployment mode; use the package version to indicate maturity instead`,
+			},
+		},
 		"bad_input_deployment_modes": {
 			"manifest.yml",
 			[]string{

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -18,6 +18,7 @@
     - description: Add var_groups support to policy template and input levels in integration packages, and to policy template and package root levels in input packages.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1120
+<<<<<<< HEAD
     # Pending on https://github.com/elastic/kibana/pull/262138
     - description: Add support for named inputs in policy templates to disambiguate multiple inputs of the same type.
       type: enhancement
@@ -40,6 +41,11 @@
     - description: Add `show_divider` optional boolean to input objects to suppress horizontal dividers in the Fleet UI.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1133
+=======
+    - description: Add optional `release` field to agentless deployment mode to allow declaring a different maturity level than that of the package version.
+      type: enhancement
+      link: TBD
+>>>>>>> 6b7538c (Add support for  field in agentless deployment mode)
 - version: 3.6.0
   changes:
     - description: Add pipeline tag validations.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -18,7 +18,6 @@
     - description: Add var_groups support to policy template and input levels in integration packages, and to policy template and package root levels in input packages.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1120
-<<<<<<< HEAD
     # Pending on https://github.com/elastic/kibana/pull/262138
     - description: Add support for named inputs in policy templates to disambiguate multiple inputs of the same type.
       type: enhancement
@@ -41,11 +40,6 @@
     - description: Add `show_divider` optional boolean to input objects to suppress horizontal dividers in the Fleet UI.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1133
-=======
-    - description: Add optional `release` field to agentless deployment mode to allow declaring a different maturity level than that of the package version.
-      type: enhancement
-      link: TBD
->>>>>>> 6b7538c (Add support for  field in agentless deployment mode)
 - version: 3.6.0
   changes:
     - description: Add pipeline tag validations.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -8,6 +8,11 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
+- version: 3.6.3-next
+  changes:
+    - description: Add optional `release` field to agentless deployment mode to explicitly declare its release stage.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1130
 - version: 3.6.2
   changes:
     - description: Add support for ML modules in content packages.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -8,8 +8,6 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
-- version: 3.6.3-next
-  changes:
     - description: Add optional `release` field to agentless deployment mode to explicitly declare its release stage.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1130

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -298,16 +298,17 @@ spec:
             release:
               description: >
                 The maturity level of the agentless deployment mode for this policy template.
-                Only needs to be set when the agentless deployment mode has a different maturity than the package's overall release state.
-                Not allowed in single policy template packages where agentless is the only
-                deployment mode.
+                When absent, the implicit maturity is "beta".
+                Only needs to be set to "ga" when the agentless deployment mode has reached general availability.
+                Not set in packages where agentless is the only deployment mode — in that case
+                defer to the package's top-level release.
               type: string
               enum:
                 - beta
-                - preview
+                - ga
               examples:
                 - beta
-                - preview
+                - ga
             resources:
               description: >
                 The computing resources specifications for the Agentless deployment.

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -360,7 +360,7 @@ spec:
           url:
             description: Link url. Format is `http://...` or `https://...` for external links,  `kbn:/app/...` for links internal to Kibana.
             type: string
-            pattern: "^(http(s)?://|kbn:/)"
+            pattern: '^(http(s)?://|kbn:/)'
           type:
             description: Type of link. `next_steps` for links to locations that can be relevant right after configuring the policy. `action` for actions that can be performed while the policy is in use.
             type: string
@@ -371,9 +371,9 @@ spec:
             description: Link description
             type: string
         required:
-          - title
-          - url
-          - type
+        - title
+        - url
+        - type
     fips_compatible:
       type: boolean
       description: Indicate if this package is capable of satisfying FIPS requirements. Set to false if it uses any input that cannot be configured to use FIPS cryptography.
@@ -556,7 +556,7 @@ spec:
         from the referenced package. The package must be listed in the manifest's
         requires section.
       type: string
-      pattern: "^[a-z0-9_]+$"
+      pattern: '^[a-z0-9_]+$'
       examples:
         - filelog_otel
         - sql_input
@@ -568,7 +568,7 @@ spec:
         package:
           description: Name of the required package.
           type: string
-          pattern: "^[a-z0-9_]+$"
+          pattern: '^[a-z0-9_]+$'
           examples:
             - sql_input
             - elastic_agent
@@ -645,7 +645,7 @@ spec:
           name:
             description: Unique identifier for this variable group selector.
             type: string
-            pattern: "^[a-z][a-z0-9_]*$"
+            pattern: '^[a-z][a-z0-9_]*$'
             examples:
               - credential_type
           title:
@@ -685,7 +685,7 @@ spec:
                 name:
                   description: Unique identifier (stored in policy when selected).
                   type: string
-                  pattern: "^[a-z][a-z0-9_]*$"
+                  pattern: '^[a-z][a-z0-9_]*$'
                   examples:
                     - direct_access_key
                     - cloud_connectors
@@ -744,7 +744,7 @@ spec:
     name:
       description: The name of the package.
       type: string
-      pattern: "^[a-z0-9_]+$"
+      pattern: '^[a-z0-9_]+$'
       examples:
         - apache
     title:

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -295,6 +295,21 @@ spec:
               type: string
               examples:
                 - "cloud-security-posture-management"
+            release:
+              description: >
+                The maturity level of the agentless deployment mode for this policy template.
+                Only needs to be set when the agentless deployment mode has a different maturity than the package's overall release state.
+                Not allowed in single policy template packages where agentless is the only
+                deployment mode.
+              type: string
+              enum:
+                - beta
+                - rc
+                - preview
+              examples:
+                - beta
+                - rc
+                - preview
             resources:
               description: >
                 The computing resources specifications for the Agentless deployment.

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -304,11 +304,9 @@ spec:
               type: string
               enum:
                 - beta
-                - rc
                 - preview
               examples:
                 - beta
-                - rc
                 - preview
             resources:
               description: >
@@ -361,7 +359,7 @@ spec:
           url:
             description: Link url. Format is `http://...` or `https://...` for external links,  `kbn:/app/...` for links internal to Kibana.
             type: string
-            pattern: '^(http(s)?://|kbn:/)'
+            pattern: "^(http(s)?://|kbn:/)"
           type:
             description: Type of link. `next_steps` for links to locations that can be relevant right after configuring the policy. `action` for actions that can be performed while the policy is in use.
             type: string
@@ -372,9 +370,9 @@ spec:
             description: Link description
             type: string
         required:
-        - title
-        - url
-        - type
+          - title
+          - url
+          - type
     fips_compatible:
       type: boolean
       description: Indicate if this package is capable of satisfying FIPS requirements. Set to false if it uses any input that cannot be configured to use FIPS cryptography.
@@ -557,7 +555,7 @@ spec:
         from the referenced package. The package must be listed in the manifest's
         requires section.
       type: string
-      pattern: '^[a-z0-9_]+$'
+      pattern: "^[a-z0-9_]+$"
       examples:
         - filelog_otel
         - sql_input
@@ -569,7 +567,7 @@ spec:
         package:
           description: Name of the required package.
           type: string
-          pattern: '^[a-z0-9_]+$'
+          pattern: "^[a-z0-9_]+$"
           examples:
             - sql_input
             - elastic_agent
@@ -646,7 +644,7 @@ spec:
           name:
             description: Unique identifier for this variable group selector.
             type: string
-            pattern: '^[a-z][a-z0-9_]*$'
+            pattern: "^[a-z][a-z0-9_]*$"
             examples:
               - credential_type
           title:
@@ -686,7 +684,7 @@ spec:
                 name:
                   description: Unique identifier (stored in policy when selected).
                   type: string
-                  pattern: '^[a-z][a-z0-9_]*$'
+                  pattern: "^[a-z][a-z0-9_]*$"
                   examples:
                     - direct_access_key
                     - cloud_connectors
@@ -745,7 +743,7 @@ spec:
     name:
       description: The name of the package.
       type: string
-      pattern: '^[a-z0-9_]+$'
+      pattern: "^[a-z0-9_]+$"
       examples:
         - apache
     title:

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -302,6 +302,7 @@ spec:
                 Only needs to be set to "ga" when the agentless deployment mode has reached general availability.
                 Not set in packages where agentless is the only deployment mode — in that case
                 defer to the package's top-level release.
+                Only evaluated in Kibana 9.5.0 or later.
               type: string
               enum:
                 - beta

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -298,10 +298,8 @@ spec:
             release:
               description: >
                 The maturity level of the agentless deployment mode for this policy template.
-                When absent, the implicit maturity is "beta".
-                Only needs to be set to "ga" when the agentless deployment mode has reached general availability.
-                Not set in packages where agentless is the only deployment mode — in that case
-                defer to the package's top-level release.
+                If not defined, Kibana will provide a default value based on agentless platform maturity.
+                Packages where agentless is the only deployment mode, should defer to the package's top-level `version`.
                 Only evaluated in Kibana 9.5.0 or later.
               type: string
               enum:

--- a/test/packages/bad_agentless_release/changelog.yml
+++ b/test/packages/bad_agentless_release/changelog.yml
@@ -1,0 +1,5 @@
+- version: 0.0.1
+  changes:
+    - description: Initial version
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1130

--- a/test/packages/bad_agentless_release/docs/README.md
+++ b/test/packages/bad_agentless_release/docs/README.md
@@ -1,0 +1,3 @@
+# Test Package
+
+This is a test package for agentless release validation.

--- a/test/packages/bad_agentless_release/manifest.yml
+++ b/test/packages/bad_agentless_release/manifest.yml
@@ -13,7 +13,7 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: elastic
         division: observability
         team: test

--- a/test/packages/bad_agentless_release/manifest.yml
+++ b/test/packages/bad_agentless_release/manifest.yml
@@ -22,6 +22,9 @@ policy_templates:
         title: Test HTTP JSON
         description: Test HTTP JSON input
         deployment_modes: ['agentless']
+conditions:
+  kibana:
+    version: '^9.5.0'
 owner:
   github: elastic/ecosystem
   type: elastic

--- a/test/packages/bad_agentless_release/manifest.yml
+++ b/test/packages/bad_agentless_release/manifest.yml
@@ -1,0 +1,27 @@
+format_version: 3.6.1
+name: bad_agentless_release
+title: Bad Agentless Release
+description: Test package where agentless.release is set but agentless is the only deployment mode
+version: 0.0.1
+type: integration
+policy_templates:
+  - name: test
+    title: Test
+    description: Test policy template
+    deployment_modes:
+      default:
+        enabled: false
+      agentless:
+        enabled: true
+        release: beta
+        organization: elastic
+        division: observability
+        team: test
+    inputs:
+      - type: httpjson
+        title: Test HTTP JSON
+        description: Test HTTP JSON input
+        deployment_modes: ['agentless']
+owner:
+  github: elastic/ecosystem
+  type: elastic

--- a/test/packages/good_v3/manifest.yml
+++ b/test/packages/good_v3/manifest.yml
@@ -8,7 +8,7 @@ source:
   license: "Apache-2.0"
 conditions:
   kibana:
-    version: '^8.10.0'
+    version: '^9.5.0'
   elastic:
     subscription: 'basic'
     capabilities:
@@ -39,6 +39,7 @@ policy_templates:
       agentless:
         enabled: true
         is_default: true
+        release: ga
         organization: elastic
         division: observability
         team: obs-infraobs-integrations


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here WHAT changes you made in the PR.
-->
* Adds support for a `release` field in the agentless deployment mode. This is to help indicate a different maturity level than that of the package semver.  Accepts values `beta`, `ga`. Absence implies `beta` by default

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Agentless deployment modes for an integration can be at a different level of functional maturity than the default deployment of an integration. This will help communicate that expectation to users downstream in Kibana.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes: https://github.com/elastic/package-spec/issues/1098
