### PR TITLE
Rename ingest-fp team reference to Streams

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
 
 spec:
   type: library
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   lifecycle: production
 
@@ -31,7 +31,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -59,7 +59,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
@@ -77,7 +77,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -105,7 +105,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
 
 spec:
   type: library
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   lifecycle: production
 
@@ -31,7 +31,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -59,7 +59,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
@@ -77,7 +77,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -105,7 +105,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
Catches up catalog-info.yaml to the GitHub team's actual current name (ingest-fp was renamed to Streams).