### PR TITLE
Fix: resolve test requires source paths relative to the package root

### DIFF
--- a/code/go/internal/validator/semantic/validate_test_package_requirements.go
+++ b/code/go/internal/validator/semantic/validate_test_package_requirements.go
@@ -126,7 +126,7 @@ func validateIntegrationTestRequirements(fsys fspath.FS, requiredPackages map[st
 
 						source, _ := reqMap["source"].(string)
 						if source != "" {
-							err := validateTestRequirementSource(fsys.Path("_dev/test/config.yml"), source)
+							err := validateTestRequirementSource(fsys.Path(), fsys.Path("_dev/test/config.yml"), source)
 							if err != nil {
 								errs = append(errs, err)
 							}
@@ -177,7 +177,7 @@ func validateDataStreamTestRequirements(fsys fspath.FS, requiredPackages map[str
 
 						source, _ := reqMap["source"].(string)
 						if source != "" {
-							err := validateTestRequirementSource(fsys.Path(config.Path()), source)
+							err := validateTestRequirementSource(fsys.Path(), fsys.Path(config.Path()), source)
 							if err != nil {
 								errs = append(errs, err)
 							}
@@ -242,17 +242,19 @@ func validateTestRequirementPackageVersion(configPath, testType string, idx int,
 	return nil
 }
 
-// validateTestRequirementSource checks if the relative path exists. This could be done with "format: relative-path" in
-// the spec, but this format checker only works with relative files inside the package. In this case the source package
-// is going to be outside the current package.
-func validateTestRequirementSource(configFile, source string) *specerrors.StructuredError {
+// validateTestRequirementSource checks if the relative path exists. The source is resolved relative to the package
+// root (packageRoot), so a path like "../other_package" reaches a sibling package in the same repository. This could
+// be done with "format: relative-path" in the spec, but that format checker only works with relative files inside the
+// package, and here the source package is going to be outside the current package. configFile is used only to report
+// which file is invalid.
+func validateTestRequirementSource(packageRoot, configFile, source string) *specerrors.StructuredError {
 	cleanSource := filepath.Clean(filepath.FromSlash(source))
 	if filepath.IsAbs(cleanSource) {
 		return specerrors.NewStructuredErrorf(
 			"file \"%s\" is invalid: source path to required package \"%s\" must be relative",
 			configFile, source)
 	}
-	targetPath := filepath.Join(filepath.Dir(configFile), filepath.FromSlash(source))
+	targetPath := filepath.Join(packageRoot, filepath.FromSlash(source))
 	if _, err := os.Stat(targetPath); err != nil {
 		return specerrors.NewStructuredErrorf(
 			"file \"%s\" is invalid: source path to required package \"%s\" does not exist",

--- a/code/go/internal/validator/semantic/validate_test_package_requirements_test.go
+++ b/code/go/internal/validator/semantic/validate_test_package_requirements_test.go
@@ -149,8 +149,8 @@ format_version: 3.6.0`,
   requires:
     - source: ../my_input_package`,
 			testConfigPath: "_dev/test/config.yml",
-			// source "../my_input_package" is relative to _dev/test/, resolves to _dev/my_input_package
-			sourceDirs:  []string{"_dev/my_input_package"},
+			// source "../my_input_package" is relative to the package root, resolving to a sibling package
+			sourceDirs:  []string{"../my_input_package"},
 			expectError: false,
 		},
 		"invalid_source_path_requirement": {
@@ -169,8 +169,8 @@ format_version: 3.6.0`,
 			testConfig: `requires:
   - source: ../my_content_package`,
 			testConfigPath: "data_stream/example/_dev/test/system/test-default-config.yml",
-			// source "../my_content_package" is relative to .../system/, resolves to .../test/my_content_package
-			sourceDirs:  []string{"data_stream/example/_dev/test/my_content_package"},
+			// source "../my_content_package" is relative to the package root, resolving to a sibling package
+			sourceDirs:  []string{"../my_content_package"},
 			expectError: false,
 		},
 		"invalid_datastream_source_path_requirement": {
@@ -186,13 +186,19 @@ format_version: 3.6.0`,
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			pkgRoot := t.TempDir()
+			// Nest the package root under a base dir so that source paths like
+			// "../sibling" resolve to a sibling of the package root, mirroring how
+			// packages live side by side in a repository.
+			base := t.TempDir()
+			pkgRoot := filepath.Join(base, "package")
+			require.NoError(t, os.MkdirAll(pkgRoot, 0755))
 
 			// Create manifest
 			err := os.WriteFile(filepath.Join(pkgRoot, "manifest.yml"), []byte(tc.manifest), 0644)
 			require.NoError(t, err)
 
-			// Create source directories referenced by source entries
+			// Create source directories referenced by source entries. They are
+			// resolved relative to the package root (so "../x" is a sibling).
 			for _, sourceDir := range tc.sourceDirs {
 				err = os.MkdirAll(filepath.Join(pkgRoot, sourceDir), 0755)
 				require.NoError(t, err)

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -18,7 +18,7 @@
   changes:
     - description: Resolve test requires `source` paths relative to the package root instead of the test config directory.
       type: bugfix
-      link: https://github.com/elastic/package-spec/pull/1192
+      link: https://github.com/elastic/package-spec/pull/1193
 - version: 3.6.4
   changes:
     - description: Add provider_permissions field to package, policy_template, input, and data_stream levels for declaring provider-specific permissions.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -14,7 +14,7 @@
     - description: Implement `source` and `build` validation modes.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1178
-- version: 3.6.5-next
+- version: 3.6.5
   changes:
     - description: Resolve test requires `source` paths relative to the package root instead of the test config directory.
       type: bugfix

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -14,6 +14,11 @@
     - description: Implement `source` and `build` validation modes.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1178
+- version: 3.6.5-next
+  changes:
+    - description: Resolve test requires `source` paths relative to the package root instead of the test config directory.
+      type: bugfix
+      link: https://github.com/elastic/package-spec/pull/1192
 - version: 3.6.4
   changes:
     - description: Add provider_permissions field to package, policy_template, input, and data_stream levels for declaring provider-specific permissions.

--- a/spec/integration/data_stream/_dev/test/config.spec.yml
+++ b/spec/integration/data_stream/_dev/test/config.spec.yml
@@ -47,7 +47,7 @@ spec:
         - additionalProperties: false
           properties:
             source:
-              description: Relative path to the source of the required package.
+              description: Relative path (from the package root) to the source of the required package.
               type: string
           required:
             - source

--- a/test/packages/good_requires/_dev/test/config.yml
+++ b/test/packages/good_requires/_dev/test/config.yml
@@ -2,7 +2,7 @@ system:
   requires:
     - package: sql_input
       version: 1.0.0
-    - source: ../../../good_input
+    - source: ../good_input
 policy:
   requires:
     - package: log_input


### PR DESCRIPTION
## What does this PR do?

Fixes `validateTestRequirementSource` to resolve `source` paths in test config `requires` blocks relative to the **package root** instead of the config file's directory.

Changes:
- `validateTestRequirementSource` now accepts an explicit `packageRoot` argument; the target path is computed as `filepath.Join(packageRoot, source)` instead of `filepath.Join(filepath.Dir(configFile), source)`.
- Both call sites pass `fsys.Path()` (the package root) as the new first argument.
- Unit tests updated: the harness now nests `pkgRoot` under a `base` temp dir so `../sibling` resolves to a real sibling directory, mirroring actual repo layout.
- Spec description for the `source` field clarified: *"Relative path (from the package root) to the source of the required package."*

## Why is it important?

The `source` field in a test config `requires` block is meant to point to a sibling package — e.g. `../filelog_otel` — so that `elastic-package` can locate it at validation and test time.

`elastic-package`'s own test runner (`absoluteSourcePath` in `globaltestconfig.go`) resolves this field against the **package root**:
```go
filepath.Clean(filepath.Join(packageRoot, source))
// "../filelog_otel" → …/packages/filelog_otel  ✓
```

The spec validator was doing it differently — resolving against `filepath.Dir(configFile)` (i.e. `_dev/test/` or `data_stream/…/_dev/test/system/`):
```go
filepath.Join(filepath.Dir(configFile), source)
// "../filelog_otel" → …/_dev/filelog_otel  ✗  (doesn't exist)
```

This mismatch caused valid `source` values to always fail validation with:
```
source path to required package "../filelog_otel" does not exist
```

The fix aligns the spec validator with `elastic-package`'s resolution logic. The bug was surfaced while testing validation modes on the nginx integration using input package dependencies.

## Checklist

- ~~I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed resolution of test package requirement source paths to be relative to the package root instead of relative to the test configuration file location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->