### PR TITLE
[skills] Update documentation for version patches and test package scaffolding

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,8 +25,9 @@ reviews:
     This is the elastic/package-spec repository, which defines the Elastic Package
     specification and its validation logic.
     Detailed contribution rules are in the code guidelines file loaded above.
-    Always check: changelog entry in spec/changelog.yml, version patches for any new
-    spec fields, semantic validator registration, test coverage, and Go style.
+    Always check: changelog entry in spec/changelog.yml; backward-compat handling for spec
+    schema changes (version patches and/or version scoping per the guidelines—not every new field
+    needs a `versions` remove patch); semantic validator registration; test coverage; and Go style.
     Dependabot dependency-bump PRs are the only exception to the changelog requirement.
 
   path_instructions:

--- a/.cursor/skills/review-pr/SKILL.md
+++ b/.cursor/skills/review-pr/SKILL.md
@@ -118,8 +118,11 @@ Consult section **0** in the reference file and [CONTRIBUTING.md](../../../CONTR
 
 Consult the "Version patches" and "Schema reuse" sections of the reference file.
 
-- Every new field or definition added to a `.spec.yml` file **must** have a corresponding
-  `versions[].patch` block that removes it for older spec versions.
+- For new `properties` or `definitions` that older `format_version` values must **not** include, add
+  `versions[].patch` remove operations (see the reference file). **Not** every addition needs a
+  patch: if the change is **only** meaningful at the introducing spec version (e.g. a new
+  **required** field or other **breaking** change with a clear minimum `format_version`), rely on
+  **version scoping** instead of remove patches when appropriate.
 - The remove order matters: property `$ref` entries must be removed before the definition
   they reference.
 - Shared fields used in multiple spec files must be defined once in

--- a/.cursor/skills/review-pr/SKILL.md
+++ b/.cursor/skills/review-pr/SKILL.md
@@ -141,6 +141,9 @@ Consult the "Semantic validators" section of the reference file.
 
 Consult the "Test packages" section of the reference file.
 
+- Prefer scaffolding with **`elastic-package create package`** or, for new data streams in an
+  existing package, **`elastic-package create data-stream`** (from that package’s directory), over
+  manual copies.
 - Each package under `test/packages/` or `compliance/testdata/packages/` must contain:
   `manifest.yml`, `changelog.yml`, `docs/README.md`.
 - Any data stream must include a valid ingest pipeline: processors need a `tag` field, and

--- a/.cursor/skills/review-pr/references/checklist.md
+++ b/.cursor/skills/review-pr/references/checklist.md
@@ -64,9 +64,12 @@ When a spec feature is complete but blocked on upstream (Kibana, elastic-package
 
 ## 2. Version Patches
 
-**Why they exist:** The spec supports multiple format versions. New fields added in, say, 3.7.0
-must be invisible to packages using 3.6.x or earlier. Version patches achieve this by removing
-the new fields from the schema when validating older packages.
+**Why they exist:** The spec supports multiple format versions. When a single `.spec.yml` still
+validates **older** `format_version` values, **remove patches** drop newer optional
+`properties` and `definitions` from the schema those older versions use. **Not** every change needs
+a remove patch: if the change applies **only** at the introducing version (e.g. a new **required**
+field or **breaking** change with a clear minimum `format_version`), **version scoping** may be
+enough—see the Patch Rules table below.
 
 **Where they live:** In the same `.spec.yml` file that defines the new field, under a `versions`
 key at the top level.

--- a/.cursor/skills/review-pr/references/checklist.md
+++ b/.cursor/skills/review-pr/references/checklist.md
@@ -73,9 +73,20 @@ key at the top level.
 
 ### Patch Format
 
+Add each new patch block at the **top** of the `versions` list so **newer spec versions come first**
+(higher `before` value above lower). When you add a patch for a new release, **insert** a new list
+item at the top—do not append at the bottom.
+
 ```yaml
 versions:
+  # Newer `before` first — insert new patch blocks here, above existing entries.
   - before: 3.7.0
+    patch:
+      - op: remove
+        path: "/properties/recent_field"
+      - op: remove
+        path: "/definitions/recent_field"
+  - before: 3.6.0
     patch:
       - op: remove
         path: "/properties/my_new_field"

--- a/.cursor/skills/review-pr/references/checklist.md
+++ b/.cursor/skills/review-pr/references/checklist.md
@@ -264,8 +264,9 @@ func TestValidateMyRule(t *testing.T) {
 
 Use when the rule requires a full package structure (multiple data streams, pipelines, etc.).
 
-1. Create the package: `cd test/packages && elastic-package create package`
-2. Modify its `manifest.yml` to exercise the rule.
+1. Scaffold with **`elastic-package create package`** (`cd test/packages` first), or add a data
+   stream with **`elastic-package create data-stream`** from inside the package directory.
+2. Modify `manifest.yml` (and data stream files if applicable) to exercise the rule.
 3. Add entries to `code/go/pkg/validator/validator_test.go`:
 
 ```go
@@ -294,6 +295,11 @@ tests := map[string]struct {
 **Location:** `test/packages/` (general), `compliance/testdata/packages/` (compliance-only)
 
 ### Required files
+
+The layout below is what **`elastic-package`** scaffolds when you create artifacts interactively:
+use **`elastic-package create package`** for a new package (integration, input, or content), or
+**`elastic-package create data-stream`** to add a data stream under an existing package. Prefer those
+commands over copying folders by hand so required files stay consistent.
 
 Every package directory must contain:
 
@@ -356,7 +362,8 @@ _meta:
 - [ ] `manifest.yml`, `changelog.yml`, and `docs/README.md` all present.
 - [ ] Data stream ingest pipelines have `tag` on each processor and a valid `on_failure` block.
 - [ ] Compliance-only transform packages use non-hidden dest index and `run_as_kibana_system: false`.
-- [ ] Package was created using `elastic-package create package` (not manually scaffolded) when possible.
+- [ ] Prefer **`elastic-package create package`** or **`elastic-package create data-stream`** over
+      manual scaffolding when adding a test package or data stream.
 
 ---
 

--- a/.cursor/skills/review-pr/references/checklist.md
+++ b/.cursor/skills/review-pr/references/checklist.md
@@ -87,7 +87,7 @@ versions:
 
 | Rule | Detail |
 | --- | --- |
-| Required for all new fields | Every new `properties` entry and `definitions` entry in a `.spec.yml` needs a `versions.before` patch. |
+| When to add `before:` patches | Add `versions.before` remove patches for new `properties` and `definitions` when the file still validates **older** `format_version` values and that schema must **not** apply to them (typical for optional fields in a spec file shared across versions). **Not every change needs a patch:** if the change is **already scoped** to the introducing spec version—e.g. a new **required** field or other **breaking** change with a clear minimum `format_version`—you may rely on that scoping instead of remove patches. |
 | `versions` list order | Add new version entries at the **top** of the `versions` list (newer spec versions first), per [CONTRIBUTING.md](../../../../CONTRIBUTING.md#version-patches). |
 | Remove order | **References before definitions.** Remove `/properties/my_field` before `/definitions/my_field`. Otherwise the patch fails because it tries to remove a definition that is still referenced. |
 | `_dev` exception | Files under `_dev` directories do not need version patches. These are developer tooling files, not part of the distributed spec. |
@@ -116,8 +116,7 @@ versions:
 
 ### Version Patches Checklist
 
-- [ ] Every new `properties` key has a `remove` patch.
-- [ ] Every new `definitions` key has a `remove` patch.
+- [ ] Every new `properties` or `definitions` entry that **older** `format_version` values must not include has a matching `remove` patch (or the change is correctly **scoped to the introducing version** only, e.g. required/breaking at a minimum `format_version`).
 - [ ] Properties are removed before their definitions in the patch list.
 - [ ] `_dev` files are excluded.
 - [ ] Comments follow the path-line convention.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,11 +128,20 @@ cd test/packages
 elastic-package create package
 ```
 
-The tool prompts for: package type, name, title, description, license (Apache-2.0), Kibana version (^8.0.0), subscription (basic), owner (elastic/foobar), and categories.
+To scaffold a **new data stream** under an existing test package, run from that package’s root:
+
+```bash
+cd test/packages/my_package
+elastic-package create data-stream
+```
+
+The tool prompts for: package type, name, title, description, license (Apache-2.0), Kibana version (^8.0.0), subscription (basic), owner (elastic/foobar), and categories (for `create package`).
 
 **After creation**: Adjust `format_version` and modify manifest.yml to test specific fields.
 
 ### Required Files
+
+Package roots created by **`elastic-package create package`** include:
 
 ```
 test/packages/my_package/
@@ -429,7 +438,8 @@ invalid_field: value`,
 
 For validators that need complete package structures (multiple data streams, pipelines, kibana objects, etc.):
 
-1. Create test package in `test/packages/` using `elastic-package create package`
+1. Create test package in `test/packages/` using `elastic-package create package`, or add a data
+   stream with `elastic-package create data-stream` from the package directory
 2. Add test case to `code/go/pkg/validator/validator_test.go`:
 
 ```go
@@ -527,7 +537,8 @@ Remove the comment once the blocker is resolved. Also add a corresponding `@skip
 4. **Missing test package files**: changelog.yml and docs/README.md are required
 5. **Invalid pipelines**: Data streams need proper ingest pipelines with on_failure handlers and processor tags
 6. **Wrong conditions format**: Use `conditions.kibana.version` not `conditions.kibana:version` for spec 3.0+
-7. **Creating test packages manually**: Always use `elastic-package create package`
+7. **Creating test packages manually**: Prefer `elastic-package create package` and
+   `elastic-package create data-stream` over copying folders by hand
 
 ## Example: Adding a New Field
 
@@ -562,7 +573,8 @@ Remove the comment once the blocker is resolved. Also add a corresponding `@skip
 
 4. **Check for custom validation** in `code/go/internal/validator/semantic/`
 
-5. **Create test packages**: `elastic-package create package`, then modify manifest
+5. **Create test packages**: `elastic-package create package` (and `elastic-package create
+   data-stream` when adding streams), then modify manifests as needed
 
 6. **Add test cases** in `validator_test.go`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,12 @@ properties:
 
 ### Version Patches
 
-Version patches enable backward compatibility by removing features from older spec versions:
+Version patches enable backward compatibility by removing features from older spec versions.
+**Not every** new `properties` or `definitions` entry needs a patch: use remove patches when the
+same file still validates older `format_version` values and new schema must be stripped for them;
+for changes that are **only** defined for the introducing version (e.g. new **required** fields or
+**breaking** changes with a clear minimum `format_version`), **scope** the change to that version
+instead of adding remove patches.
 
 ```yaml
 versions:
@@ -515,7 +520,8 @@ Remove the comment once the blocker is resolved. Also add a corresponding `@skip
 
 ## Common Pitfalls
 
-1. **Forgetting version patches**: New features must be removed for older versions
+1. **Forgetting version patches**: When optional additions in a shared spec file must be absent for
+   older `format_version` values, add remove patches; do not assume every field needs one
 2. **Not using shared definitions**: Define common fields once and reference with `$ref`
 3. **Wrong patch order**: Remove property references before shared definitions
 4. **Missing test package files**: changelog.yml and docs/README.md are required
@@ -541,7 +547,9 @@ Remove the comment once the blocker is resolved. Also add a corresponding `@skip
        # or: $ref: "../integration/manifest.spec.yml#/definitions/my_field"
    ```
 
-3. **Add version patch** (remove references first, then definition):
+3. **Add version patch when needed** (remove references first, then definition)—if older
+   `format_version` values must not see this field; otherwise scope the field to the introducing
+   version only:
    ```yaml
    versions:
      - before: 3.X.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,9 +175,14 @@ owner:
 
 ### Version Patches
 
-When adding new features to the specification, you must ensure backward compatibility by adding
-version patches. Version patches remove new features from older spec versions, allowing packages
-with older `format_version` values to continue validating correctly.
+When changing the specification, keep **backward compatibility** for packages with older
+`format_version` values. **Version patches** remove newer schema from older spec versions so those
+packages keep validating. You do **not** need a remove patch for every new field: if a change
+applies **only** at the introducing spec version (for example a new **required** field or another
+**breaking** change with a clear minimum `format_version`), you can **scope** the change to that
+version instead of adding `versions.before` remove operations. Use remove patches when the same
+`.spec.yml` file still serves older versions and new optional `properties` or `definitions` must be
+absent from the schema they see.
 
 Version patches are defined at the bottom of spec files (e.g., `spec/integration/manifest.spec.yml`):
 
@@ -193,6 +198,8 @@ versions:
 
 Guidelines:
 - Add patches at the top of the versions list (newer versions first).
+- Add remove patches when older spec versions must not include the new schema; skip them when the
+  change is only meaningful at the introducing version.
 - Remove both the property and its definition(s) if they are not used elsewhere.
 - Order matters: remove properties before the definitions they reference.
 - Only remove definitions that are not used by other features.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,15 +142,23 @@ test/packages/my_package/
 After creating test packages, remember to add corresponding test cases in
 `code/go/pkg/validator/validator_test.go`.
 
-If the `elastic-package` tool is available, you can use it to scaffold test packages interactively:
+If the `elastic-package` tool is available, use it to scaffold test packages and data streams
+interactively instead of copying directories by hand:
 
 ```bash
 cd test/packages
 elastic-package create package
 ```
 
-The tool will prompt for package details. After creation, you may need to adjust the `format_version`
-or any other content that you need for your test case.
+To add a **data stream** to an existing package, run this from **inside** that package directory:
+
+```bash
+cd test/packages/my_package
+elastic-package create data-stream
+```
+
+The tool will prompt for package or data stream details. After creation, you may need to adjust the
+`format_version` or any other content that you need for your test case.
 
 #### Manifest Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ This command validates:
 - Spec file syntax (manifest.spec.yml, etc.)
 - Changelog format and structure
 - Schema definitions and references
-- JSON patches for version compatibility
+- JSON Patch `versions` entries for backward compatibility (when present in spec files)
 
 This is **different** from package validation tests. The internal tests validate the specification
 itself, while package tests validate that packages conform to the specification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,10 +184,20 @@ version instead of adding `versions.before` remove operations. Use remove patche
 `.spec.yml` file still serves older versions and new optional `properties` or `definitions` must be
 absent from the schema they see.
 
-Version patches are defined at the bottom of spec files (e.g., `spec/integration/manifest.spec.yml`):
+Version patches are defined at the bottom of spec files (e.g., `spec/integration/manifest.spec.yml`).
+Add each new patch block at the **top** of the `versions` list so **newer spec versions come first**
+(higher `before` value above lower). Example:
 
 ```yaml
 versions:
+  # Newer `before` first — when you add a patch for a new release, insert a new list item here,
+  # above existing entries (do not append at the bottom of this list).
+  - before: 3.7.0
+    patch:
+      - op: remove
+        path: "/properties/recent_field"
+      - op: remove
+        path: "/definitions/recent_field"
   - before: 3.6.0
     patch:
       - op: remove
@@ -197,7 +207,7 @@ versions:
 ```
 
 Guidelines:
-- Add patches at the top of the versions list (newer versions first).
+- Add patches at the top of the versions list (newer versions first), as in the example above.
 - Add remove patches when older spec versions must not include the new schema; skip them when the
   change is only meaningful at the introducing version.
 - Remove both the property and its definition(s) if they are not used elsewhere.

--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ of the changed specification must be determined as follows:
     `Z = z + 1`. This includes any change on validation that doesn't neccesarily
     lead to a change in the behaviour of the installed package.
 
-If the change is in a schema file, add a JSON patch in the `versions` section to
-continue supporting the previous format. See the [Version Patches section in CONTRIBUTING.md](./CONTRIBUTING.md#version-patches)
-for detailed guidelines and examples.
+If the change is in a schema file, preserve backward compatibility for older `format_version`
+values—often with JSON Patch entries under `versions`, or by **scoping** the change to the
+introducing spec version when remove patches are unnecessary. See the [Version Patches section in CONTRIBUTING.md](./CONTRIBUTING.md#version-patches)
+for when to add remove patches versus version-only scoping, plus examples.
 
 If the change is in semantic rules, add a constraint in the rule, so they only
 apply on the indicated version range and package types.


### PR DESCRIPTION
## What does this PR do?

Followup addressing feedback from https://github.com/elastic/package-spec/pull/1146

## Why is it important?

Some concepts around version patchs where not aligned


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified conditions for adding version patches and alternative backward compatibility approaches for schema changes, improving guidance on when version scoping is sufficient.
  * Expanded instructions for test package and data stream creation, including interactive scaffolding with build tools.
  * Updated best practices and examples for managing schema modifications across different specification versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->