### PR TITLE
Add Agent Skills, review-pr workflow, and CodeRabbit checklist integration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,63 @@
+# CodeRabbit configuration for elastic/package-spec
+#
+# Rules originate from .cursor/skills/review-pr/references/checklist.md — the single source
+# of truth for contribution rules. Update that file first; CodeRabbit picks up the
+# changes automatically on the next PR via knowledge_base.code_guidelines.
+#
+# Prerequisite: the CodeRabbit GitHub App must be installed on this repository.
+
+language: en-US
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - ".cursor/skills/review-pr/references/checklist.md"
+
+reviews:
+  profile: assertive
+  auto_review:
+    enabled: true
+  path_filters:
+    - "!**/vendor/**"
+
+  instructions: |
+    This is the elastic/package-spec repository, which defines the Elastic Package
+    specification and its validation logic.
+    Detailed contribution rules are in the code guidelines file loaded above.
+    Always check: changelog entry in spec/changelog.yml, version patches for any new
+    spec fields, semantic validator registration, test coverage, and Go style.
+    Dependabot dependency-bump PRs are the only exception to the changelog requirement.
+
+  path_instructions:
+    - path: "spec/**/*.spec.yml"
+      instructions: |
+        Apply the "Version Patches" and "Schema Reuse" sections of the guidelines.
+
+    - path: "code/go/internal/validator/semantic/*.go"
+      instructions: |
+        Apply the "Semantic Validators" and "Tests for Semantic Validators" sections
+        of the guidelines.
+
+    - path: "code/go/internal/validator/spec.go"
+      instructions: |
+        Check that any new validator added in semantic/ is registered here with
+        appropriate fn, since, and types fields per the "Semantic Validators" section
+        of the guidelines.
+
+    - path: "test/packages/**"
+      instructions: |
+        Apply the "Test Packages" section of the guidelines.
+
+    - path: "compliance/testdata/packages/**"
+      instructions: |
+        Apply the "Test Packages" section of the guidelines, including the transform
+        package rules.
+
+    - path: "compliance/features/*.feature"
+      instructions: |
+        Apply the "Compliance Feature Files" section of the guidelines.
+
+    - path: "**/*.go"
+      instructions: |
+        Apply the "Go Style" section of the guidelines.

--- a/.cursor/rules/agentskills-skill-authoring.mdc
+++ b/.cursor/rules/agentskills-skill-authoring.mdc
@@ -1,5 +1,5 @@
 ---
-description: Author Agent Skills using the agentskills.io open standard (SKILL.md, layout, progressive disclosure).
+description: Author portable Agent Skills (agentskills.io) usable in Claude, Claude Code, Copilot, and Cursor.
 globs: .cursor/skills/**/SKILL.md
 alwaysApply: false
 ---
