### PR TITLE
[CI] Allow github-actions[bot] user

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -21,7 +21,7 @@
       "pipelineSlug": "package-spec",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
-      "allowed_list": ["dependabot[bot]", "mergify[bot]"],
+      "allowed_list": ["dependabot[bot]", "mergify[bot]", "github-actions[bot]"],
       "set_commit_status": true,
       "build_on_commit": true,
       "build_on_comment": true,


### PR DESCRIPTION
Allow triggering Buildkite builds from github-actions[bot] user.

Follows https://github.com/elastic/package-spec/pull/1169

Relates https://github.com/elastic/package-registry/pull/1759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to authorize an additional automation tool for triggering package specification validation checks
  * Added automated workflow for maintaining Go modules in the compliance subsystem triggered by dependency updates to specific branches, with automatic change detection and committing modifications back to the source branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->