### PR TITLE
Add updatecli Configuration for Automated Updating of Package Registry URL Version

### DIFF
--- a/.github/workflows/run-updatecli.yml
+++ b/.github/workflows/run-updatecli.yml
@@ -1,0 +1,44 @@
+---
+name: Run updatecli
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * 1-5'
+  pull_request:
+    paths:
+      - .github/workflows/updatecli/**
+      - .github/workflows/run-updatecli.yml
+
+permissions:
+  contents: read
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Select diff action
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "UPDATECLI_ACTION=diff" >> $GITHUB_ENV
+
+      - name: Select apply action
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          echo "UPDATECLI_ACTION=apply" >> $GITHUB_ENV
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@2c3221bc5f4499a99fec2c87d9de4a83cb30e990 #v3.1.3
+
+      - name: Run updatecli
+        # --experimental needed for commitusingapi option.
+        run: updatecli --experimental ${{ env.UPDATECLI_ACTION }} --config .github/workflows/updatecli --values .github/workflows/updatecli/values.d/scm.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-updatecli.yml
+++ b/.github/workflows/run-updatecli.yml
@@ -22,7 +22,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Select diff action
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/updatecli/updatecli.d/bump-package-registry-categories-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-package-registry-categories-version.yml
@@ -1,0 +1,44 @@
+---
+name: Bump Package Registry categories version
+pipelineid: 'bump-package-registry-categories-version'
+
+actions:
+  default:
+    title: '[updatecli] Update Package Registry categories URL to {{ source "latestRegistryVersion" }}'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      labels:
+        - automation
+        - dependency
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repository }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      commitusingapi: true
+      branch: main
+
+sources:
+  latestRegistryVersion:
+    name: Get latest Package Registry version
+    kind: json
+    spec:
+      file: https://api.github.com/repos/elastic/package-registry/releases/latest
+      key: .tag_name
+
+targets:
+  update-package-registry-categories-url:
+    name: '[updatecli] Update Package Registry categories URL to {{ source "latestRegistryVersion" }}'
+    kind: file
+    sourceid: latestRegistryVersion
+    scmid: default
+    spec:
+      file: code/go/internal/validator/semantic/validate_datastream_package_categories.go
+      matchpattern: 'package-registry/v[0-9\.]+/categories/categories\.yml'
+      replacepattern: 'package-registry/{{ source "latestRegistryVersion" }}/categories/categories.yml'

--- a/.github/workflows/updatecli/updatecli.d/bump-package-registry-categories-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-package-registry-categories-version.yml
@@ -10,7 +10,6 @@ actions:
     spec:
       labels:
         - automation
-        - dependency
 
 scms:
   default:

--- a/.github/workflows/updatecli/values.d/scm.yml
+++ b/.github/workflows/updatecli/values.d/scm.yml
@@ -1,0 +1,4 @@
+---
+scm:
+  owner: elastic
+  repository: package-spec


### PR DESCRIPTION
## What does this PR do?
Adds updatecli configuration to create a PR on [package registry version ](https://github.com/JDKurma/package-spec/blob/main/code/go/internal/validator/semantic/validate_datastream_package_categories.go#L22)updates in order to retrieve the latest categories

Local Verification:
```bash
❯ GITHUB_ACTOR=jdkurma GITHUB_TOKEN=$(gh auth token) \   
    updatecli --experimental diff \
    --config .github/workflows/updatecli \
    --values .github/workflows/updatecli/values.d/scm.yml
Experimental Mode Enabled
WARNING: Deprecated command, please instead use `updatecli pipeline diff`


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline ".github/workflows/updatecli/updatecli.d/bump-package-registry-categories-version.yml"
Loading Pipeline ".github/workflows/updatecli/values.d/scm.yml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


############################################
# BUMP PACKAGE REGISTRY CATEGORIES VERSION #
############################################

Pipeline ID     : bump-package-registry-categories-version
Dry Run         : enabled

source: latestRegistryVersion
-----------------------------

WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
✔ value "v1.38.0", found in file "https://api.github.com/repos/elastic/package-registry/releases/latest", for key ".tag_name"
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

target: update-package-registry-categories-url
----------------------------------------------

Repository      : github.com/elastic/package-spec@main

✔ - all contents from 'file' and 'files' combined already up to date
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

###########
# SCM.YML #
###########

Pipeline ID     : f50ca7ab7cdb51f68c46dfad30d573950701242d7457923cb3212b30f4d34f0d
Dry Run         : enabled


ACTIONS
========

---
Pipeline Name   : Bump Package Registry categories version
Pipeline ID     : bump-package-registry-categories-version
Dry run         : true
Repository      : github.com/elastic/package-spec@main
Action          : [updatecli] Update Package Registry categories URL to v1.38.0
---

No follow up action needed


UDASH - EXPERIMENTAL
=====================

Publishing report to Udash
no Udash endpoint detected, skipping


REPORT - EXPERIMENTAL
======================

Bump Package Registry categories version:
        => "/var/folders/bb/myg0lcmj54z_c9sckgs3tc8r0000gn/T/updatecli/report/54812d68a5aa5a82233b63fe8fcec4f9f5a44655492f4e9667e9927a898fcec0/20260505154621.yaml"
SCM.YML:
        => "/var/folders/bb/myg0lcmj54z_c9sckgs3tc8r0000gn/T/updatecli/report/67b2f2b5d094e2b705867a84bd7b4c2b396e9ded7d1dd522f95b2a9e0a9d12ea/20260505154621.yaml"

=============================

SUMMARY:

✔ Bump Package Registry categories version:
        Source:
                ✔ [latestRegistryVersion] Get latest Package Registry version
        Target:
                ✔ [update-package-registry-categories-url] [updatecli] Update Package Registry categories URL to v1.38.0
                      * Repository: https://github.com/elastic/package-spec.git (branch: main)


✔ SCM.YML:

Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  2
  * Total:      2


---
A new version of updatecli is available: v0.117.0 (current: "0.117.0")
Changelog available at: www.updatecli.io/changelogs/updatecli/changelogs/v0.117.0/
---

```

## Why is it important?
Without some type of upkeep, the [package registry URL](https://github.com/JDKurma/package-spec/blob/main/code/go/internal/validator/semantic/validate_datastream_package_categories.go#L22) will become stale with whatever pinned version we keep. To avoid manual busywork, updatecli provides a automated way to periodically check for new package registry versions, make the modification to our URL, and create a PR.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~
- [ ] ~~I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).~~

## Related issues
https://github.com/elastic/package-spec/pull/1095#discussion_r3236065903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a scheduled/manually-triggered CI workflow to run Updatecli for routine updates.
  * Added an automation workflow that opens PRs to bump package registry category versions based on the latest release.
  * Added SCM configuration values to support the automated update workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elastic/package-spec/pull/1171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->