### PR TITLE
Add blueprint package type for canonical IaC base blueprints

### DIFF
--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -86,6 +86,7 @@ func Test_ValidateFromPath(t *testing.T) {
 				"field group: Does not match pattern '^[a-z0-9_]+$'",
 			},
 		},
+		"good_blueprint": {},
 		"bad_duration_vars": {
 			"manifest.yml",
 			[]string{

--- a/spec/blueprint/blueprints/spec.yml
+++ b/spec/blueprint/blueprints/spec.yml
@@ -1,0 +1,29 @@
+##
+## Describes the layout of the blueprints/ payload folder.
+##
+## Files are laid out to mirror the blueprint `id` (<provider>/<trust-model>/<scope>)
+## with the `format` and file extension appended:
+##
+##   blueprints/<provider>/<trust-model>/<scope>.<format>.<ext>
+##
+## e.g. blueprints/aws/federated-identity/account.cloudformation.json
+##
+spec:
+  additionalContents: false
+  contents:
+    - description: Provider directory (e.g. aws, azure, gcp)
+      type: folder
+      pattern: '^[a-z0-9][a-z0-9-]*$'
+      required: true
+      additionalContents: false
+      contents:
+        - description: Trust-model directory (e.g. federated-identity, workload-identity, service-principal)
+          type: folder
+          pattern: '^[a-z0-9][a-z0-9-]*$'
+          required: true
+          additionalContents: false
+          contents:
+            - description: A canonical IaC blueprint file, named <scope>.<format>.<ext>
+              type: file
+              pattern: '^[a-z0-9][a-z0-9_-]*\.[a-z0-9-]+\.[a-z0-9]+$'
+              required: true

--- a/spec/blueprint/manifest.spec.yml
+++ b/spec/blueprint/manifest.spec.yml
@@ -1,0 +1,54 @@
+##
+## Describes the specification for the blueprint package's main manifest.yml file
+##
+spec:
+  # Everything under here follows JSON schema (https://json-schema.org/), written as YAML for readability
+  type: object
+  additionalProperties: false
+  properties:
+    format_version:
+      description: The version of the package specification format used by this package.
+      $ref: "../integration/manifest.spec.yml#/definitions/version"
+    name:
+      description: The name of the package.
+      type: string
+      pattern: '^[a-z0-9_]+$'
+      examples:
+      - elastic_iac_blueprints
+    title:
+      $ref: "../integration/manifest.spec.yml#/definitions/title"
+    description:
+      $ref: "../integration/manifest.spec.yml#/definitions/description"
+    version:
+      description: The version of the package.
+      $ref: "../integration/manifest.spec.yml#/definitions/version"
+    source:
+      $ref: "../integration/manifest.spec.yml#/definitions/source"
+    type:
+      description: The type of package.
+      type: string
+      enum:
+      - blueprint
+      examples:
+      - blueprint
+    conditions:
+      description: Conditions under which this package can be installed.
+      type: object
+      additionalProperties: false
+      properties:
+        elastic:
+          $ref: "../integration/manifest.spec.yml#/definitions/conditions/properties/elastic"
+        kibana:
+          $ref: "../integration/manifest.spec.yml#/definitions/conditions/properties/kibana"
+    owner:
+      $ref: "../integration/manifest.spec.yml#/definitions/owner"
+    deprecated:
+      $ref: "../integration/manifest.spec.yml#/definitions/deprecated"
+  required:
+  - format_version
+  - name
+  - title
+  - description
+  - version
+  - type
+  - owner

--- a/spec/blueprint/spec.yml
+++ b/spec/blueprint/spec.yml
@@ -1,0 +1,53 @@
+##
+## Entrypoint of "blueprint packages" specification.
+##
+## A blueprint package is a versioned bundle of canonical Infrastructure-as-Code (IaC)
+## base templates ("blueprints"). Unlike other package types it is not installed into
+## Kibana, Elasticsearch, or the Elastic Agent — it is fetched by the cloud-iac-provisioner
+## renderer, which applies each enabled integration's RFC 6902 `iac_blueprints` patches on
+## top of the canonical blueprint to produce one deployable artifact.
+##
+## Describes the folders and files that make up a package.
+##
+spec:
+  additionalContents: false
+  totalContentsLimit: 65535
+  totalSizeLimit: 250MB
+  sizeLimit: 150MB
+  configurationSizeLimit: 5MB
+  relativePathSizeLimit: 3MB
+  contents:
+    - description: The main package manifest file
+      type: file
+      contentMediaType: "application/x-yaml"
+      sizeLimit: 5MB
+      name: "manifest.yml"
+      required: true
+      $ref: "./manifest.spec.yml"
+    - description: The package's CHANGELOG file
+      type: file
+      contentMediaType: "application/x-yaml"
+      name: "changelog.yml"
+      required: true
+      $ref: "../integration/changelog.spec.yml"
+    - description: The package's license file
+      type: file
+      contentMediaType: "text/plain"
+      name: "LICENSE.txt"
+      required: false
+    - description: Folder containing documentation for the package
+      type: folder
+      name: docs
+      required: true
+      $ref: "../integration/docs/spec.yml"
+    - description: Folder containing the canonical IaC base blueprints served to the renderer
+      type: folder
+      name: blueprints
+      required: true
+      $ref: "./blueprints/spec.yml"
+    - description: Configuration file to process the results returned from the package validation. This file is just for package validation and it should be ignored when installing or using the package.
+      type: file
+      contentMediaType: "application/x-yaml"
+      name: "validation.yml"
+      required: false
+      $ref: "../integration/validation.spec.yml"

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,7 +10,7 @@
       link: https://github.com/elastic/package-spec/pull/807
     - description: Add `blueprint` package type for hosting canonical IaC base blueprints served to the cloud-iac-provisioner renderer.
       type: enhancement
-      link: TBD
+      link: https://github.com/elastic/package-spec/pull/1224
 - version: 3.6.6
   changes:
     - description: Add support for mode-aware constructors and validation APIs.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -8,6 +8,9 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
+    - description: Add `blueprint` package type for hosting canonical IaC base blueprints served to the cloud-iac-provisioner renderer.
+      type: enhancement
+      link: TBD
 - version: 3.6.6
   changes:
     - description: Add support for mode-aware constructors and validation APIs.

--- a/test/packages/good_blueprint/blueprints/aws/federated-identity/account.cloudformation.json
+++ b/test/packages/good_blueprint/blueprints/aws/federated-identity/account.cloudformation.json
@@ -1,0 +1,30 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Canonical base blueprint for the aws/federated-identity/account deployment. The cloud-iac-provisioner loads this template and appends RFC 6902 patches from each enabled integration.",
+  "Parameters": {
+    "ElasticResourceId": {
+      "Type": "String",
+      "Description": "Elastic resource ID used to construct the ExternalId trust condition."
+    }
+  },
+  "Resources": {
+    "ElasticFederatedIdentityRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": { "Fn::Sub": "ElasticFederatedIdentity-${AWS::StackName}" },
+        "Path": "/",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": []
+        },
+        "ManagedPolicyArns": []
+      }
+    }
+  },
+  "Outputs": {
+    "RoleArn": {
+      "Description": "ARN of the Elastic Federated Identity role.",
+      "Value": { "Fn::GetAtt": ["ElasticFederatedIdentityRole", "Arn"] }
+    }
+  }
+}

