### PR TITLE
Support configuring dynamic dataset and namespace in input packages

### DIFF
--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -20,6 +20,9 @@
     - description: Add validation for Fleet-reserved variables (use_apm, data_stream.dataset) to enforce correct types and constraints when explicitly overridden in package manifests.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1134
+    - description: Add "elasticsearch.dynamic_dataset" and "elasticsearch.dynamic_namespace" to input package manifest.
+      type: enhancement
+      link: TBD
 - version: 3.6.0
   changes:
     - description: Add pipeline tag validations.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -22,7 +22,7 @@
       link: https://github.com/elastic/package-spec/pull/1134
     - description: Add "elasticsearch.dynamic_dataset" and "elasticsearch.dynamic_namespace" to input package manifest.
       type: enhancement
-      link: TBD
+      link: https://github.com/elastic/package-spec/pull/1140
 - version: 3.6.0
   changes:
     - description: Add pipeline tag validations.

--- a/spec/input/manifest.spec.yml
+++ b/spec/input/manifest.spec.yml
@@ -155,6 +155,10 @@ spec:
           $ref: "../integration/data_stream/manifest.spec.yml#/definitions/elasticsearch_index_mode"
         index_template:
           $ref: "../integration/data_stream/manifest.spec.yml#/definitions/elasticsearch_index_template"
+        dynamic_dataset:
+          $ref: "../integration/data_stream/manifest.spec.yml#/definitions/elasticsearch_dynamic_dataset"
+        dynamic_namespace:
+          $ref: "../integration/data_stream/manifest.spec.yml#/definitions/elasticsearch_dynamic_namespace"
     deprecated:
       $ref: "../integration/manifest.spec.yml#/definitions/deprecated"
   required:

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -247,6 +247,12 @@ spec:
       - "time_series" # Enables time series data streams https://www.elastic.co/guide/en/elasticsearch/reference/master/tsds.html
       examples:
       - "time_series"
+    elasticsearch_dynamic_dataset:
+      description: When set to true, agents running this integration are granted data stream privileges for all datasets of its type
+      type: boolean
+    elasticsearch_dynamic_namespace:
+      description: When set to true, agents running this integration are granted data stream privileges for all namespaces of its type
+      type: boolean
     elasticsearch_index_template:
       description: Index template definition
       type: object
@@ -685,11 +691,9 @@ spec:
           examples:
           - "synthetic"
         dynamic_dataset:
-          description: When set to true, agents running this integration are granted data stream privileges for all datasets of its type
-          type: boolean
+          $ref: "#/definitions/elasticsearch_dynamic_dataset"
         dynamic_namespace:
-          description: When set to true, agents running this integration are granted data stream privileges for all namespaces of its type
-          type: boolean
+          $ref: "#/definitions/elasticsearch_dynamic_namespace"
     categories:
       description: >
         Optional categories that describe the type of data collected by this data stream.

--- a/test/packages/good_input/manifest.yml
+++ b/test/packages/good_input/manifest.yml
@@ -93,6 +93,8 @@ agent:
   privileges:
     root: true
 elasticsearch:
+  dynamic_dataset: true
+  dynamic_namespace: true
   index_template:
     mappings:
       properties:


### PR DESCRIPTION
## What does this PR do?

Add support to configure dynamic dataset and namespace in input packages.

## Why is it important?

There can be generic inputs that can store documents, or their documents can be rerouted, to multiple datasets or namespaces.

Currently Kibana is adding permissions for input packages depending on the kind of input, instead of that, it should give the minimum set of permissions, and developers should use `dynamic_dataset`/`dynamic_namespace` if permissions for more datasets are required.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-