@@ -7,6 +7,16 @@ alwaysApply: false
 # Agent Skills format (agentskills.io)
 
 When creating or editing a skill under `.cursor/skills/`, follow the **[Agent Skills specification](https://agentskills.io/specification.md)** and **[best practices](https://agentskills.io/skill-creation/best-practices.md)**.
+
+The same skill folder should be **universal**: usable by any Agent Skills–compatible client. Treat **[Claude / Claude Code](https://code.claude.com/docs/en/skills)**, **[GitHub Copilot agent skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)**, and **[Cursor skills](https://cursor.com/docs/context/skills)** as target consumers unless the repo explicitly documents a narrower scope. Do not rely on one vendor’s UI or tool names in the **only** path through the workflow.
+
+## Portable across Claude, Claude Code, Copilot, and Cursor
+
+- **Spec-first:** Valid YAML frontmatter + Markdown body per the [specification](https://agentskills.io/specification.md); optional `scripts/`, `references/`, `assets/` as defined there.
+- **Core flow is product-agnostic:** Steps, checks, and outputs must work without Cursor-only tools (e.g. no mandatory `AskQuestion` / MCP / canvas). Use plain chat prompts, numbered options, or “ask once in natural language” as the default.
+- **Product-specific hints are optional add-ons:** If a client offers a nicer path (e.g. a structured question UI), put it in a short labeled subsection (e.g. “**Cursor:** …”) **after** the universal fallback, or in one line in **`compatibility`** / metadata—never as the only way to complete a step.
+- **Tools and environment:** Prefer standard shell, `git`, and repo files. Use **`compatibility`** for needs like network, `gh`, Docker, or a particular host app so Claude Code / Copilot / Cursor can all interpret constraints the same way.
+- **Naming:** Keep **`name`** aligned with the directory name so the skill validates and ports cleanly across hosts.
 
 ## Layout
 

--- a/.cursor/rules/agentskills-skill-authoring.mdc
+++ b/.cursor/rules/agentskills-skill-authoring.mdc
@@ -1,0 +1,51 @@
+---
+description: Author Agent Skills using the agentskills.io open standard (SKILL.md, layout, progressive disclosure).
+globs: .cursor/skills/**/SKILL.md
+alwaysApply: false
+---
+
+# Agent Skills format (agentskills.io)
+
+When creating or editing a skill under `.cursor/skills/`, follow the **[Agent Skills specification](https://agentskills.io/specification.md)** and **[best practices](https://agentskills.io/skill-creation/best-practices.md)**.
+
+## Layout
+
+- Skill root = one directory named like the skill; it **must** contain `SKILL.md`.
+- Optional folders: `scripts/`, `references/`, `assets/` (and other supporting files as needed).
+
+## `SKILL.md` frontmatter (YAML)
+
+Required:
+
+- **`name`**: 1–64 chars; lowercase `a-z`, digits, single hyphens only; no leading/trailing hyphen; no `--`; **must equal the parent directory name**.
+- **`description`**: 1–1024 chars; state **what** the skill does and **when** to use it; include **concrete trigger phrases** so agents match the right tasks.
+
+Optional (use when they add real signal):
+
+- **`license`**, **`compatibility`** (1–500 chars if present), **`metadata`** (string keys → string values), **`allowed-tools`** (experimental; space-separated).
+
+Minimal valid opening:
+
+```markdown
+---
+name: my-skill
+description: Does X and Y. Use when the user asks for Z or mentions A/B keywords.
+---
+
+```
+
+## Body
+
+- Write **procedural, task-shaped** instructions (steps, defaults, validation loops). Omit generic advice the model already knows.
+- Prefer **progressive disclosure**: keep `SKILL.md` **under ~500 lines**; move deep reference to `references/` or `assets/` and tell the agent **when** to read each file.
+- Reference other files with **paths relative to the skill root**, ideally **one level** from `SKILL.md` (e.g. `references/workflow.md`).
+
+## Validation
+
+After substantive edits, validate when possible:
+
+```bash
+skills-ref validate ./path/to/skill-directory
+```
+
+Use the [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref) tool from the agentskills.io project if it is installed locally.

--- a/.cursor/skills/open-pull-request/SKILL.md
+++ b/.cursor/skills/open-pull-request/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: open-pull-request
+description: Drafts or opens a GitHub pull request body that matches this repository’s .github/PULL_REQUEST_TEMPLATE.md, keeps What/Why concise, and fills Related issues with links to issues, PRs, or other repos. Use when the user asks to open a PR, create a pull request, write PR description, or prepare gh pr create.
+license: Elastic License (see LICENSE.txt in repository root)
+compatibility: Requires repository checkout; optional network for gh. GitHub CLI (gh) optional for creating the PR from the terminal.
+metadata:
+  spec: https://agentskills.io/specification.md
+---
+
+# Open pull request (Agent Skill)
+
+Portable **[Agent Skills](https://agentskills.io/specification.md)** skill: core steps use git, repo files, and plain chat only.
+
+## Instructions
+
+1. **Read the template** at `.github/PULL_REQUEST_TEMPLATE.md` from the repository root. The PR description **must** use the same section headings and checklist structure as that file (do not rename sections or drop checklist items).
+
+2. **Gather facts (short):**
+   - Summarize **what** changed (scope, key files or areas) in a few sentences or tight bullets.
+   - Summarize **why** in 1–3 sentences (motivation, risk, or user impact).
+   - Infer the default base branch from repo conventions if unclear (often `main`).
+
+3. **Related issues / PRs / other repos:**
+   - Parse the **user’s request** for URLs, `#123`, `owner/repo#123`, `Closes` / `Fixes` / `Relates`, or explicit issue/PR numbers.
+   - Parse **recent commits** on the current branch (e.g. `git log --oneline -20` and, if needed, `git log -1 --format=%B` / `git log --grep` for issue keywords) for the same patterns.
+   - If **no** related references are found in the prompt or commits, **ask once in natural language** (or offer two numbered options): whether to include links to related issues, PRs, or other repositories; if yes, ask for a single reply listing URLs or `#refs`. Merge answers into the **Related issues** section using the template’s bullet style (`Closes #…`, `Relates #…`, etc.).
+
+   **Cursor:** If the structured **`AskQuestion`** tool is available, you may use it instead of freeform numbering for the same yes/no + follow-up flow (e.g. “No related items” vs “Yes — I will send references in chat”).
+
+4. **Checklist:** Copy the checklist from the template verbatim. Mark items `[x]` only when verified from the diff or file tree; otherwise leave `[ ]`. For items that do not apply, **strike through** the line with `~~...~~` per the template comment (do not delete rows).
+
+5. **Length:** Keep **What does this PR do?** and **Why is it important?** brief. Prefer pointers (file paths, spec areas) over long narratives. Put deep detail in review comments or commits if needed.
+
+6. **Open the PR:** Prefer `gh pr create` with a body file when `gh` is available and authenticated; otherwise output the final Markdown for the user to paste. Ensure the body matches the template sections exactly before submitting.
+
+## Output shape
+
+Produce a single Markdown document that could be saved and passed to `gh pr create --body-file`, with no extra title line unless the hosting workflow requires it—sections should match `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Examples
+
+**Related issues line when user said “fixes observability backlog” but no number:**
+
+After the agent asked for references, the user sends `Closes elastic/package-spec#999`. Body includes:
+
+```markdown
+## Related issues
+
+- Closes #999
+```
+
+**Short What / Why:**
+
+```markdown
+## What does this PR do?
+
+- Tightens validation for `foo` in `spec/…`
+- Updates `spec/changelog.yml` for the next minor
+
+## Why is it important?
+
+Prevents invalid packages from passing `elastic-package` checks and documents the behavior change for integrators.
+```
+
+## Validation
+
+After substantive edits to this skill, run (if installed):
+
+```bash
+skills-ref validate ./.cursor/skills/open-pull-request
+```

--- a/.cursor/skills/package-spec-release/SKILL.md
+++ b/.cursor/skills/package-spec-release/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: package-spec-release
+description: Prepares a package-spec release branch from elastic/main, finalizes spec/changelog.yml, updates compliance CI matrix, reviews Go toolchain (prompts whether to adopt a newer Go minor when stable releases are ahead, otherwise patch-only .go-version), updates AGENTS.md, commits by topic, pushes to the contributor fork, and opens a PR to elastic/main. If git remotes do not clearly identify the user's fork, lists remotes and asks which remote to use. Use when the user asks to release package-spec, prepare a release, or run the release workflow.
+license: Elastic License (see LICENSE.txt in repository root)
+compatibility: Requires git, network access, and GitHub push access to a fork; GitHub CLI (gh) optional for opening pull requests.
+metadata:
+  spec: https://agentskills.io/specification.md
+---
+
+# package-spec release (Agent Skill)
+
+This skill conforms to the **[Agent Skills](https://agentskills.io/specification.md)** open format ([agentskills.io](https://agentskills.io/)).
+
+## Instructions
+
+1. Read and follow the full procedure in **[references/workflow.md](references/workflow.md)** end-to-end.
+2. **Cursor only:** when presenting discrete choices, prefer the **`AskQuestion`** tool when it is available; otherwise use the numbered list (or A/B) pattern described in that file.

--- a/.cursor/skills/package-spec-release/references/workflow.md
+++ b/.cursor/skills/package-spec-release/references/workflow.md
@@ -1,0 +1,116 @@
+# package-spec release workflow
+
+Portable steps to open a **`prepare-release-<version>`** pull request against `elastic/package-spec` `main`. Repository paths below are relative to the **repository root**.
+
+## Prompting for choices
+
+Whenever the workflow needs a **discrete choice** from the user (fork remote, Go minor vs patches-only, etc.):
+
+1. Be **direct**: one short sentence of context, then the choice (no long setup).
+2. Present a **numbered markdown list** (or two clear options **A** / **B**), one entry per concrete choice; put distinguishing detail in each line (e.g. remote name and fetch URL).
+3. Ask for a **single reply** (the number, the letter, or the exact label).
+4. If the client provides a **structured selectable list** UI, you may use it instead, with the **same** options as the numbered list.
+
+## When the user skips required input
+
+If the user **skips** a required prompt (dismisses structured choices without picking, leaves an answer empty, or otherwise does not provide **required** information): **stop** immediately—no branch creation, no repository edits.
+
+**Reply style:** **Do not** extend the response. **Only** thank the user and, in **one brief sentence**, explain that a release needs **version** confirmation (`X.Y.Z`) and **fork remote** confirmation when that applies. If **version and fork remote are already settled** and the only missing piece is another required choice (e.g. Go minor vs patches), use **one** short sentence naming only that choice instead—still no extra paragraphs or tips.
+
+## 0. Preconditions
+
+- Clean working tree on a machine with `git` and network access.
+- Resolve remotes with `git remote -v`:
+  - **`UPSTREAM_REMOTE`**: the remote whose fetch URL is **`elastic/package-spec`** (common name `upstream`; sometimes `origin` if the clone is from the elastic org).
+  - **`FORK_REMOTE`**: the remote pointing at **the user’s fork** (same repo name under their GitHub user or org), used for `git push` and PR head.
+- If **`FORK_REMOTE` is unclear** (e.g. two remotes look like forks, `origin` is elastic not personal, or naming is nonstandard): follow **Prompting for choices**—e.g. *“Which remote is your fork?”* with **one option per remote**, each line showing **name and fetch URL** (e.g. `1. myfork — git@github.com:alice/package-spec.git`). Store the chosen remote name as `FORK_REMOTE`. If the user **skips** without choosing, follow **When the user skips required input**.
+- Keep **base branch** = `main` on the elastic org repo (`elastic/main` in GitHub terms).
+
+## 1. Version
+
+1. Ask: **Which version are we releasing?** Expected: `X.Y.Z` (Semantic Versioning, no prerelease suffix in the answer).
+2. If the user gives **no version** or empty input, **stop** (do not create branch or edits). Follow **When the user skips required input** for the reply.
+3. Validate `X.Y.Z` (three dot-separated non-negative integers). If invalid, ask again or exit with a clear message.
+
+Let `VERSION` = the agreed value (e.g. `3.6.1`).
+
+## 2. Branch
+
+1. `git fetch ${UPSTREAM_REMOTE}` (use the remote that tracks the elastic org repo).
+2. Create from latest upstream main:
+
+   `git checkout -b prepare-release-${VERSION} ${UPSTREAM_REMOTE}/main`
+
+3. Push to the **fork**:
+
+   `git push -u ${FORK_REMOTE} prepare-release-${VERSION}`
+
+## 3. Changelog — `spec/changelog.yml`
+
+1. Find a top-level entry whose `version` field is exactly **`${VERSION}-next`** (e.g. `3.6.1-next`).
+2. If **no such entry**, **stop** and tell the user the version was not found (they may need a `-next` section added on `main` first).
+3. If found, set `version` to **`${VERSION}`** (remove only the `-next` suffix). Do not reorder sections beyond what is needed for the edit.
+
+## 4. Compliance CI — `.buildkite/pipeline.trigger.compliance.tests.sh`
+
+1. Locate calls to `compliance_test <stack_version> <spec_version>`.
+2. Update the **latest-stack** row (today the first call, pairing the newest `*-SNAPSHOT` or newest stack with the spec under release): set the **second argument** (`spec_version`) from the **previously released** spec on that row to **`${VERSION}`**.
+
+   Example: releasing `3.6.1` when the first line is `compliance_test 9.4.0-SNAPSHOT 3.6.0` → `compliance_test 9.4.0-SNAPSHOT 3.6.1`.
+
+3. Do **not** change other `compliance_test` rows unless the user explicitly asked to refresh those stack/spec pairs.
+
+## 5. Go toolchain
+
+1. Read `go.mod` `go` directive (repo minor; line may be `1.MM` or `1.MM.P`) and `.go-version` (full `1.MM.P`, e.g. `1.25.8`).
+2. From **official Go releases**, determine the **latest stable** version (minor + patch).
+3. **Newer minor than `go.mod`?** If latest stable’s **minor** is **greater** than the repo’s `go` minor:
+   - State one line of fact (e.g. *Repo `go` is 1.25.x; latest stable Go is 1.26.y.*).
+   - Follow **Prompting for choices**—e.g. *“Update Go for this release?”* with exactly two options: **Bump `go.mod` + `.go-version` to latest stable (`1.26.y`)** and **Stay on current minor; patch `.go-version` only**.
+   - **If they choose the minor bump:** update `go` in `go.mod` to match this repo’s style (same `1.MM` vs `1.MM.P` pattern as today), set `.go-version` to the new minor’s latest patch, run `go mod tidy` / `make check` if needed, and **state rationale + alignment** with default branches of [elastic/elastic-package](https://github.com/elastic/elastic-package) and [elastic/integrations](https://github.com/elastic/integrations) in the PR.
+   - **If they choose patches only:** do **not** change `go.mod` minor; continue with step 4 only. If those repos are already on a **higher** minor, **note the gap in the PR** (no automatic minor bump).
+4. **Patch-only path** (no newer stable minor than `go.mod`, **or** user chose patches only in step 3): resolve the **latest patch** for **`go.mod`’s minor**. If that patch is **greater** than `.go-version`, update **only** `.go-version`. Optionally run `go mod tidy` / `make check`.
+5. Do not churn unrelated `require` blocks; scope edits to the Go version lines unless `tidy` demands otherwise.
+
+## 6. `AGENTS.md`
+
+After changelog and CI edits, scan `AGENTS.md` for:
+
+- Examples using `TEST_SPEC_VERSION`, `format_version`, validator `semver.MustParse`, or narrative **“currently `X.Y.Z-next`”** notes.
+- Compliance / local run examples that should reference **`${VERSION}`** or the new **`-next`** line if a follow-on dev version appears in `changelog.yml`.
+
+Update only what is **factually wrong** after the release edit (keep the doc accurate; avoid unrelated rewrites).
+
+## 7. Commits
+
+Create **one commit per topic**, short imperative subject, e.g.:
+
+- `Update changelog for ${VERSION}`
+- `Bump compliance CI spec version to ${VERSION}`
+- `Bump Go patch version in .go-version` (if applicable)
+- `Bump Go to 1.MM.P` (if `go.mod` / `.go-version` minor bump)
+- `Update AGENTS.md for ${VERSION} release`
+
+## 8. Push and pull request
+
+1. `git push ${FORK_REMOTE}` (same branch as in step 2; add `--set-upstream` on first push if not already set).
+2. Open a PR **from the fork** → **`elastic/package-spec` `main`** (GitHub UI or `gh pr create --repo elastic/package-spec --base main --head <fork-owner>:prepare-release-${VERSION} --title "Prepare release ${VERSION}"`). Derive `<fork-owner>` from the **`FORK_REMOTE`** URL if needed. If `gh` defaults the head correctly after `push`, `--head` may be omitted.
+
+### PR body
+
+Use [`.github/PULL_REQUEST_TEMPLATE.md`](../../../../.github/PULL_REQUEST_TEMPLATE.md): fill **What**, **Why**, and **Checklist** (strike items that do not apply, e.g. no new test packages for a pure release prep).
+
+- Short **description of the release** (what `VERSION` contains at a high level).
+- **Comprehensive summary of changes in this release:** bullet list derived from `spec/changelog.yml` for **`${VERSION}`** (every `changes[].description`, note breaking-change vs enhancement vs bugfix, include links already in the changelog).
+
+Title suggestion: `Prepare release ${VERSION}`.
+
+## Quick verification
+
+- `spec/changelog.yml` contains `version: ${VERSION}` (no stray `${VERSION}-next` for that release block).
+- First/latest `compliance_test` uses spec **`${VERSION}`** where intended.
+- `go test ./code/go/...` or `make check` if Go files or version files changed.
+
+## Optional reference
+
+For changelog conventions and compliance tags, see existing sections in [`AGENTS.md`](../../../../AGENTS.md) (changelog management, compliance testing).

--- a/.cursor/skills/review-pr/SKILL.md
+++ b/.cursor/skills/review-pr/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: review-pr
+description: Review a package-spec pull request or branch for completeness and correctness. Use when the user asks to review a PR, check their branch is ready to merge, verify they have not missed required changes, or wants a pre-submission checklist. Accepts a PR number, a branch name, or no argument (current branch vs main).
+license: Elastic License (see LICENSE.txt in repository root)
+compatibility: Requires git. For PR number resolution, also requires the gh CLI authenticated against elastic/package-spec. For local validation (make check, go test), requires a Go toolchain and make. Compatible with Claude Code (/review-pr), Cursor, GitHub Copilot, Gemini CLI, and other Agent Skills-compatible agents.
+metadata:
+  spec: https://agentskills.io/specification.md
+---
+
+# package-spec PR Review (Agent Skill)
+
+This skill conforms to the **[Agent Skills](https://agentskills.io/specification.md)** open format ([agentskills.io](https://agentskills.io/)).
+
+**This skill does not modify the codebase.** It does not edit source files, run any git
+command that modifies state (no commit, push, checkout, reset, stash, merge, or rebase), or
+change anything on the branch under review. If an issue is found, describe it and stop — do
+not attempt to fix it. The only file it writes is the review report at `.cursor/review-pr-output.md`.
+
+Reviews a branch or pull request against the contribution rules for this repository.
+See [references/checklist.md](references/checklist.md) for full rules and examples.
+
+For narrative onboarding (Makefile targets, scaffolding test packages, testing against the integrations repo), see **[CONTRIBUTING.md](../../../CONTRIBUTING.md)** at the repository root. This skill and the checklist focus on **PR completeness** against those practices.
+
+## How to Use This Skill
+
+| Situation | What to do |
+| --- | --- |
+| **Claude Code** | `/review-pr`, `/review-pr <branch>`, or `/review-pr <PR-number>` |
+| **Cursor / Copilot** | Attach this file to your chat and say "review my changes" or paste your diff |
+| **Any LLM** | Paste this file as a system message, then provide the output of `git diff main...HEAD` |
+
+---
+
+## Step 1 — Resolve the Target
+
+Determine what to diff based on the input provided:
+
+**If a PR number was given** (e.g., `1140`):
+
+```bash
+gh pr view 1140 --repo elastic/package-spec --json headRefName,baseRefName,title,url
+git fetch origin <headRefName>
+# diff: FETCH_HEAD vs <baseRefName>
+git diff <baseRefName>...FETCH_HEAD --stat
+git diff <baseRefName>...FETCH_HEAD
+```
+
+**If a branch name was given** (e.g., `my-feature`):
+
+```bash
+git diff main...<branch> --stat
+git diff main...<branch>
+```
+
+**If no argument was given** (review current branch):
+
+```bash
+git branch --show-current          # confirm we are not on main
+git diff main...HEAD --stat
+git diff main...HEAD
+```
+
+If the current branch is `main` and no argument was given, report that there is nothing to review.
+
+---
+
+## Step 2 — Categorize Changed Files
+
+Using the file list from `--stat`, bucket each changed file into one or more categories:
+
+| Category | File pattern |
+| --- | --- |
+| **Spec files** | `spec/**/*.spec.yml` |
+| **Changelog** | `spec/changelog.yml` |
+| **Semantic validators** | `code/go/internal/validator/semantic/*.go` (excluding `*_test.go`) |
+| **Validator registry** | `code/go/internal/validator/spec.go` |
+| **Validator unit tests** | `code/go/internal/validator/semantic/*_test.go` |
+| **Validator integration tests** | `code/go/pkg/validator/validator_test.go` |
+| **Test packages** | `test/packages/**` |
+| **Compliance packages** | `compliance/testdata/packages/**` |
+| **Compliance features** | `compliance/features/*.feature` |
+
+Use the categories internally to pick checklist sections; do not paste the full categorized file list into the report unless it clarifies an extra-review item.
+
+---
+
+## Step 3 — Run the Checklist
+
+Work through each applicable section from [references/checklist.md](references/checklist.md).
+
+Below is a compact version of the checks. The reference file has full rules, edge cases, and
+exact examples.
+
+### Contribution process (when relevant)
+
+Consult section **0** in the reference file and [CONTRIBUTING.md](../../../CONTRIBUTING.md#change-proposals).
+
+- Cross-stack or cross-product spec changes should follow the **Change Proposals** process before merge.
+- New **package categories** require the **Category Proposals** process.
+- If the change is large and the PR does not reference a proposal or tracking issue, add an extra-review note asking the author to confirm process was followed.
+
+### Always: Changelog
+
+- Is `spec/changelog.yml` modified?
+  - If not: **flag as missing** (required for all non-trivial changes; dependency-bump PRs
+    from Dependabot are the only exception).
+- If modified, verify:
+  - Entry is under the correct in-development version (the one with `-next` suffix).
+  - New entry is at the **bottom** of that version's `changes` list.
+  - `description` is a complete sentence ending with a period.
+  - `type` is one of: `enhancement`, `bugfix`, or `breaking-change`.
+  - `link` points to a valid PR URL or is `TBD` (not empty, not an issue URL unless the
+    change originated from an issue with no PR).
+  - If the feature is blocked on Kibana/elastic-package: a `# Pending on <url>` comment
+    appears directly above the entry.
+
+### If spec files changed
+
+Consult the "Version patches" and "Schema reuse" sections of the reference file.
+
+- Every new field or definition added to a `.spec.yml` file **must** have a corresponding
+  `versions[].patch` block that removes it for older spec versions.
+- The remove order matters: property `$ref` entries must be removed before the definition
+  they reference.
+- Shared fields used in multiple spec files must be defined once in
+  `spec/integration/manifest.spec.yml` and referenced via `$ref` elsewhere — not duplicated
+  inline.
+
+### If semantic validators changed
+
+Consult the "Semantic validators" section of the reference file.
+
+- New validator function: check it is registered in `code/go/internal/validator/spec.go`
+  in the `rulesDef` slice, with appropriate `fn`, `since`, and `types` fields.
+- Tests: at least one of the following must be present:
+  - A `*_test.go` file alongside the validator using `t.TempDir()` (simple/single-file rules).
+  - New test cases in `code/go/pkg/validator/validator_test.go` referencing packages in
+    `test/packages/` (complex multi-file scenarios).
+
+### If test packages changed
+
+Consult the "Test packages" section of the reference file.
+
+- Each package under `test/packages/` or `compliance/testdata/packages/` must contain:
+  `manifest.yml`, `changelog.yml`, `docs/README.md`.
+- Any data stream must include a valid ingest pipeline: processors need a `tag` field, and
+  there must be an `on_failure` block that sets `event.kind: pipeline_error` and
+  `error.message` to a string containing the three Handlebars placeholders.
+
+### If compliance feature files changed
+
+Consult the "Compliance features" section of the reference file.
+
+- Every `Scenario:` must have a `@X.Y.Z` version tag immediately above it.
+- A `@skip` tag must always be paired with a `# Pending on <url>` comment on the next line.
+- When `@skip` is added, the corresponding `spec/changelog.yml` entry must also have a
+  matching `# Pending on <url>` comment.
+
+### If new Go files added
+
+- Every new `.go` file must start with the Elastic license header:
+
+  ```go
+  // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+  // or more contributor license agreements. Licensed under the Elastic License;
+  // you may not use this file except in compliance with the Elastic License.
+  ```
+- Variable and function names must be unabbreviated (e.g., `packageName` not `pkgName`,
+  `dataStreamManifests` not `dsManifests`).
+- Indentation must use tabs, not spaces.
+
+---
+
+## Step 4 — Run Local Validation
+
+If a Go toolchain and `make` are available in the environment, run at minimum (same order as [CONTRIBUTING.md](../../../CONTRIBUTING.md#testing-your-changes)):
+
+```bash
+# Validate spec YAML syntax (fast, always do this after spec changes)
+go test ./code/go/internal
+
+# Lint and license headers
+make check
+```
+
+**Optional (broader validation):** When the diff warrants it, also run `make test` for the full suite ([CONTRIBUTING.md](../../../CONTRIBUTING.md#testing-your-changes)). For changes that should be exercised across many real packages, see **Testing with integrations repository** in [CONTRIBUTING.md](../../../CONTRIBUTING.md#testing-with-integrations-repository) (e.g. `test integrations` PR comment and closing the spawned integrations PR when done).
+
+Record validation outcomes only as described in **Step 5** (short summary per command; on failure, include a small excerpt only). If the toolchain is not available, note `skipped` for those commands.
+
+---
+
+## Step 5 — Write the Report
+
+Write a **short** report to `.cursor/review-pr-output.md`, overwriting any previous run. Use **plain text only** (no emoji or decorative symbols). Aim for roughly one screen of content.
+
+Include **only** what follows. Omit empty sections entirely.
+
+```markdown
+# PR review: <branch or PR title>
+<!-- reviewed: <ISO date> -->
+
+## Scope
+
+At most 2–4 bullets: what the diff changes, only if that context helps a reviewer. Omit this section if the PR title and `git diff --stat` are enough and nothing needs extra review.
+
+## Extra review
+
+Bullets **only** for items that need human attention: checklist gaps, blockers, open questions, or parts of the change that are easy to get wrong (for example new `versions` patches, new semantic validators, `spec/changelog.yml` entries, compliance `@skip`, or cross-file `$ref`). For each bullet use `path:approximate-line` (or `path` and a short region description) plus **one sentence**. Prefix with `blocker`, `suggestion`, or `question` when useful.
+
+If there is nothing to flag here and validation passed, use a single line instead of a list:
+
+No items flagged for extra review.
+
+## Validation
+
+One line per command you ran, for example: `go test ./code/go/internal: pass`. Use `fail` or `skipped` as appropriate. If a command failed, add a **short** excerpt (failing test name or error lines only), not the full log. If no commands ran, one line: `Validation: skipped (toolchain not available).`
+```
+
+**Do not** add per-topic sections (changelog, version patches, tests, etc.) when there is nothing to say. Do not paste full `go test` or `make check` output on success. Do not list files that look fine.
+
+After writing the file, print this message to the user:
+
+```
+Review written to .cursor/review-pr-output.md
+```
+
+## Validating this skill
+
+After substantive edits to this skill, run (if installed):
+
+```bash
+skills-ref validate ./.cursor/skills/review-pr
+```

--- a/.cursor/skills/review-pr/references/checklist.md
+++ b/.cursor/skills/review-pr/references/checklist.md
@@ -1,0 +1,450 @@
+# package-spec PR Review Checklist — Detailed Reference
+
+This file contains the full rules, rationale, and examples for each review category.
+It is referenced by `SKILL.md` and is loaded on demand when deeper detail is needed.
+
+The human-oriented contributor guide ([CONTRIBUTING.md](../../../../CONTRIBUTING.md)) covers the same development workflows (Makefile targets, test packages, integrations testing) in narrative form. Prefer that document for onboarding; use this checklist for systematic PR review.
+
+---
+
+## 0. Contribution process
+
+**When it applies:** Large or cross-product spec changes, or new package categories.
+
+| Topic | Rule |
+| --- | --- |
+| **Change proposals** | Changes that impact the Elastic Stack or Elastic Packages beyond this repo should follow the **Change Proposals** process in [CONTRIBUTING.md](../../../../CONTRIBUTING.md#change-proposals) (GitHub issue, consensus, ordered checklist) before landing as a single drive-by PR. |
+| **Category proposals** | New supported package categories require the **Category Proposals** flow in [CONTRIBUTING.md](../../../../CONTRIBUTING.md#category-proposals). |
+
+**Review hint:** If the diff is a substantial spec or validator change and the PR description does not reference a proposal or tracking issue, add an extra-review note asking the author to confirm process was followed.
+
+---
+
+## 1. Changelog
+
+**File:** `spec/changelog.yml`
+
+### Changelog Format
+
+```yaml
+- version: 3.7.0-next        # in-development version always has -next suffix
+  changes:
+    - description: Brief description of the change ending with a period.
+      type: enhancement        # enhancement | bugfix | breaking-change
+      link: https://github.com/elastic/package-spec/pull/NUMBER
+```
+
+### Changelog Rules
+
+| Rule | Detail |
+| --- | --- |
+| Always required | Every non-trivial PR must add an entry. Dependabot dependency bumps are the only exception. |
+| Position | New entries go at the **bottom** of the `changes` list of the in-development version. |
+| Version | Must be the version with a `-next` suffix, not a released version. |
+| Description | Complete sentence ending with a period. Describes what was added/changed, not why. |
+| Type | Exactly one of: `enhancement`, `bugfix`, `breaking-change`. |
+| Link | Full GitHub PR URL. Use `TBD` only if the PR does not exist yet. Never use an issue URL here unless explicitly intended. |
+
+### Pending features
+
+When a spec feature is complete but blocked on upstream (Kibana, elastic-package):
+
+```yaml
+    # Pending on https://github.com/elastic/kibana/issues/NNNNNN
+    - description: Add support for foo.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/NNN
+```
+
+- The `# Pending on <url>` comment must appear on the line **directly above** the entry.
+- The corresponding compliance `.feature` file must also have a `@skip` tag with the same URL.
+- Remove both when the blocker is resolved.
+
+---
+
+## 2. Version Patches
+
+**Why they exist:** The spec supports multiple format versions. New fields added in, say, 3.7.0
+must be invisible to packages using 3.6.x or earlier. Version patches achieve this by removing
+the new fields from the schema when validating older packages.
+
+**Where they live:** In the same `.spec.yml` file that defines the new field, under a `versions`
+key at the top level.
+
+### Patch Format
+
+```yaml
+versions:
+  - before: 3.7.0
+    patch:
+      - op: remove
+        path: "/properties/my_new_field"
+      - op: remove
+        path: "/definitions/my_new_definition"
+```
+
+### Patch Rules
+
+| Rule | Detail |
+| --- | --- |
+| Required for all new fields | Every new `properties` entry and `definitions` entry in a `.spec.yml` needs a `versions.before` patch. |
+| `versions` list order | Add new version entries at the **top** of the `versions` list (newer spec versions first), per [CONTRIBUTING.md](../../../../CONTRIBUTING.md#version-patches). |
+| Remove order | **References before definitions.** Remove `/properties/my_field` before `/definitions/my_field`. Otherwise the patch fails because it tries to remove a definition that is still referenced. |
+| `_dev` exception | Files under `_dev` directories do not need version patches. These are developer tooling files, not part of the distributed spec. |
+| Patch comments | Comments should be placed on the `path:` line, not the `op:` line. Only add comments for non-obvious paths (e.g., array index paths like `required/-`). Omit comments for simple, self-explanatory paths. |
+
+### Comment convention examples
+
+```yaml
+# GOOD — comment on path line, only for complex path
+- op: add
+  path: "/properties/policy_templates/items/required/-"  # re-add type as required
+  value: type
+
+# GOOD — no comment for simple path
+- op: remove
+  path: "/properties/my_field"
+
+# BAD — comment on op line
+- op: remove  # removes my_field
+  path: "/properties/my_field"
+
+# BAD — redundant comment for obvious path
+- op: remove
+  path: "/properties/my_field"  # removes my_field property
+```
+
+### Version Patches Checklist
+
+- [ ] Every new `properties` key has a `remove` patch.
+- [ ] Every new `definitions` key has a `remove` patch.
+- [ ] Properties are removed before their definitions in the patch list.
+- [ ] `_dev` files are excluded.
+- [ ] Comments follow the path-line convention.
+
+---
+
+## 3. Schema Reuse
+
+**Why it matters:** Duplicate inline definitions drift out of sync. The spec uses JSON Schema
+`$ref` to define a field once and reference it everywhere.
+
+### When to use `$ref`
+
+If the same field definition appears in two or more spec files: define it once in
+`spec/integration/manifest.spec.yml` under `definitions`, then reference it everywhere else.
+
+### Cross-file reference syntax
+
+```yaml
+# Same file
+$ref: "#/definitions/my_field"
+
+# From spec/input/manifest.spec.yml referencing spec/integration/manifest.spec.yml
+$ref: "../integration/manifest.spec.yml#/definitions/my_field"
+
+# From spec/integration/data_stream/manifest.spec.yml
+$ref: "../../integration/manifest.spec.yml#/definitions/my_field"
+```
+
+Always use **relative paths** (starting with `../`). Absolute or root-relative paths break
+portability.
+
+### `additionalProperties: false`
+
+Objects should have `additionalProperties: false` to prevent undeclared fields from silently
+passing validation. Flag if a new object type is missing this.
+
+### Schema Reuse Checklist
+
+- [ ] No field definition appears inline in two different `.spec.yml` files.
+- [ ] Shared definitions live in `spec/integration/manifest.spec.yml`.
+- [ ] All `$ref` uses relative paths.
+- [ ] New object schemas include `additionalProperties: false` where appropriate.
+
+---
+
+## 4. Semantic Validators
+
+**Location:** `code/go/internal/validator/semantic/`
+
+### Registration
+
+New validator functions must be registered in `code/go/internal/validator/spec.go` inside
+the `rulesDef` slice within the `rules()` function:
+
+```go
+// Minimal — applies to all package types and all versions
+{fn: semantic.ValidateMyRule},
+
+// With version gate — only applies for spec >= 3.7.0
+{fn: semantic.ValidateMyRule, since: semver.MustParse("3.7.0")},
+
+// With package type filter
+{fn: semantic.ValidateMyRule, types: []string{"integration", "input"}, since: semver.MustParse("3.7.0")},
+
+// With upper bound — only applies before 3.0.0
+{fn: warnOn(semantic.ValidateMyRule), until: semver.MustParse("3.0.0")},
+```
+
+Fields:
+
+- `fn` — required, the validator function
+- `since` — optional, minimum spec version (inclusive)
+- `until` — optional, maximum spec version (exclusive)
+- `types` — optional, package types this applies to; omit to apply to all types
+
+### Semantic Validators Checklist
+
+- [ ] New `ValidateXxx` function is present in the `rulesDef` slice.
+- [ ] `since` is set when the rule corresponds to a new spec feature (should match the spec
+  version being targeted).
+- [ ] `types` is set when the rule is not universally applicable (e.g., only for `integration`
+  packages).
+- [ ] `warnOn()` is used only for rules that are being phased in (deprecation warnings before
+  becoming hard errors in a future version).
+
+---
+
+## 5. Tests for Semantic Validators
+
+Two testing strategies; choose based on complexity:
+
+### Simple: unit test with `t.TempDir()`
+
+Use when the validator reads a single file or a simple directory structure.
+
+```go
+func TestValidateMyRule(t *testing.T) {
+    tests := map[string]struct {
+        manifest      string
+        expectError   bool
+        errorContains string
+    }{
+        "valid": {
+            manifest:    "name: test\nformat_version: 3.7.0\n",
+            expectError: false,
+        },
+        "invalid_missing_field": {
+            manifest:      "name: test\nformat_version: 3.7.0\nbad_field: value\n",
+            expectError:   true,
+            errorContains: "bad_field",
+        },
+    }
+    for name, tc := range tests {
+        t.Run(name, func(t *testing.T) {
+            pkgRoot := t.TempDir()
+            err := os.WriteFile(filepath.Join(pkgRoot, "manifest.yml"),
+                []byte(tc.manifest), 0644)
+            require.NoError(t, err)
+            fsys := fspath.DirFS(pkgRoot)
+            errs := semantic.ValidateMyRule(fsys)
+            if tc.expectError {
+                require.NotEmpty(t, errs)
+                require.Contains(t, errs[0].Error(), tc.errorContains)
+            } else {
+                require.Empty(t, errs)
+            }
+        })
+    }
+}
+```
+
+### Complex: test packages + `validator_test.go`
+
+Use when the rule requires a full package structure (multiple data streams, pipelines, etc.).
+
+1. Create the package: `cd test/packages && elastic-package create package`
+2. Modify its `manifest.yml` to exercise the rule.
+3. Add entries to `code/go/pkg/validator/validator_test.go`:
+
+```go
+tests := map[string]struct {
+    invalidPkgFilePath  string
+    expectedErrContains []string
+}{
+    "good_my_feature": {},   // valid — no errors expected
+    "bad_my_feature": {
+        "manifest.yml",
+        []string{`expected error substring here`},
+    },
+}
+```
+
+### Validator Tests Checklist
+
+- [ ] At least one of the above test strategies is present for every new validator.
+- [ ] Tests cover both the valid and invalid cases.
+- [ ] Error message substrings in `expectedErrContains` are specific enough to be meaningful.
+
+---
+
+## 6. Test Packages
+
+**Location:** `test/packages/` (general), `compliance/testdata/packages/` (compliance-only)
+
+### Required files
+
+Every package directory must contain:
+
+```text
+my_package/
+├── manifest.yml          # package manifest
+├── changelog.yml         # at minimum: one version entry with at least one change
+└── docs/
+    └── README.md         # package documentation
+```
+
+### Valid ingest pipeline
+
+Any data stream that includes an ingest pipeline must follow this structure:
+
+```yaml
+---
+description: Pipeline description.
+processors:
+  - set:
+      tag: set_field_name     # tag is required on every processor
+      field: my.field
+      value: test
+on_failure:                   # on_failure block is required
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - set:
+      field: error.message
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        in pipeline '{{{ _ingest.pipeline }}}'
+        failed with message '{{{ _ingest.on_failure_message }}}'
+```
+
+Required elements:
+
+- Every processor must have a `tag` field.
+- `on_failure` must set `event.kind` to `pipeline_error`.
+- `error.message` must include all three Handlebars placeholders:
+  `_ingest.on_failure_processor_type`, `_ingest.on_failure_processor_tag`, `_ingest.pipeline`.
+  (A fourth, `_ingest.on_failure_message`, is also included by convention.)
+
+### Transform packages (compliance only)
+
+Transforms in `compliance/testdata/packages/` that are installed and uninstalled across
+test runs must use:
+
+```yaml
+dest:
+  index: "metrics-mypackage.my_dest_default"  # no leading dot — hidden indices cause 403 on uninstall
+_meta:
+  managed: true
+  run_as_kibana_system: false  # use logged-in user credentials, not kibana_system
+```
+
+### Test Packages Checklist
+
+- [ ] `manifest.yml`, `changelog.yml`, and `docs/README.md` all present.
+- [ ] Data stream ingest pipelines have `tag` on each processor and a valid `on_failure` block.
+- [ ] Compliance-only transform packages use non-hidden dest index and `run_as_kibana_system: false`.
+- [ ] Package was created using `elastic-package create package` (not manually scaffolded) when possible.
+
+---
+
+## 7. Compliance Feature Files
+
+**Location:** `compliance/features/*.feature`
+
+### Version tagging
+
+Every `Scenario:` must be tagged with the minimum spec version that introduced the feature:
+
+```gherkin
+  @3.6.0
+  Scenario: Integration package with named input can be installed
+   Given the "good_v3" package is installed
+   ...
+```
+
+The tag controls whether the scenario runs: it is skipped if the `TEST_SPEC_VERSION`
+environment variable is lower than the tag.
+
+### Skipped scenarios
+
+When a scenario cannot pass because upstream (Kibana or elastic-package) hasn't implemented
+support yet:
+
+```gherkin
+  @3.6.0
+  @skip
+  # Pending support for qualified input names: https://github.com/elastic/kibana/pull/262138
+  Scenario: Integration package with OTel input can be installed
+   Given the "good_v3" package is installed
+   ...
+```
+
+Rules:
+
+- `@skip` must appear directly after the version tag.
+- A `# Pending <description>: <url>` comment must appear on the line after `@skip`.
+- The corresponding `spec/changelog.yml` entry must have a matching `# Pending on <url>`
+  comment above it.
+- Both the `@skip` and the `# Pending on` comment in the changelog must be removed together
+  when the blocker is resolved.
+
+### Compliance Features Checklist
+
+- [ ] Every `Scenario:` has a `@X.Y.Z` tag.
+- [ ] Every `@skip` is accompanied by a `# Pending ...` comment with a URL.
+- [ ] Changelog entry for the same feature has a matching `# Pending on <url>` comment.
+- [ ] No scenario has `@skip` without a tracking issue URL.
+
+---
+
+## 8. Go Style
+
+### License header
+
+Every new `.go` file must begin with:
+
+```go
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+```
+
+Enforced by `make check`. Running `make -C code/go update` adds headers automatically.
+
+### Naming conventions
+
+| Bad (abbreviation) | Good (full name) |
+| --- | --- |
+| `pkgName` | `packageName` |
+| `dsManifests` | `dataStreamManifests` |
+| `ptIdx` | `templateIndex` |
+| `errs` (in loops) | `validationErrors` or be specific |
+
+Exception: loop variables (`i`, `j`) and widely accepted short names (`err`, `ok`) are fine.
+
+### Indentation
+
+Go files use **tabs**, not spaces. `gofmt` enforces this — run `make -C code/go format`.
+
+### Error messages
+
+When creating structured errors with file paths, use `fsys.Path("relative/path")` rather than
+`file.Path()` to get the full package-relative path expected by the test framework:
+
+```go
+// Good
+specerrors.NewStructuredErrorf("file %q is invalid: %s", fsys.Path("_dev/test/config.yml"), err)
+
+// Bad — path is relative within fsys, not the full package path
+specerrors.NewStructuredErrorf("file %q is invalid: %s", config.Path(), err)
+```
+
+### Go Style Checklist
+
+- [ ] License header present in every new `.go` file.
+- [ ] No abbreviations in variable/function names (outside `err`, `ok`, loop vars).
+- [ ] Indentation uses tabs.
+- [ ] Error messages use `fsys.Path()` for file path references.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot instructions — package-spec
+
+## Release workflow
+
+When the user asks to **release package-spec**, **prepare a release**, or work on a **`prepare-release-*`** branch, follow the maintainer steps in **[docs/releasing-package-spec.md](../docs/releasing-package-spec.md)** (canonical steps in `.cursor/skills/package-spec-release/references/workflow.md`).

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.cursor/review-pr-output.md
+
 .idea/
 temp/
 fuzz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This document contains important information learned while working on the package-spec repository to help future AI agents working on this codebase.
 
+## Releases
+
+Maintainers preparing a versioned release (`prepare-release-X.Y.Z`, changelog finalization, compliance CI, PR to `elastic/main`) should follow **[docs/releasing-package-spec.md](docs/releasing-package-spec.md)**.
+
 ## Repository Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code — package-spec
+
+## Releases
+
+When preparing a **package-spec release** (e.g. user mentions releasing package-spec, `prepare-release-*`, or finalizing `spec/changelog.yml` for a version), follow **[docs/releasing-package-spec.md](docs/releasing-package-spec.md)**. It links to the canonical workflow under `.cursor/skills/package-spec-release/references/workflow.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,10 @@ Currently, the following custom formats are available:
 * `data-stream-name`: Name of a data stream. The format checker verifies if the data stream exists.
 
 
+## Agent-assisted PR review
+
+Maintainers and contributors can use the in-repository Agent Skill for a structured pre-merge checklist: [.cursor/skills/review-pr/SKILL.md](.cursor/skills/review-pr/SKILL.md). Detailed rules and examples live in [.cursor/skills/review-pr/references/checklist.md](.cursor/skills/review-pr/references/checklist.md).
+
 ## Development
 
 Download the latest main of `package-spec` repository:

--- a/docs/releasing-package-spec.md
+++ b/docs/releasing-package-spec.md
@@ -1,0 +1,7 @@
+# Releasing package-spec
+
+Step-by-step workflow for maintainers preparing a **`prepare-release-X.Y.Z`** pull request (changelog finalization, compliance CI matrix, Go toolchain review, `AGENTS.md`, commits, fork push, PR to `elastic/main`).
+
+**Full procedure (single source of truth):** [.cursor/skills/package-spec-release/references/workflow.md](../.cursor/skills/package-spec-release/references/workflow.md)
+
+That document is portable across editors and agents (Cursor, Claude Code, Copilot, and other [Agent Skills](https://agentskills.io/clients.md)-compatible tools). The packaged skill metadata lives under [.cursor/skills/package-spec-release/](../.cursor/skills/package-spec-release/).


### PR DESCRIPTION
## What does this PR do?

Introduces and documents **Agent Skills** and related AI workflow assets in the repo:

- **`.cursor/skills/`** — `package-spec-release` (release procedure + `references/workflow.md`), `open-pull-request` (PR body from the repo template), and **`review-pr`** (read-only PR review with `references/checklist.md`).
- **`.cursor/rules/agentskills-skill-authoring.mdc`** — authoring guidance aligned with the portable Agent Skills spec.
- **`.coderabbit.yaml`** — CodeRabbit knowledge base pointing at `review-pr` checklist paths for contribution rules.
- **Docs and pointers** — `CONTRIBUTING.md`, `AGENTS.md`, `CLAUDE.md`, `docs/releasing-package-spec.md`, and `.github/copilot-instructions.md` updated so maintainers and agents can find the skills without Makefile installs.
- **`.gitignore`** — ignores local review output (`.cursor/review-pr-output.md`).

## Why is it important?

Gives contributors and agents a **single, documented place** (skills + checklist + CodeRabbit) to run releases, draft PRs, and review changes consistently. This is **not tied to a product issue**; it is an incremental improvement to maintainer and AI-assisted workflows.

## Checklist

- [ ] ~~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Not linked to an issue; workflow and documentation improvement only.