--- a/test/packages/good_blueprint/changelog.yml
+++ b/test/packages/good_blueprint/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1

--- a/test/packages/good_blueprint/docs/README.md
+++ b/test/packages/good_blueprint/docs/README.md
@@ -1,0 +1,3 @@
+# Good blueprint
+
+Test package for the `blueprint` package type, which hosts canonical IaC base blueprints under `blueprints/<provider>/<trust-model>/<scope>.<format>.<ext>`.

--- a/test/packages/good_blueprint/manifest.yml
+++ b/test/packages/good_blueprint/manifest.yml
@@ -1,0 +1,16 @@
+format_version: 3.7.0
+name: good_blueprint
+title: Good blueprint package
+description: Tests the blueprint package type that hosts canonical IaC base blueprints.
+version: 0.0.1
+type: blueprint
+source:
+  license: "Apache-2.0"
+conditions:
+  kibana:
+    version: '^8.0.0'
+  elastic:
+    subscription: basic
+owner:
+  github: elastic/foobar
+  type: elastic


### PR DESCRIPTION
## What does this PR do?

- Adds a new `type: blueprint` package under `spec/blueprint/` for hosting canonical IaC base templates
- Adds `test/packages/good_blueprint` and wires it in `validator_test.go`
- Documents the change under `3.7.0-next` in `spec/changelog.yml`

## Why is it important?

Dynamic IaC generation needs a dedicated package type for canonical blueprints that the cloud-iac-provisioner can fetch and patch. Split out of #1209 so the new package type can be reviewed independently from integration/input field changes.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Relates #1209
- Relates https://github.com/elastic/security-team/issues/18260
- Relates elastic/elastic-package#3827
- Relates elastic/elastic-package#3828


Made with [Cursor](https://cursor.com)