### PR TITLE
code/go/internal/validator/semantic: narrow by-reference panel flagging to exclude saved searches

### DIFF
--- a/code/go/internal/validator/semantic/validate_visualizations_used_by_value.go
+++ b/code/go/internal/validator/semantic/validate_visualizations_used_by_value.go
@@ -75,7 +75,7 @@ func anyReference(val interface{}) ([]reference, error) {
 	var references []reference
 	for _, reference := range allReferences {
 		switch reference.Type {
-		case "lens", "map", "search", "visualization":
+		case "lens", "map", "visualization":
 			references = append(references, reference)
 		}
 	}

--- a/code/go/internal/validator/semantic/validate_visualizations_used_by_value_test.go
+++ b/code/go/internal/validator/semantic/validate_visualizations_used_by_value_test.go
@@ -105,7 +105,6 @@ func TestAnyReference(t *testing.T) {
 				{"12345", "panel_0", "visualization"},
 				{"9000", "panel_1", "lens"},
 				{"4", "panel_2", "map"},
-				{"44", "panel_4", "search"},
 			},
 		},
 		{

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -14,6 +14,9 @@
     - description: Implement `source` and `build` validation modes.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1178
+    - description: Remove the search type from by-reference validation checks.
+      type: bugfix
+      link: https://github.com/elastic/package-spec/pull/1196
 - version: 3.6.5
   changes:
     - description: Resolve test requires `source` paths relative to the package root instead of the test config directory.

--- a/test/packages/bad_dangling_object_ids/validation.yml
+++ b/test/packages/bad_dangling_object_ids/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - SVR00004  # References in dashboards.

--- a/test/packages/kibana_legacy_visualizations/validation.yml
+++ b/test/packages/kibana_legacy_visualizations/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - SVR00004  # References in dashboards.


### PR DESCRIPTION
Saved searches are inherently referenced and should not be flagged as by-reference panels. Restrict the check to visualization, lens, and map reference types only.

## What does this PR do?

<!-- Mandatory
Explain here WHAT changes you made in the PR.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-