### PR TITLE
spec/{input,integration}/_dev/test/config.spec.yml: allow policy test s to ignore fields

### DIFF
--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -346,6 +346,12 @@ func Test_ValidateFromPath(t *testing.T) {
 				`system.requires[0] package "sql_input" version "1.5.0" does not satisfy constraint "2.0.0"`,
 			},
 		},
+		"bad_policy_ignore_fields": {
+			"_dev/test/config.yml",
+			[]string{
+				"field system: Additional property ignore_fields is not allowed",
+			},
+		},
 		"bad_input_dataset_vars": {
 			"_dev/test/policy/test-vars.yml",
 			[]string{

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -17,9 +17,6 @@
     - description: Remove the search type from by-reference validation checks.
       type: bugfix
       link: https://github.com/elastic/package-spec/pull/1196
-    - description: Allow policy tests to ignore fields.
-      type: enhancement
-      link: https://github.com/elastic/package-spec/pull/1214
 - version: 3.6.6-next
   changes:
     - description: Add support for saved search assets in content packages.
@@ -28,6 +25,9 @@
     - description: Add optional top-level `group` field to integration, input, and content package manifests for declaring marketplace group membership.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1213
+    - description: Allow policy tests to ignore fields.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1214
 - version: 3.6.5
   changes:
     - description: Resolve test requires `source` paths relative to the package root instead of the test config directory.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -17,6 +17,9 @@
     - description: Remove the search type from by-reference validation checks.
       type: bugfix
       link: https://github.com/elastic/package-spec/pull/1196
+    - description: Allow policy tests to ignore fields.
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1214
 - version: 3.6.6-next
   changes:
     - description: Add support for saved search assets in content packages.

--- a/spec/input/_dev/test/config.spec.yml
+++ b/spec/input/_dev/test/config.spec.yml
@@ -11,4 +11,4 @@ spec:
       $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/config_tests"
     policy:
       description: Configuration for policy tests
-      $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/config_tests"
+      $ref: "../../../integration/_dev/test/config.spec.yml#/definitions/policy_config_tests"

--- a/spec/integration/_dev/test/config.spec.yml
+++ b/spec/integration/_dev/test/config.spec.yml
@@ -21,6 +21,29 @@ spec:
           type: array
           items:
             $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/package_requirement"
+    policy_config_tests:
+      type: object
+      additionalProperties: false
+      properties:
+        parallel:
+          description: Tests defined can be run in parallel (default true).
+          type: boolean
+          default: false
+        skip:
+          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
+        requires:
+          description: Package dependencies required for these tests with exact versions.
+          type: array
+          items:
+            $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/package_requirement"
+        ignore_fields:
+          description: >
+            Stream-level field paths to strip before comparing the actual policy
+            against the expected file. Paths use dot notation scoped to the stream
+            level (e.g. "state.user_agent" strips inputs[].streams[].state.user_agent).
+          type: array
+          items:
+            type: string
   properties:
     system:
       description: Configuration for system tests
@@ -30,7 +53,7 @@ spec:
       $ref: "#/definitions/config_tests"
     policy:
       description: Configuration for policy tests
-      $ref: "#/definitions/config_tests"
+      $ref: "#/definitions/policy_config_tests"
     static:
       description: Configuration for static tests
       $ref: "#/definitions/config_tests"

--- a/spec/integration/_dev/test/config.spec.yml
+++ b/spec/integration/_dev/test/config.spec.yml
@@ -26,16 +26,11 @@ spec:
       additionalProperties: false
       properties:
         parallel:
-          description: Tests defined can be run in parallel (default true).
-          type: boolean
-          default: false
+          $ref: "#/definitions/config_tests/properties/parallel"
         skip:
-          $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/skip"
+          $ref: "#/definitions/config_tests/properties/skip"
         requires:
-          description: Package dependencies required for these tests with exact versions.
-          type: array
-          items:
-            $ref: "../../data_stream/_dev/test/config.spec.yml#/definitions/package_requirement"
+          $ref: "#/definitions/config_tests/properties/requires"
         ignore_fields:
           description: >
             Stream-level field paths to strip before comparing the actual policy

--- a/test/packages/bad_policy_ignore_fields/_dev/test/config.yml
+++ b/test/packages/bad_policy_ignore_fields/_dev/test/config.yml
@@ -1,0 +1,6 @@
+system:
+  parallel: true
+  ignore_fields:
+    - state.user_agent
+policy:
+  parallel: false

--- a/test/packages/bad_policy_ignore_fields/changelog.yml
+++ b/test/packages/bad_policy_ignore_fields/changelog.yml
@@ -1,0 +1,5 @@
+- version: "0.0.1"
+  changes:
+    - description: Initial version
+      type: enhancement
+      link: https://github.com/elastic/package-spec/pull/1214

--- a/test/packages/bad_policy_ignore_fields/docs/README.md
+++ b/test/packages/bad_policy_ignore_fields/docs/README.md
@@ -1,0 +1,3 @@
+# Bad Policy Ignore Fields
+
+Test package for validating that ignore_fields is not allowed in system test config.

--- a/test/packages/bad_policy_ignore_fields/manifest.yml
+++ b/test/packages/bad_policy_ignore_fields/manifest.yml
@@ -1,0 +1,22 @@
+format_version: 3.6.0
+name: bad_policy_ignore_fields
+title: Bad policy ignore fields
+description: Test package for validating that ignore_fields is not allowed in system test config.
+version: 0.0.1
+type: integration
+source:
+  license: "Apache-2.0"
+conditions:
+  kibana:
+    version: '^8.0.0'
+policy_templates:
+  - name: example
+    title: Example
+    description: Example policy template
+    inputs:
+      - type: logfile
+        title: Log file input
+        description: Collect logs from files
+owner:
+  github: elastic/ecosystem
+  type: elastic

--- a/test/packages/good_input/_dev/test/config.yml
+++ b/test/packages/good_input/_dev/test/config.yml
@@ -2,6 +2,8 @@ system:
   parallel: true
 policy:
   parallel: false
+  ignore_fields:
+    - state.user_agent
   skip:
     reason: ignoring all system tests
     link: https://github.com/elastic/package-spec/issues/1

--- a/test/packages/good_v3/_dev/test/config.yml
+++ b/test/packages/good_v3/_dev/test/config.yml
@@ -9,5 +9,7 @@ asset:
   parallel: false
 policy:
   parallel: false
+  ignore_fields:
+    - state.user_agent
 static:
   parallel: false


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here WHAT changes you made in the PR.
-->

Allows (dynamic) fields to be ignored in integration policy tests.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Dynamic fields break existing tests.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [ ] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For elastic/elastic-package#3771
