### PR TITLE
Add post-dependabot workflow to auto-tidy compliance go.mod

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -2,6 +2,7 @@
 # in compliance/ (a separate Go module) may fall out of sync. This workflow
 # runs go mod tidy in compliance/ on every Dependabot go_modules push and
 # commits any resulting changes back to the branch.
+
 name: post-dependabot
 
 on:

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -1,0 +1,52 @@
+# When Dependabot bumps a dependency in the root module, indirect dependencies
+# in compliance/ (a separate Go module) may fall out of sync. This workflow
+# runs go mod tidy in compliance/ on every Dependabot go_modules push and
+# commits any resulting changes back to the branch.
+name: post-dependabot
+
+on:
+  push:
+    branches:
+      - 'dependabot/go_modules/**'
+      - '!dependabot/go_modules/compliance/**'
+
+permissions:
+  contents: write
+
+jobs:
+  update-compliance-go-mod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: .go-version
+
+      - name: set up git user
+        uses: elastic/oblt-actions/git/setup@v1
+        with:
+          username: 'dependabot[bot]'
+          email: 'dependabot[bot]@users.noreply.github.com'
+
+      - name: Run go mod tidy in compliance
+        run: cd compliance && go mod tidy
+
+      - name: Check for compliance go.mod changes
+        id: compliance-check
+        run: |
+          if git diff --quiet HEAD -- compliance/go.mod compliance/go.sum; then
+            echo "modified=false" >> $GITHUB_OUTPUT
+          else
+            echo "modified=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit compliance go.mod changes
+        if: steps.compliance-check.outputs.modified == 'true'
+        run: |
+          git add compliance/go.mod compliance/go.sum
+          git commit -m "Update compliance go.mod"
+
+      - name: Push compliance go.mod changes
+        if: steps.compliance-check.outputs.modified == 'true'
+        run: git push


### PR DESCRIPTION
## What does this PR do?

Adds a new GitHub Actions workflow (`.github/workflows/post-dependabot.yml`) that automatically runs `go mod tidy` in the `/compliance` sub-module whenever Dependabot bumps a dependency in the root Go module.

The workflow:
- Triggers on pushes to `dependabot/go_modules/**` branches, **excluding** `dependabot/go_modules/compliance/**` (those Dependabot PRs already target compliance directly)
- Runs `go mod tidy` inside the `compliance/` directory
- Commits and pushes `compliance/go.mod` and `compliance/go.sum` back to the Dependabot branch if they changed

Inspired by a similar workflow in elastic-agent: [`post-dependabot.yml`](https://github.com/elastic/elastic-agent/blob/d7eec0f46b8f0841b19a2bcb67e40277ba100232/.github/workflows/post-dependabot.yml), which uses the same pattern to keep sub-module go.mod files in sync after Dependabot bumps.

## Why is it important?

The root module and the `/compliance` sub-module share transitive Go dependencies. When Dependabot bumps a package in the root, the compliance `go.mod` frequently needs a `go mod tidy` to stay consistent — but Dependabot doesn't do this automatically.

This has required manual intervention at least **10 times** in the past, including:

| PR | Package bumped | Manual fix needed |
|----|---------------|-------------------|
| [#1056](https://github.com/elastic/package-spec/pull/1056) | `golang.org/x/tools` 0.40→0.41 | `Update go.mod in compliance` |
| [#1055](https://github.com/elastic/package-spec/pull/1055) | `go-viper/mapstructure/v2` 2.4→2.5 | `Update go.mod in compliance` |
| [#1035](https://github.com/elastic/package-spec/pull/1035) | `golang.org/x/tools` 0.39→0.40 | `Update go.mod in compliance folder` |
| [#1016](https://github.com/elastic/package-spec/pull/1016) | `golang.org/x/tools` 0.38→0.39 | `Update go.mod in /compliance too` |
| [#980](https://github.com/elastic/package-spec/pull/980) | `gotest.tools/gotestsum` 1.12.3→1.13.0 | `Update compliance go.mod` |
| [#927](https://github.com/elastic/package-spec/pull/927) | `go-viper/mapstructure/v2` 2.3→2.4 | `Update compliance go.mod` |
| [#912](https://github.com/elastic/package-spec/pull/912) | `Masterminds/semver/v3` 3.3.1→3.4.0 | `Update compliance go.mod too` |
| [#907](https://github.com/elastic/package-spec/pull/907) | `gotest.tools/gotestsum` 1.12.2→1.12.3 | `Update go.mod in compliance folder` |
| [#750](https://github.com/elastic/package-spec/pull/750) | `elastic/kbncontent` 0.1.3→0.1.4 | `Fix compliance go.mod and add changelog` |
| [#692](https://github.com/elastic/package-spec/pull/692) | `evanphx/json-patch/v5` 5.8.0→5.8.1 | `Update go.mod and go.sum in compliance/` |

This workflow eliminates that class of manual steps entirely.

## Checklist

- [x] ~~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~ (CI-only change, no test packages needed)
- [x] ~~I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).~~ (CI infrastructure change, no spec changelog entry needed)


---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to run dependency cleanup when dependency updates are pushed, automatically committing and pushing any resulting module file updates back to the branch.
  * Workflow scoped to specific dependency update paths and excludes designated compliance updates to avoid unwanted changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elastic/package-spec/pull/1169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->