### PR TITLE
Update EPR categories reference URL to v1.39.0

### DIFF
--- a/code/go/internal/validator/semantic/validate_datastream_package_categories.go
+++ b/code/go/internal/validator/semantic/validate_datastream_package_categories.go
@@ -19,7 +19,7 @@ import (
 	"github.com/elastic/package-spec/v3/code/go/pkg/specerrors"
 )
 
-const packageRegistryCategoriesURL = "https://raw.githubusercontent.com/elastic/package-registry/v1.38.0/categories/categories.yml"
+const packageRegistryCategoriesURL = "https://raw.githubusercontent.com/elastic/package-registry/v1.39.0/categories/categories.yml"
 
 type registryCategories struct {
 	Categories map[string]struct {
@@ -102,7 +102,8 @@ func ValidateDatastreamPackageCategories(fsys fspath.FS) specerrors.ValidationEr
 	pkgType, pkgCategories, err := readPackageManifestTypeAndCategories(fsys)
 	if err != nil {
 		return specerrors.ValidationErrors{
-			specerrors.NewStructuredErrorf("file \"%s\" is invalid: %w", fsys.Path(manifestPath), err)}
+			specerrors.NewStructuredErrorf("file \"%s\" is invalid: %w", fsys.Path(manifestPath), err),
+		}
 	}
 
 	if pkgType != integrationPackageType {
@@ -112,7 +113,8 @@ func ValidateDatastreamPackageCategories(fsys fspath.FS) specerrors.ValidationEr
 	dsCategories, err := readDataStreamManifestCategories(fsys)
 	if err != nil {
 		return specerrors.ValidationErrors{
-			specerrors.NewStructuredErrorf("file \"%s\" is invalid: %w", fsys.Path(manifestPath), err)}
+			specerrors.NewStructuredErrorf("file \"%s\" is invalid: %w", fsys.Path(manifestPath), err),
+		}
 	}
 
 	if len(dsCategories) == 0 {
@@ -122,7 +124,8 @@ func ValidateDatastreamPackageCategories(fsys fspath.FS) specerrors.ValidationEr
 	categoryToParent, err := fetchRegistryCategoryToParentMap()
 	if err != nil {
 		return specerrors.ValidationErrors{
-			specerrors.NewStructuredErrorf("file \"%s\" is invalid: failed to load registry categories: %w", fsys.Path(manifestPath), err)}
+			specerrors.NewStructuredErrorf("file \"%s\" is invalid: failed to load registry categories: %w", fsys.Path(manifestPath), err),
+		}
 	}
 
 	var errs specerrors.ValidationErrors

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -17,6 +17,11 @@
     - description: Remove the search type from by-reference validation checks.
       type: bugfix
       link: https://github.com/elastic/package-spec/pull/1196
+- version: 3.6.7-next
+  changes:
+    - description: Update EPR categories reference URL to v1.39.0.
+      type: bugfix
+      link: https://github.com/elastic/package-spec/pull/1215
 - version: 3.6.6-next
   changes:
     - description: Add support for saved search assets in content packages.
@@ -25,9 +30,6 @@
     - description: Add optional top-level `group` field to integration, input, and content package manifests for declaring marketplace group membership.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1213
-    - description: Update EPR categories reference URL to v1.39.0.
-      type: bugfix
-      link: https://github.com/elastic/package-spec/pull/1215
 - version: 3.6.5
   changes:
     - description: Resolve test requires `source` paths relative to the package root instead of the test config directory.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -25,6 +25,9 @@
     - description: Add optional top-level `group` field to integration, input, and content package manifests for declaring marketplace group membership.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/1213
+    - description: Update EPR categories reference URL to v1.39.0.
+      type: bugfix
+      link: https://github.com/elastic/package-spec/pull/1215
 - version: 3.6.5
   changes:
     - description: Resolve test requires `source` paths relative to the package root instead of the test config directory.


### PR DESCRIPTION
## What does this PR do?

Updates the package-registry categories reference URL from `v1.38.0` to `v1.39.0` in the datastream package categories validator.

## Why is it important?

Keeps the categories validation in sync with the latest release of the Elastic Package Registry, ensuring that new or updated categories introduced in `v1.39.0` are recognized as valid.

## Checklist

- ~~[ ] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.~~
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Proposed commit

```
Update package-registry categories reference URL to v1.39.0
```

## Related issues

- Relates #1171 — adds updatecli automation to keep this URL updated automatically

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).