### PR TITLE
Add optional top-level `group` field to package manifests

### DIFF
--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -72,6 +72,20 @@ func Test_ValidateFromPath(t *testing.T) {
 		"with_links":                             {},
 		"good_provider_permissions":              {},
 		"good_provider_permissions_input":        {},
+		"good_integration_group":                 {},
+		"good_input_group":                       {},
+		"bad_integration_group": {
+			"manifest.yml",
+			[]string{
+				"field group: Does not match pattern '^[a-z0-9_]+$'",
+			},
+		},
+		"bad_input_group": {
+			"manifest.yml",
+			[]string{
+				"field group: Does not match pattern '^[a-z0-9_]+$'",
+			},
+		},
 		"bad_duration_vars": {
 			"manifest.yml",
 			[]string{

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -19,7 +19,7 @@
       link: https://github.com/elastic/package-spec/pull/1196
     - description: Add optional top-level `group` field to integration, input, and content package manifests for declaring marketplace group membership.
       type: enhancement
-      link: https://github.com/elastic/package-spec/pull/XXXX
+      link: https://github.com/elastic/package-spec/pull/1213
 - version: 3.6.5
   changes:
     - description: Resolve test requires `source` paths relative to the package root instead of the test config directory.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -17,6 +17,8 @@
     - description: Remove the search type from by-reference validation checks.
       type: bugfix
       link: https://github.com/elastic/package-spec/pull/1196
+- version: 3.6.6-next
+  changes:
     - description: Add optional top-level `group` field to integration, input, and content package manifests for declaring marketplace group membership.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1213

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -4,9 +4,6 @@
 ##
 - version: 3.7.0-next
   changes:
-    - description: Add optional top-level `group` field to integration, input, and content package manifests for declaring marketplace group membership.
-      type: enhancement
-      link: https://github.com/elastic/package-spec/pull/1213
     # Pending on https://github.com/elastic/kibana/issues/220294
     - description: Add support for semantic_text field definition.
       type: enhancement
@@ -20,6 +17,9 @@
     - description: Remove the search type from by-reference validation checks.
       type: bugfix
       link: https://github.com/elastic/package-spec/pull/1196
+    - description: Add optional top-level `group` field to integration, input, and content package manifests for declaring marketplace group membership.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/XXXX
 - version: 3.6.5
   changes:
     - description: Resolve test requires `source` paths relative to the package root instead of the test config directory.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -4,6 +4,9 @@
 ##
 - version: 3.7.0-next
   changes:
+    - description: Add optional top-level `group` field to integration, input, and content package manifests for declaring marketplace group membership.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1213
     # Pending on https://github.com/elastic/kibana/issues/220294
     - description: Add support for semantic_text field definition.
       type: enhancement

--- a/spec/content/manifest.spec.yml
+++ b/spec/content/manifest.spec.yml
@@ -47,6 +47,8 @@ spec:
       pattern: '^[a-z0-9_]+$'
       examples:
       - apache
+    group:
+      $ref: "../integration/manifest.spec.yml#/definitions/group"
     title:
       $ref: "../integration/manifest.spec.yml#/definitions/title"
     description:

--- a/spec/input/manifest.spec.yml
+++ b/spec/input/manifest.spec.yml
@@ -15,6 +15,8 @@ spec:
       pattern: '^[a-z0-9_]+$'
       examples:
       - apache
+    group:
+      $ref: "../integration/manifest.spec.yml#/definitions/group"
     title:
       $ref: "../integration/manifest.spec.yml#/definitions/title"
     description:

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -549,6 +549,17 @@ spec:
       required:
         - since
         - description
+    group:
+      description: >
+        Opaque identifier declaring membership in a marketplace group. All packages
+        that share the same value are considered members of the same group.
+        Kibana owns tile title/icon/description via a static descriptor keyed by
+        this id; packages only declare membership.
+      type: string
+      pattern: '^[a-z0-9_]+$'
+      examples:
+        - nginx
+        - redis
     package_reference:
       description: >
         Reference to an input package. When specified, configuration is inherited
@@ -824,6 +835,8 @@ spec:
       pattern: '^[a-z0-9_]+$'
       examples:
         - apache
+    group:
+      $ref: "#/definitions/group"
     title:
       $ref: "#/definitions/title"
     description:

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -551,10 +551,10 @@ spec:
         - description
     group:
       description: >
-        Opaque identifier declaring membership in a marketplace group. All packages
-        that share the same value are considered members of the same group.
-        Kibana owns tile title/icon/description via a static descriptor keyed by
-        this id; packages only declare membership.
+        Identifier of a marketplace group. Packages that share the same
+        value belong to the same group. Kibana owns the group's title,
+        icon, and description; this field only declares membership.
+        Values are not validated against Kibana's group list.
       type: string
       pattern: '^[a-z0-9_]+$'
       examples:

--- a/test/packages/bad_input_group/agent/input/input.yml.hbs
+++ b/test/packages/bad_input_group/agent/input/input.yml.hbs
@@ -1,0 +1,4 @@
+paths:
+{{#each paths as |path i|}}
+  - {{path}}
+{{/each}}

--- a/test/packages/bad_input_group/changelog.yml
+++ b/test/packages/bad_input_group/changelog.yml
@@ -1,0 +1,5 @@
+- version: 0.0.1
+  changes:
+    - description: Initial version
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1213

--- a/test/packages/bad_input_group/docs/README.md
+++ b/test/packages/bad_input_group/docs/README.md
@@ -1,0 +1,3 @@
+# Bad Input Group
+
+This is a test package for input packages with an invalid group value.

--- a/test/packages/bad_input_group/fields/base-fields.yml
+++ b/test/packages/bad_input_group/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/test/packages/bad_input_group/manifest.yml
+++ b/test/packages/bad_input_group/manifest.yml
@@ -1,0 +1,26 @@
+format_version: 3.5.0
+name: bad_input_group
+title: Bad Input Group
+description: Input package with an invalid group value (contains uppercase/spaces).
+version: 0.0.1
+type: input
+group: "Nginx-OTel"
+source:
+  license: "Apache-2.0"
+categories:
+  - web
+conditions:
+  kibana:
+    version: "^9.0.0"
+  elastic:
+    subscription: "basic"
+policy_templates:
+  - name: nginx_logs
+    type: logs
+    title: Nginx logs
+    description: Collect logs from Nginx
+    input: logfile
+    template_path: input.yml.hbs
+owner:
+  github: elastic/ecosystem
+  type: elastic

--- a/test/packages/bad_integration_group/changelog.yml
+++ b/test/packages/bad_integration_group/changelog.yml
@@ -1,0 +1,5 @@
+- version: 0.0.1
+  changes:
+    - description: Initial version
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1213

--- a/test/packages/bad_integration_group/docs/README.md
+++ b/test/packages/bad_integration_group/docs/README.md
@@ -1,0 +1,3 @@
+# Bad Integration Group
+
+This is a test package for integration packages with an invalid group value.

--- a/test/packages/bad_integration_group/manifest.yml
+++ b/test/packages/bad_integration_group/manifest.yml
@@ -1,0 +1,25 @@
+format_version: 3.3.2
+name: bad_integration_group
+title: Bad Integration Group
+description: Integration package with an invalid group value (contains uppercase/spaces).
+version: 0.0.1
+type: integration
+group: "Nginx OTel"
+source:
+  license: "Apache-2.0"
+conditions:
+  kibana:
+    version: "^9.0.0"
+  elastic:
+    subscription: "basic"
+policy_templates:
+  - name: nginx
+    title: Nginx logs
+    description: Collect logs from Nginx
+    inputs:
+      - type: logfile
+        title: Collect logs from Nginx
+        description: Collecting Nginx logs
+owner:
+  github: elastic/ecosystem
+  type: elastic

--- a/test/packages/good_input_group/agent/input/input.yml.hbs
+++ b/test/packages/good_input_group/agent/input/input.yml.hbs
@@ -1,0 +1,4 @@
+paths:
+{{#each paths as |path i|}}
+  - {{path}}
+{{/each}}

--- a/test/packages/good_input_group/changelog.yml
+++ b/test/packages/good_input_group/changelog.yml
@@ -1,0 +1,5 @@
+- version: 0.0.1
+  changes:
+    - description: Initial version
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1213

--- a/test/packages/good_input_group/docs/README.md
+++ b/test/packages/good_input_group/docs/README.md
@@ -1,0 +1,3 @@
+# Good Input with Group
+
+This is a test package for input packages that declare a marketplace group.

--- a/test/packages/good_input_group/fields/base-fields.yml
+++ b/test/packages/good_input_group/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/test/packages/good_input_group/manifest.yml
+++ b/test/packages/good_input_group/manifest.yml
@@ -1,0 +1,26 @@
+format_version: 3.5.0
+name: good_input_group
+title: Good Input with Group
+description: Input package declaring membership in a marketplace group.
+version: 0.0.1
+type: input
+group: nginx
+source:
+  license: "Apache-2.0"
+categories:
+  - web
+conditions:
+  kibana:
+    version: "^9.0.0"
+  elastic:
+    subscription: "basic"
+policy_templates:
+  - name: nginx_logs
+    type: logs
+    title: Nginx logs
+    description: Collect logs from Nginx
+    input: logfile
+    template_path: input.yml.hbs
+owner:
+  github: elastic/ecosystem
+  type: elastic

--- a/test/packages/good_integration_group/changelog.yml
+++ b/test/packages/good_integration_group/changelog.yml
@@ -1,0 +1,5 @@
+- version: 0.0.1
+  changes:
+    - description: Initial version
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1213

--- a/test/packages/good_integration_group/docs/README.md
+++ b/test/packages/good_integration_group/docs/README.md
@@ -1,0 +1,3 @@
+# Good Integration with Group
+
+This is a test package for integration packages that declare a marketplace group.

--- a/test/packages/good_integration_group/manifest.yml
+++ b/test/packages/good_integration_group/manifest.yml
@@ -1,0 +1,27 @@
+format_version: 3.3.2
+name: good_integration_group
+title: Good Integration with Group
+description: Integration package declaring membership in a marketplace group.
+version: 0.0.1
+type: integration
+group: nginx
+source:
+  license: "Apache-2.0"
+categories:
+  - web
+conditions:
+  kibana:
+    version: "^9.0.0"
+  elastic:
+    subscription: "basic"
+policy_templates:
+  - name: nginx
+    title: Nginx logs and metrics
+    description: Collect logs and metrics from Nginx instances
+    inputs:
+      - type: logfile
+        title: Collect logs from Nginx
+        description: Collecting Nginx access and error logs
+owner:
+  github: elastic/ecosystem
+  type: elastic


### PR DESCRIPTION
## What does this PR do?

Adds an optional top-level `group` field to `manifest.yml` for **integration**, **input**, and **content** package types.

```yaml
format_version: 3.5.0
name: nginx_input_otel
title: Nginx (OpenTelemetry)
type: input
group: nginx
# ...
```

Field contract:
- **Type**: `string`, optional
- **Pattern**: `^[a-z0-9_]+$` (same as package `name`)
- **Semantics**: opaque group id — all packages sharing the same value are members of the same marketplace group
- **No existence validation** — the spec does not validate the id against a known list; Fleet ignores unknown ids and group activation also requires a Kibana descriptor entry

## Why is it important?

The Elastic marketplace needs a way to collapse related packages (e.g. `nginx`, `nginx_input_otel`, `nginx_ingress_controller`) into a single tile. Kibana owns the tile title/icon/description via a static `INTEGRATION_GROUPS` config keyed by the group id; packages only declare membership.

**No version gate** — the field is pure metadata and requires no Fleet/Kibana runtime support. Other recently-added optional fields with the same nature (`fips_compatible`, `provider_permissions`) are also ungated. Gating behind a new `format_version` would force every adopting package to bump its format version, pulling in unrelated schema constraints. Most packages in the integrations repo are at `3.0.x`–`3.5.x` (e.g. `nginx` at `3.0.2`, `nginx_input_otel` at `3.5.0`); those packages can adopt `group` as-is.

Content packages are included for schema parity even though their tiles are hidden by default.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
  - `good_integration_group` — valid `group: nginx` on an integration (format_version 3.3.2)
  - `good_input_group` — valid `group: nginx` on an input package (format_version 3.5.0)
  - `bad_integration_group` — invalid value (`"Nginx OTel"`) fails the pattern
  - `bad_input_group` — invalid value (`"Nginx-OTel"`) fails the pattern
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Part of https://github.com/elastic/ingest-dev/issues/8082