### PR TITLE
Add iac_blueprints and scoped provider_permissions for integrations/inputs

### DIFF
--- a/code/go/pkg/validator/validator_test.go
+++ b/code/go/pkg/validator/validator_test.go
@@ -86,6 +86,21 @@ func Test_ValidateFromPath(t *testing.T) {
 				"field group: Does not match pattern '^[a-z0-9_]+$'",
 			},
 		},
+		"good_iac_blueprints":       {},
+		"good_iac_blueprints_input": {},
+		"bad_iac_blueprints_missing_required": {
+			"manifest.yml",
+			[]string{
+				`field iac_blueprints.0: format is required`,
+				`field iac_blueprints.0: patches is required`,
+			},
+		},
+		"bad_iac_blueprints_invalid_format": {
+			"manifest.yml",
+			[]string{
+				`field iac_blueprints.0.format: iac_blueprints.0.format must be one of the following: "cloudformation", "arm", "terraform", "deployment-manager", "helm", "kustomize", "ansible", "bicep"`,
+			},
+		},
 		"bad_duration_vars": {
 			"manifest.yml",
 			[]string{

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -10,10 +10,10 @@
       link: https://github.com/elastic/package-spec/pull/807
     - description: Extend provider_permissions.permissions items with resource scoping (resources array) and conditional narrowing (conditions object) fields.
       type: enhancement
-      link: TBD
+      link: https://github.com/elastic/package-spec/pull/1225
     - description: Add iac_blueprints field at package, policy_template, input, and data_stream levels for IaC composition contributions via RFC 6902 patch files.
       type: enhancement
-      link: TBD
+      link: https://github.com/elastic/package-spec/pull/1225
 - version: 3.6.6
   changes:
     - description: Add support for mode-aware constructors and validation APIs.

--- a/spec/changelog.yml
+++ b/spec/changelog.yml
@@ -8,6 +8,12 @@
     - description: Add support for semantic_text field definition.
       type: enhancement
       link: https://github.com/elastic/package-spec/pull/807
+    - description: Extend provider_permissions.permissions items with resource scoping (resources array) and conditional narrowing (conditions object) fields.
+      type: enhancement
+      link: TBD
+    - description: Add iac_blueprints field at package, policy_template, input, and data_stream levels for IaC composition contributions via RFC 6902 patch files.
+      type: enhancement
+      link: TBD
 - version: 3.6.6
   changes:
     - description: Add support for mode-aware constructors and validation APIs.

--- a/spec/input/manifest.spec.yml
+++ b/spec/input/manifest.spec.yml
@@ -88,6 +88,8 @@ spec:
             $ref: "../integration/manifest.spec.yml#/definitions/sections"
           provider_permissions:
             $ref: "../integration/manifest.spec.yml#/definitions/provider_permissions"
+          iac_blueprints:
+            $ref: "../integration/manifest.spec.yml#/definitions/iac_blueprints"
           input:
             type: string
             examples:
@@ -152,6 +154,8 @@ spec:
       $ref: "../integration/manifest.spec.yml#/definitions/sections"
     provider_permissions:
       $ref: "../integration/manifest.spec.yml#/definitions/provider_permissions"
+    iac_blueprints:
+      $ref: "../integration/manifest.spec.yml#/definitions/iac_blueprints"
     owner:
       $ref: "../integration/manifest.spec.yml#/definitions/owner"
     agent:
@@ -178,6 +182,12 @@ spec:
 
 # JSON patches for newer versions should be placed on top
 versions:
+  - before: 3.7.0
+    patch:
+      - op: remove
+        path: "/properties/policy_templates/items/properties/iac_blueprints"
+      - op: remove
+        path: "/properties/iac_blueprints"
   - before: 3.6.0
     patch:
       - op: remove

--- a/spec/integration/data_stream/manifest.spec.yml
+++ b/spec/integration/data_stream/manifest.spec.yml
@@ -766,12 +766,16 @@ spec:
       $ref: "../../integration/manifest.spec.yml#/definitions/deprecated"
     provider_permissions:
       $ref: "../../integration/manifest.spec.yml#/definitions/provider_permissions"
+    iac_blueprints:
+      $ref: "../../integration/manifest.spec.yml#/definitions/iac_blueprints"
   required:
   - title
 # JSON patches for newer versions should be placed on top
 versions:
   - before: 3.7.0
     patch:
+      - op: remove
+        path: "/properties/iac_blueprints"
       # Variable-level scope migration.
       - op: remove
         path: /definitions/vars/items/properties/migrate_from

--- a/spec/integration/manifest.spec.yml
+++ b/spec/integration/manifest.spec.yml
@@ -825,6 +825,66 @@ spec:
                 description:
                   description: Human-readable description of why this permission is needed.
                   type: string
+                resources:
+                  description: >
+                    Provider-native resource targets this permission applies to (ARNs, Azure resource paths,
+                    GCP resource selectors, K8s apiGroup/resource, SQL object names, …).
+                    When omitted the permission applies account-wide.
+                  type: array
+                  items:
+                    type: string
+                  examples:
+                    - - "arn:aws:s3:::my-log-bucket/*"
+                    - - "arn:aws:s3:::*"
+                    - - "/subscriptions/*/resourceGroups/*/providers/Microsoft.Storage/storageAccounts/*"
+                conditions:
+                  description: >
+                    Provider-native conditions that narrow when this permission applies
+                    (AWS Condition block, Azure conditions, GCP IAM Conditions in CEL, …).
+                  type: object
+    iac_blueprints:
+      description: >
+        IaC composition contributions this integration unit makes to a shared canonical blueprint.
+        Pointers to RFC 6902 patch files the cloud-iac-provisioner renderer applies on top of a
+        canonical blueprint to produce one deployable artifact covering all enabled integrations.
+        May be declared at package, policy_template, input, and data_stream levels;
+        contributions across all applicable levels are merged into a single artifact.
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        required:
+          - id
+          - format
+          - patches
+        properties:
+          id:
+            description: >
+              Blueprint identifier in the form <provider>/<trust-model>/<scope>,
+              e.g. aws/federated-identity/account.
+            type: string
+            examples:
+              - aws/federated-identity/account
+              - azure/service-principal/subscription
+              - gcp/workload-identity/project
+          format:
+            description: IaC format this patch targets.
+            type: string
+            enum:
+              - cloudformation
+              - arm
+              - terraform
+              - deployment-manager
+              - helm
+              - kustomize
+              - ansible
+              - bicep
+          patches:
+            description: Relative path inside the package to the RFC 6902 JSON Patch file.
+            type: string
+          title:
+            description: Optional human-readable label for this IaC contribution.
+            type: string
   properties:
     format_version:
       description: The version of the package specification format used by this package.
@@ -859,6 +919,8 @@ spec:
       $ref: "#/definitions/conditions"
     provider_permissions:
       $ref: "#/definitions/provider_permissions"
+    iac_blueprints:
+      $ref: "#/definitions/iac_blueprints"
     # requires a conditional JSON schema to update the value depending
     # on the policy_templates length
     policy_templates_behavior:
@@ -1005,6 +1067,8 @@ spec:
                     - credential_type: [cloud_connectors]
                 provider_permissions:
                   $ref: "#/definitions/provider_permissions"
+                iac_blueprints:
+                  $ref: "#/definitions/iac_blueprints"
               required:
                 - title
                 - description
@@ -1033,6 +1097,8 @@ spec:
             $ref: "#/definitions/deprecated"
           provider_permissions:
             $ref: "#/definitions/provider_permissions"
+          iac_blueprints:
+            $ref: "#/definitions/iac_blueprints"
         required:
           - name
           - title
@@ -1101,6 +1167,20 @@ spec:
 
 # JSON patches for newer versions should be placed on top
 versions:
+  - before: 3.7.0
+    patch:
+      - op: remove
+        path: "/definitions/iac_blueprints"
+      - op: remove
+        path: "/properties/iac_blueprints"
+      - op: remove
+        path: "/properties/policy_templates/items/properties/iac_blueprints"
+      - op: remove
+        path: "/properties/policy_templates/items/properties/inputs/items/properties/iac_blueprints"
+      - op: remove
+        path: "/definitions/provider_permissions/items/properties/permissions/items/properties/resources"
+      - op: remove
+        path: "/definitions/provider_permissions/items/properties/permissions/items/properties/conditions"
   - before: 3.6.0
     patch:
       # Input qualifier (named inputs).

--- a/test/packages/bad_iac_blueprints_invalid_format/LICENSE.txt
+++ b/test/packages/bad_iac_blueprints_invalid_format/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test/packages/bad_iac_blueprints_invalid_format/changelog.yml
+++ b/test/packages/bad_iac_blueprints_invalid_format/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1

--- a/test/packages/bad_iac_blueprints_invalid_format/docs/README.md
+++ b/test/packages/bad_iac_blueprints_invalid_format/docs/README.md
@@ -1,0 +1,3 @@
+# Bad IaC Blueprints Invalid Format
+
+Test package for `iac_blueprints` with an invalid format enum value.

--- a/test/packages/bad_iac_blueprints_invalid_format/manifest.yml
+++ b/test/packages/bad_iac_blueprints_invalid_format/manifest.yml
@@ -1,0 +1,31 @@
+format_version: 3.7.0
+name: bad_iac_blueprints_invalid_format
+title: Bad package with iac_blueprints invalid format enum
+description: Tests that iac_blueprints items with an unrecognized format value are rejected.
+version: 0.0.1
+type: integration
+categories:
+  - aws
+source:
+  license: "Apache-2.0"
+conditions:
+  kibana:
+    version: '^8.0.0'
+  elastic:
+    subscription: basic
+# Invalid: "pulumi" is not a recognised IaC format.
+iac_blueprints:
+  - id: aws/federated-identity/account
+    format: pulumi
+    patches: iac/patches.json
+policy_templates:
+  - name: sample
+    title: Sample logs
+    description: Collect sample logs
+    inputs:
+      - type: logfile
+        title: Collect sample logs from instances
+        description: Collecting sample logs
+owner:
+  github: elastic/foobar
+  type: elastic

--- a/test/packages/bad_iac_blueprints_missing_required/LICENSE.txt
+++ b/test/packages/bad_iac_blueprints_missing_required/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test/packages/bad_iac_blueprints_missing_required/changelog.yml
+++ b/test/packages/bad_iac_blueprints_missing_required/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1

--- a/test/packages/bad_iac_blueprints_missing_required/docs/README.md
+++ b/test/packages/bad_iac_blueprints_missing_required/docs/README.md
@@ -1,0 +1,3 @@
+# Bad IaC Blueprints Missing Required
+
+Test package for `iac_blueprints` missing required fields.

--- a/test/packages/bad_iac_blueprints_missing_required/manifest.yml
+++ b/test/packages/bad_iac_blueprints_missing_required/manifest.yml
@@ -1,0 +1,29 @@
+format_version: 3.7.0
+name: bad_iac_blueprints_missing_required
+title: Bad package with iac_blueprints missing required fields
+description: Tests that iac_blueprints items missing required fields (format, patches) are rejected.
+version: 0.0.1
+type: integration
+categories:
+  - aws
+source:
+  license: "Apache-2.0"
+conditions:
+  kibana:
+    version: '^8.0.0'
+  elastic:
+    subscription: basic
+# Invalid: iac_blueprints item is missing the required `format` and `patches` fields.
+iac_blueprints:
+  - id: aws/federated-identity/account
+policy_templates:
+  - name: sample
+    title: Sample logs
+    description: Collect sample logs
+    inputs:
+      - type: logfile
+        title: Collect sample logs from instances
+        description: Collecting sample logs
+owner:
+  github: elastic/foobar
+  type: elastic

--- a/test/packages/good_iac_blueprints/LICENSE.txt
+++ b/test/packages/good_iac_blueprints/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test/packages/good_iac_blueprints/changelog.yml
+++ b/test/packages/good_iac_blueprints/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1

--- a/test/packages/good_iac_blueprints/data_stream/cloudtrail_logs/agent/stream/stream.yml.hbs
+++ b/test/packages/good_iac_blueprints/data_stream/cloudtrail_logs/agent/stream/stream.yml.hbs
@@ -1,0 +1,1 @@
+{{fields "stream"}}

--- a/test/packages/good_iac_blueprints/data_stream/cloudtrail_logs/fields/fields.yml
+++ b/test/packages/good_iac_blueprints/data_stream/cloudtrail_logs/fields/fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/test/packages/good_iac_blueprints/data_stream/cloudtrail_logs/manifest.yml
+++ b/test/packages/good_iac_blueprints/data_stream/cloudtrail_logs/manifest.yml
@@ -1,0 +1,19 @@
+title: AWS CloudTrail Logs
+type: logs
+# Data-stream-level IaC contribution: S3 notification wiring specific to this stream.
+iac_blueprints:
+  - id: aws/federated-identity/account
+    format: cloudformation
+    patches: iac/cloudtrail-logs-ds-cloudformation.json
+    title: CloudTrail S3 event notification
+provider_permissions:
+  - provider: aws
+    description: CloudTrail-specific permissions for this data stream.
+    permissions:
+      - name: cloudtrail:LookupEvents
+        resources:
+          - "*"
+streams:
+  - input: aws-s3
+    title: CloudTrail logs from S3
+    description: Collect CloudTrail events from an S3 bucket.

--- a/test/packages/good_iac_blueprints/docs/README.md
+++ b/test/packages/good_iac_blueprints/docs/README.md
@@ -1,0 +1,3 @@
+# Good IaC Blueprints
+
+Test package for `iac_blueprints` at package, policy_template, input, and data_stream levels.

--- a/test/packages/good_iac_blueprints/iac/aws-cloudformation-account.json
+++ b/test/packages/good_iac_blueprints/iac/aws-cloudformation-account.json
@@ -1,0 +1,18 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticFederatedRole/Properties/AssumeRolePolicyDocument/Statement/-",
+    "value": {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::{{AccountId}}:oidc-provider/id.elastic.co"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "id.elastic.co:aud": "{{ElasticConnectorAudience}}"
+        }
+      }
+    }
+  }
+]

--- a/test/packages/good_iac_blueprints/iac/cloudtrail-cloudformation.json
+++ b/test/packages/good_iac_blueprints/iac/cloudtrail-cloudformation.json
@@ -1,0 +1,25 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticFederatedRole/Properties/Policies/-",
+    "value": {
+      "PolicyName": "ElasticCloudTrailReadAccess",
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "s3:GetObject",
+              "s3:ListBucket"
+            ],
+            "Resource": [
+              "arn:aws:s3:::my-cloudtrail-bucket",
+              "arn:aws:s3:::my-cloudtrail-bucket/*"
+            ]
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/packages/good_iac_blueprints/iac/cloudtrail-logs-ds-cloudformation.json
+++ b/test/packages/good_iac_blueprints/iac/cloudtrail-logs-ds-cloudformation.json
@@ -1,0 +1,20 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/CloudTrailS3BucketNotification",
+    "value": {
+      "Type": "AWS::S3::BucketNotificationConfiguration",
+      "Properties": {
+        "Bucket": {"Ref": "CloudTrailBucket"},
+        "NotificationConfiguration": {
+          "QueueConfigurations": [
+            {
+              "Event": "s3:ObjectCreated:*",
+              "Queue": {"Fn::GetAtt": ["ElasticIngestQueue", "Arn"]}
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/test/packages/good_iac_blueprints/iac/cloudtrail-s3-input-cloudformation.json
+++ b/test/packages/good_iac_blueprints/iac/cloudtrail-s3-input-cloudformation.json
@@ -1,0 +1,23 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticFederatedRole/Properties/Policies/-",
+    "value": {
+      "PolicyName": "ElasticCloudTrailSQSAccess",
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "sqs:ReceiveMessage",
+              "sqs:DeleteMessage",
+              "sqs:GetQueueAttributes"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/packages/good_iac_blueprints/manifest.yml
+++ b/test/packages/good_iac_blueprints/manifest.yml
@@ -1,0 +1,64 @@
+format_version: 3.7.0
+name: good_iac_blueprints
+title: Good package with IaC blueprints
+description: Tests iac_blueprints at package, policy_template, input, and data_stream levels.
+version: 0.0.1
+type: integration
+categories:
+  - aws
+source:
+  license: "Apache-2.0"
+conditions:
+  kibana:
+    version: '^8.0.0'
+  elastic:
+    subscription: basic
+# Package-level IaC contribution: always included for any enabled policy template.
+iac_blueprints:
+  - id: aws/federated-identity/account
+    format: cloudformation
+    patches: iac/aws-cloudformation-account.json
+    title: AWS account-level federated identity role
+provider_permissions:
+  - provider: aws
+    description: Bootstrap checks needed by every AWS integration.
+    permissions:
+      - name: sts:GetCallerIdentity
+        description: Verify the IAM identity on startup.
+policy_templates:
+  - name: cloudtrail
+    title: AWS CloudTrail
+    description: Collect AWS CloudTrail events.
+    # Policy-template-level IaC contribution: included when this template is enabled.
+    iac_blueprints:
+      - id: aws/federated-identity/account
+        format: cloudformation
+        patches: iac/cloudtrail-cloudformation.json
+        title: CloudTrail S3 bucket read access
+    inputs:
+      - type: aws-s3
+        title: Collect CloudTrail logs from S3
+        description: Collect CloudTrail events from an S3 bucket.
+        # Input-level IaC contribution: specific to this collection method.
+        iac_blueprints:
+          - id: aws/federated-identity/account
+            format: cloudformation
+            patches: iac/cloudtrail-s3-input-cloudformation.json
+        provider_permissions:
+          - provider: aws
+            description: S3 read access for CloudTrail log bucket.
+            permissions:
+              - name: s3:GetObject
+                resources:
+                  - "arn:aws:s3:::my-cloudtrail-bucket/*"
+              - name: s3:ListBucket
+                resources:
+                  - "arn:aws:s3:::my-cloudtrail-bucket"
+              - name: sqs:ReceiveMessage
+              - name: sqs:DeleteMessage
+              - name: sqs:GetQueueAttributes
+    data_streams:
+      - cloudtrail_logs
+owner:
+  github: elastic/foobar
+  type: elastic

--- a/test/packages/good_iac_blueprints_input/LICENSE.txt
+++ b/test/packages/good_iac_blueprints_input/LICENSE.txt
@@ -1,0 +1,1 @@
+Apache License 2.0

--- a/test/packages/good_iac_blueprints_input/agent/input/input.yml.hbs
+++ b/test/packages/good_iac_blueprints_input/agent/input/input.yml.hbs
@@ -1,0 +1,9 @@
+data_stream:
+  dataset: {{data_stream.dataset}}
+paths:
+{{#each paths as |path i|}}
+  - {{path}}
+{{/each}}
+exclude_files: [".gz$"]
+processors:
+  - add_locale: ~

--- a/test/packages/good_iac_blueprints_input/changelog.yml
+++ b/test/packages/good_iac_blueprints_input/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.0.1"
+  changes:
+    - description: Initial draft of the package
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1

--- a/test/packages/good_iac_blueprints_input/docs/README.md
+++ b/test/packages/good_iac_blueprints_input/docs/README.md
@@ -1,0 +1,3 @@
+# Good IaC Blueprints Input Package
+
+Tests `iac_blueprints` at package and policy_template levels in an input package.

--- a/test/packages/good_iac_blueprints_input/fields/base-fields.yml
+++ b/test/packages/good_iac_blueprints_input/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/test/packages/good_iac_blueprints_input/iac/aws-account-base.json
+++ b/test/packages/good_iac_blueprints_input/iac/aws-account-base.json
@@ -1,0 +1,13 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticFederatedRole/Properties/AssumeRolePolicyDocument/Statement/-",
+    "value": {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::{{AccountId}}:oidc-provider/id.elastic.co"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity"
+    }
+  }
+]

--- a/test/packages/good_iac_blueprints_input/iac/s3-read-access.json
+++ b/test/packages/good_iac_blueprints_input/iac/s3-read-access.json
@@ -1,0 +1,25 @@
+[
+  {
+    "op": "add",
+    "path": "/Resources/ElasticFederatedRole/Properties/Policies/-",
+    "value": {
+      "PolicyName": "ElasticS3ReadAccess",
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "s3:GetObject",
+              "s3:ListBucket"
+            ],
+            "Resource": [
+              "arn:aws:s3:::my-logs-bucket",
+              "arn:aws:s3:::my-logs-bucket/*"
+            ]
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/packages/good_iac_blueprints_input/manifest.yml
+++ b/test/packages/good_iac_blueprints_input/manifest.yml
@@ -1,0 +1,50 @@
+format_version: 3.7.0
+name: good_iac_blueprints_input
+title: Good IaC Blueprints Input Package
+description: Tests iac_blueprints at package and policy_template levels in an input package.
+version: 0.0.1
+type: input
+source:
+  license: "Apache-2.0"
+conditions:
+  kibana:
+    version: "^8.0.0"
+  elastic:
+    subscription: "basic"
+# Package-level IaC contribution: always included for any enabled policy template.
+iac_blueprints:
+  - id: aws/federated-identity/account
+    format: cloudformation
+    patches: iac/aws-account-base.json
+    title: AWS account-level federated identity role
+provider_permissions:
+  - provider: aws
+    description: Credentials check on startup.
+    permissions:
+      - name: sts:GetCallerIdentity
+policy_templates:
+  - name: s3_logs
+    type: logs
+    title: S3 Logs
+    description: Collect logs from S3 buckets.
+    input: aws-s3
+    template_path: input.yml.hbs
+    # Policy-template-level IaC contribution for this specific input type.
+    iac_blueprints:
+      - id: aws/federated-identity/account
+        format: cloudformation
+        patches: iac/s3-read-access.json
+        title: S3 read access for log collection
+    provider_permissions:
+      - provider: aws
+        description: Read log objects from S3.
+        permissions:
+          - name: s3:GetObject
+            resources:
+              - "arn:aws:s3:::my-logs-bucket/*"
+          - name: s3:ListBucket
+            resources:
+              - "arn:aws:s3:::my-logs-bucket"
+owner:
+  github: elastic/foobar
+  type: elastic

--- a/test/packages/good_provider_permissions/data_stream/ec2_metrics/manifest.yml
+++ b/test/packages/good_provider_permissions/data_stream/ec2_metrics/manifest.yml
@@ -6,6 +6,11 @@ provider_permissions:
     description: EC2 describe calls for instance metrics.
     permissions:
       - name: ec2:DescribeInstances
+        resources:
+          - "arn:aws:ec2:*:*:instance/*"
+        conditions:
+          StringEquals:
+            ec2:Region: "us-east-1"
       - name: ec2:DescribeInstanceStatus
 streams:
   - input: aws/metrics

--- a/test/packages/good_provider_permissions/manifest.yml
+++ b/test/packages/good_provider_permissions/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.6.4
+format_version: 3.7.0
 name: good_provider_permissions
 title: Good package with provider permissions
-description: Tests provider_permissions at package, policy_template, input, and data_stream levels, including multiple providers per entry.
+description: Tests provider_permissions at package, policy_template, input, and data_stream levels, including resources/conditions scoping and multiple providers per entry.
 version: 0.0.1
 type: integration
 categories:
@@ -23,6 +23,14 @@ provider_permissions:
         description: Verify the IAM identity on startup.
       - name: iam:ListAccountAliases
       - name: ec2:DescribeRegions
+      - name: s3:GetObject
+        description: Read log objects from the designated S3 bucket.
+        resources:
+          - "arn:aws:s3:::my-logs-bucket/*"
+        conditions:
+          StringEquals:
+            s3:prefix:
+              - "AWSLogs/"
   - provider: azure
     description: Bootstrap check for Azure integrations.
     permissions:


### PR DESCRIPTION
## What does this PR do?

- Adds `iac_blueprints` at package, policy_template, input, and data_stream levels (RFC 6902 patch contributions)
- Extends `provider_permissions.permissions` items with `resources` and `conditions`
- Adds version patches for `format_version` before `3.7.0`
- Adds good/bad test packages and updates `good_provider_permissions`

## Why is it important?

Integrations and inputs need a way to declare IaC composition contributions and scoped provider permissions for frictionless cloud deployment. Split out of #1209 so these field changes can be reviewed separately from the new `blueprint` package type.

## Checklist

- [x] I have added test packages to [`test/packages`](https://github.com/elastic/package-spec/tree/main/test/packages) that prove my change is effective.
- [x] I have added an entry in [`spec/changelog.yml`](https://github.com/elastic/package-spec/blob/main/spec/changelog.yml).

## Related issues

- Relates #1209
- Relates https://github.com/elastic/security-team/issues/18258
- Relates https://github.com/elastic/security-team/issues/18260
- Relates elastic/package-registry#1888


Made with [Cursor](https://cursor.com)